### PR TITLE
Simplifies usage of REF_TO AxoStep

### DIFF
--- a/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
@@ -23,10 +23,8 @@ NAMESPACE AXOpen.Core
             _coordinatorState : AxoCoordinatorStates;
             _step : IAxoStep;
             _openCycleCounter : ULINT;    
-            _closeCycleCounter : ULINT;    
-            _refBeforeStep : REF_TO AxoStep;
-            _refCurrentStep : REF_TO AxoStep;
-            _refAfterStep : REF_TO AxoStep;
+            _closeCycleCounter : ULINT;  
+            _refStep :  REF_TO AxoStep;       
             _microStep : UINT;   
         END_VAR     
 
@@ -170,18 +168,18 @@ NAMESPACE AXOpen.Core
             END_IF;
 
             IF(THIS.CurrentOrder = step.GetStepOrder()) THEN
-                _refCurrentStep ?= step;
-                CurrentStep := _refCurrentStep^;
+                _refStep ?= step;
+                CurrentStep := _refStep^;                
             END_IF;   
 
             IF(THIS.CurrentOrder + ULINT#1 = step.GetStepOrder() OR (THIS.CurrentOrder = THIS.GetNumberOfConfiguredSteps() AND step.GetStepOrder() = UINT#1)) THEN
-                _refAfterStep ?= step;
-                AfterStep := _refAfterStep^;
+                _refStep ?= step;
+                AfterStep := _refStep^;
             END_IF;
 
             IF(THIS.CurrentOrder - ULINT#1 = step.GetStepOrder() OR (THIS.CurrentOrder = UINT#1 AND step.GetStepOrder() = THIS.GetNumberOfConfiguredSteps())) THEN
-                _refBeforeStep ?= step;
-                BeforeStep := _refBeforeStep^;
+                _refStep ?= step;
+                BeforeStep := _refStep^;
             END_IF; 
         END_METHOD
                 


### PR DESCRIPTION
The most significant changes involve the simplification of variable usage and the reorganization of variable declarations. The variables `_refBeforeStep`, `_refCurrentStep`, and `_refAfterStep` were replaced with a single variable `_refStep`, which is now used for all three steps. This change was reflected in the method where these steps are set. Additionally, the variable `_closeCycleCounter` was repositioned in the variable declarations.

Necessary because when built for 1500 targets the library reported an error at compilation (REF_TO AxoStep already in use). Not sure about the reason, but simplifying serves the purpose.
