### PR TITLE
updates to @ax-sdk2405.0.0

### DIFF
--- a/cake/ApaxCmd.cs
+++ b/cake/ApaxCmd.cs
@@ -184,7 +184,7 @@ public static class ApaxCmd
             var passed = false;
             foreach (var o in process.GetStandardOutput())
             {
-                if (o.Trim().Replace(" ", "").ToUpper() == "OVERALLRESULT[PASSED]")
+                if (o.Trim().Replace(" ", "").ToUpper() == "FAILED:0")
                 {
                     passed = true;
                 }

--- a/cake/BuildContext.cs
+++ b/cake/BuildContext.cs
@@ -147,6 +147,9 @@ public class BuildContext : FrostingContext
     #region Libraries
     public IEnumerable<(string folder, string name, bool pack)> Libraries { get; } = new[]
     {
+        ("ax.axopen.min", "ax.axopen.min", true),
+        ("ax.axopen.hwlib", "ax.axopen.hwlib", true),
+        ("ax.axopen.app", "ax.axopen.app", true),
         ("sdk-ax", "ax-sdk", true),
         ("abstractions", "axopen.abstractions", true),
         ("timers", "axopen.timers", true),

--- a/cake/BuildContext.cs
+++ b/cake/BuildContext.cs
@@ -148,7 +148,7 @@ public class BuildContext : FrostingContext
     public IEnumerable<(string folder, string name, bool pack)> Libraries { get; } = new[]
     {
         ("ax.axopen.min", "ax.axopen.min", true),
-        ("ax.axopen.hwlib", "ax.axopen.hwlib", true),
+        ("ax.axopen.hwlibrary", "ax.axopen.hwlibrary", true),
         ("ax.axopen.app", "ax.axopen.app", true),
         ("sdk-ax", "ax-sdk", true),
         ("abstractions", "axopen.abstractions", true),

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -199,6 +199,12 @@ public sealed class TestsTask : FrostingTask<BuildContext>
                 context.ApaxInstall(context.GetLibraryAxFolders(lib));
                 context.ApaxBuild(context.GetLibraryAxFolders(lib));
                 context.ApaxTestLibrary(lib);
+                if (context.BuildParameters.DoPack)
+                {
+                    context.ApaxPack(lib);
+                    context.ApaxCopyArtifacts(lib);
+                }
+                context.ApaxClean(lib);
             });
 
         }
@@ -209,6 +215,12 @@ public sealed class TestsTask : FrostingTask<BuildContext>
                 context.ApaxInstall(context.GetLibraryAxFolders(lib));
                 context.ApaxBuild(context.GetLibraryAxFolders(lib));
                 context.ApaxTestLibrary(lib);
+                if (context.BuildParameters.DoPack)
+                {
+                    context.ApaxPack(lib);
+                    context.ApaxCopyArtifacts(lib);
+                }
+                context.ApaxClean(lib);
             });
         }
 
@@ -242,7 +254,7 @@ public sealed class TestsTask : FrostingTask<BuildContext>
                 else
                 {
                     throw new Exception($"No app or ax folder found for {package.folder}");    
-                    }
+                }
 
                 context.DotNetTest(Path.Combine(context.RootDir, package.folder, "tmp_L3_.proj"), context.DotNetTestSettings);
             }
@@ -260,13 +272,13 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
     {
         if (context.BuildParameters.DoPack)
         {
-            context.Libraries.ToList().ForEach(lib =>
-            {
-                foreach (var apaxfile in context.GetApaxFiles(lib))
-                {
-                    context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"", "llvm", "plcsim" }, new[] { "bin", "axsharp.companion.json" });
-                }
-            });
+            //context.Libraries.ToList().ForEach(lib =>
+            //{
+            //    foreach (var apaxfile in context.GetApaxFiles(lib))
+            //    {
+            //        context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"", "llvm", "plcsim" }, new[] { "bin", "axsharp.companion.json" });
+            //    }
+            //});
         }
         
         if (!context.BuildParameters.DoPack)
@@ -275,7 +287,7 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
             return;
         }
 
-        PackApax(context);
+        //PackApax(context);
         PackNugets(context);
     }
 

--- a/src/abstractions/ctrl/apax.yml
+++ b/src/abstractions/ctrl/apax.yml
@@ -9,7 +9,7 @@ files:
 devDependencies:
   "@ix-ax/ax-sdk": '0.0.0-dev.0'
 dependencies:
-  "@ax/system-strings": ^6.0.94
+  "@ix-ax/ax.axopen.min": '0.0.0-dev.0'
 scripts:
   postbuild:
     - dotnet ixc

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -1,0 +1,18 @@
+name: "@ix-ax/ax.axopen.app"
+version: '0.0.0-dev.0'
+type: generic
+files:
+  - apax.yml
+devDependencies:
+  "@ix-ax/ax-sdk": '0.0.0-dev.0'
+dependencies: 
+  "@ix-ax/ax.axopen.min": '0.0.0-dev.0'
+  "@ax/simatic-1500-clocks": ^7.0.4  
+  "@ax/system-bitaccess": ^7.0.17
+  "@ax/system-math": ^7.0.17
+  "@ax/system-serde": ^7.0.17
+installStrategy: strict
+apaxVersion: 3.1.1
+
+
+

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -5,14 +5,11 @@ files:
   - apax.yml
 devDependencies:
   "@ix-ax/ax-sdk": '0.0.0-dev.0'
-dependencies: 
+dependencies:
   "@ix-ax/ax.axopen.min": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^7.0.4  
+  "@ax/simatic-1500-clocks": ^7.0.4
   "@ax/system-bitaccess": ^7.0.17
   "@ax/system-math": ^7.0.17
   "@ax/system-serde": ^7.0.17
 installStrategy: strict
 apaxVersion: 3.1.1
-
-
-

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -9,11 +9,8 @@ dependencies:
   "@ix-ax/ax.axopen.min": '0.0.0-dev.0'
   "@ax/simatic-1500-distributedio": ^7.0.1
   "@ax/simatic-1500-diagnostics-hardware": ^7.0.1
-  "@ax/simatic-1500-clocks": ^7.0.4    
+  "@ax/simatic-1500-clocks": ^7.0.4
   "@ax/system-timer": ^7.0.17
   "@ax/system-serde": ^7.0.17
 installStrategy: strict
 apaxVersion: 3.1.1
-
-
-

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -12,5 +12,6 @@ dependencies:
   "@ax/simatic-1500-clocks": ^7.0.4
   "@ax/system-timer": ^7.0.17
   "@ax/system-serde": ^7.0.17
+  "@ax/system-bitaccess": ^7.0.17
 installStrategy: strict
 apaxVersion: 3.1.1

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -1,0 +1,19 @@
+name: "@ix-ax/ax.axopen.hwlibrary"
+version: '0.0.0-dev.0'
+type: generic
+files:
+  - apax.yml
+devDependencies:
+  "@ix-ax/ax-sdk": '0.0.0-dev.0'
+dependencies:
+  "@ix-ax/ax.axopen.min": '0.0.0-dev.0'
+  "@ax/simatic-1500-distributedio": ^7.0.1
+  "@ax/simatic-1500-diagnostics-hardware": ^7.0.1
+  "@ax/simatic-1500-clocks": ^7.0.4    
+  "@ax/system-timer": ^7.0.17
+  "@ax/system-serde": ^7.0.17
+installStrategy: strict
+apaxVersion: 3.1.1
+
+
+

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -1,0 +1,14 @@
+name: "@ix-ax/ax.axopen.min"
+version: '0.0.0-dev.0'
+type: generic
+files:
+  - apax.yml
+devDependencies:
+  "@ix-ax/ax-sdk": '0.0.0-dev.0'
+dependencies: 
+  "@ax/system-strings": ^7.0.17
+installStrategy: strict
+apaxVersion: 3.1.1
+
+
+

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -5,10 +5,7 @@ files:
   - apax.yml
 devDependencies:
   "@ix-ax/ax-sdk": '0.0.0-dev.0'
-dependencies: 
+dependencies:
   "@ax/system-strings": ^7.0.17
 installStrategy: strict
 apaxVersion: 3.1.1
-
-
-

--- a/src/components.abb.robotics/app/apax.yml
+++ b/src/components.abb.robotics/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.abb.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.abb.robotics/ctrl/apax.yml
+++ b/src/components.abb.robotics/ctrl/apax.yml
@@ -18,8 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'  
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.abb.robotics/ctrl/apax.yml
+++ b/src/components.abb.robotics/ctrl/apax.yml
@@ -18,7 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'  
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.balluff.identification/app/apax.yml
+++ b/src/components.balluff.identification/app/apax.yml
@@ -16,11 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.balluff.identification": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/system-strings": ^6.0.94
-  "@ax/system-bitaccess": ^6.0.94
-  "@ax/system-math": ^6.0.94
-  "@ax/system-serde": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.balluff.identification/ctrl/apax.yml
+++ b/src/components.balluff.identification/ctrl/apax.yml
@@ -17,9 +17,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
-  "@ax/system-serde": ^6.0.94
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.cognex.vision/app/apax.yml
+++ b/src/components.cognex.vision/app/apax.yml
@@ -13,8 +13,7 @@ devDependencies:
 dependencies:
   "@ix-ax/axopen.components.cognex.vision": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/system-timer": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.cognex.vision/ctrl/apax.yml
+++ b/src/components.cognex.vision/ctrl/apax.yml
@@ -13,12 +13,9 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
-  "@ix-ax/axopen.utils": '0.0.0-dev.0'
-  "@ax/system-serde": ^6.0.94
-  # "@ax/system-strings": ^6.0.94
+  "@ix-ax/axopen.utils": '0.0.0-dev.0'  
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.cognex.vision/ctrl/apax.yml
+++ b/src/components.cognex.vision/ctrl/apax.yml
@@ -13,9 +13,9 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
-  "@ix-ax/axopen.utils": '0.0.0-dev.0'  
+  "@ix-ax/axopen.utils": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  
+
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.desoutter.tightening/app/apax.yml
+++ b/src/components.desoutter.tightening/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.desoutter.tightening": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.desoutter.tightening/ctrl/apax.yml
+++ b/src/components.desoutter.tightening/ctrl/apax.yml
@@ -16,13 +16,8 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/system-bitaccess": ^6.0.94
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
-  "@ax/system-strings": ^6.0.94
-  "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/system-serde": ^6.0.94
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/axopen.io": '0.0.0-dev.0'  
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.desoutter.tightening/ctrl/apax.yml
+++ b/src/components.desoutter.tightening/ctrl/apax.yml
@@ -16,8 +16,8 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
-  "@ix-ax/axopen.io": '0.0.0-dev.0'  
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
+  "@ix-ax/axopen.io": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.festo.drives/app/apax.yml
+++ b/src/components.festo.drives/app/apax.yml
@@ -9,20 +9,11 @@ variables:
     - "--debug" # Generate debug information for target "1500"
   PLC_NAME: "plc_line"
 devDependencies:
-  "@ix-ax/ax-sdk": '0.0.0-dev.0'
-  "@ax/hwc": ^0.13.375
-  "@ax/hwld": ^0.9.479
-  "@ax/dcp-utility": ^1.1.2
-  "@ax/hardware-diagnostics": ^0.1.0
-  "@ax/certificate-management": ^1.1.1
-  "@ax/plc-info": ^2.3.0
+  "@ix-ax/ax-sdk": '0.0.0-dev.0' 
 dependencies:
   "@ix-ax/axopen.components.festo.drives": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/system-bitaccess": ^6.0.94
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/system-timer": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.festo.drives/ctrl/apax.yml
+++ b/src/components.festo.drives/ctrl/apax.yml
@@ -13,11 +13,7 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.components.drives": '0.0.0-dev.0'
-  "@ax/system-bitaccess": ^6.0.94
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
-  "@ax/system-strings": ^6.0.94
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17

--- a/src/components.festo.drives/ctrl/apax.yml
+++ b/src/components.festo.drives/ctrl/apax.yml
@@ -13,7 +13,7 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.components.drives": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17

--- a/src/components.kuka.robotics/app/apax.yml
+++ b/src/components.kuka.robotics/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.kuka.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.kuka.robotics/ctrl/apax.yml
+++ b/src/components.kuka.robotics/ctrl/apax.yml
@@ -18,7 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.kuka.robotics/ctrl/apax.yml
+++ b/src/components.kuka.robotics/ctrl/apax.yml
@@ -18,8 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.mitsubishi.robotics/app/apax.yml
+++ b/src/components.mitsubishi.robotics/app/apax.yml
@@ -16,8 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.mitsubishi.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/simatic-1500-distributedio": ^6.0.3
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.mitsubishi.robotics/ctrl/apax.yml
+++ b/src/components.mitsubishi.robotics/ctrl/apax.yml
@@ -18,7 +18,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.mitsubishi.robotics/ctrl/apax.yml
+++ b/src/components.mitsubishi.robotics/ctrl/apax.yml
@@ -18,8 +18,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.rexroth.drives/app/apax.yml
+++ b/src/components.rexroth.drives/app/apax.yml
@@ -13,7 +13,7 @@ devDependencies:
 dependencies:
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
   "@ix-ax/axopen.components.rexroth.drives": '0.0.0-dev.0'
-  "@ax/system-timer": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.rexroth.drives/ctrl/apax.yml
+++ b/src/components.rexroth.drives/ctrl/apax.yml
@@ -65,7 +65,7 @@ dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.drives": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 installStrategy: strict
 apaxVersion: 3.1.1
 ...

--- a/src/components.rexroth.drives/ctrl/apax.yml
+++ b/src/components.rexroth.drives/ctrl/apax.yml
@@ -65,11 +65,7 @@ dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.drives": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/system-bitaccess": ^6.0.94
-  "@ax/system-math": ^6.0.94
-  "@ax/system-strings": ^6.0.94
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 installStrategy: strict
 apaxVersion: 3.1.1
 ...

--- a/src/components.rexroth.press/app/apax.yml
+++ b/src/components.rexroth.press/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.rexroth.press": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.rexroth.press/ctrl/apax.yml
+++ b/src/components.rexroth.press/ctrl/apax.yml
@@ -17,7 +17,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.rexroth.press/ctrl/apax.yml
+++ b/src/components.rexroth.press/ctrl/apax.yml
@@ -17,9 +17,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/system-serde": ^6.0.94
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.robotics/app/apax.yml
+++ b/src/components.robotics/app/apax.yml
@@ -17,7 +17,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   download:

--- a/src/components.robotics/ctrl/apax.yml
+++ b/src/components.robotics/ctrl/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.robotics/ctrl/apax.yml
+++ b/src/components.robotics/ctrl/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/system-math": ^6.0.94
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.siemens.identification/app/apax.yml
+++ b/src/components.siemens.identification/app/apax.yml
@@ -16,8 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.siemens.identification": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/system-serde": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.siemens.identification/ctrl/apax.yml
+++ b/src/components.siemens.identification/ctrl/apax.yml
@@ -15,9 +15,9 @@ dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
-  "@ix-ax/axopen.abstractions": '0.0.0-dev.0' 
+  "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.siemens.identification/ctrl/apax.yml
+++ b/src/components.siemens.identification/ctrl/apax.yml
@@ -15,12 +15,9 @@ dependencies:
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
-  "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/system-timer": ^6.0.94
+  "@ix-ax/axopen.abstractions": '0.0.0-dev.0' 
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/system-serde": ^6.0.94
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.ur.robotics/app/apax.yml
+++ b/src/components.ur.robotics/app/apax.yml
@@ -16,8 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.ur.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/simatic-1500-distributedio": ^6.0.3
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/components.ur.robotics/ctrl/apax.yml
+++ b/src/components.ur.robotics/ctrl/apax.yml
@@ -7,7 +7,7 @@ files:
   - src
   - axsharp.companion.json
 devDependencies:
-  "@ix-ax/ax-sdk": '0.0.0-dev.0'  
+  "@ix-ax/ax-sdk": '0.0.0-dev.0'
 scripts:
   postbuild:
     - dotnet ixc
@@ -18,7 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/components.ur.robotics/ctrl/apax.yml
+++ b/src/components.ur.robotics/ctrl/apax.yml
@@ -7,8 +7,7 @@ files:
   - src
   - axsharp.companion.json
 devDependencies:
-  "@ix-ax/ax-sdk": '0.0.0-dev.0'
-  "@ax/diagnostic-buffer": ^1.3.0
+  "@ix-ax/ax-sdk": '0.0.0-dev.0'  
 scripts:
   postbuild:
     - dotnet ixc
@@ -19,8 +18,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.components.robotics": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^6.0.3
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/integrations/app/apax.yml
+++ b/src/integrations/app/apax.yml
@@ -11,9 +11,7 @@ variables:
   PLC_NAME: "plc_line"
 devDependencies:
   "@ix-ax/ax-sdk": '0.0.0-dev.0'
-dependencies:
-  "@ax/simatic-1500-clocks": ^6.0.37
-  "@ax/system-serde": ^6.0.94
+dependencies:  
   "@ix-ax/axopen.components.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
@@ -22,6 +20,7 @@ dependencies:
   "@ix-ax/axopen.probers": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
   "@ix-ax/axopen.components.cognex.vision": '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   download:

--- a/src/io/app/apax.yml
+++ b/src/io/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   delta:

--- a/src/io/ctrl/apax.yml
+++ b/src/io/ctrl/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,6 +6,6 @@ type: generic
 files:
   - apax.yml
 dependencies:
-  "@ax/sdk": ^2405.0.0  
+  "@ax/sdk": ^2405.0.0
 installStrategy: strict
 apaxVersion: 3.1.1

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,34 +6,6 @@ type: generic
 files:
   - apax.yml
 dependencies:
-  #"@ax/sdk": ^2311.0.1
-  "@ax/hwc": ^1.0.225 # new version available, old-one removed
-  "@ax/hwld": ^1.0.75 # new version available, old-one removed
-  "@ax/dcp-utility": ^1.1.2 # still available, nothing new
-  "@ax/axunitst": ^4.2.4 # still available
-  # "@ax/axunitst": ^5.0.74                       # new version available
-  "@ax/mod": ^1.1.2 # still available
-  # "@ax/mod": ^1.2.2                             # new version available
-  "@ax/mon": ^1.1.2 # still available
-  # "@ax/mon": ^1.2.2                             # new version available
-  "@ax/sdb": ^1.1.2 # still available
-  # "@ax/sdb": ^1.2.2                             # new version available
-  "@ax/sld": ^2.5.5 # still available
-  # "@ax/sld": ^2.5.6                             # new version available
-  "@ax/stc": ^6.1.59 # still available
-  # "@ax/stc": ^7.0.52                            # new version available
-  "@ax/apax-build": ^0.8.0 # still available
-  # "@ax/apax-build": ^1.0.0                      # new version available
-  "@ax/target-llvm": ^6.1.59 # still available
-  # "@ax/target-llvm": ^7.0.52                    # new version available
-  "@ax/target-mc7plus": ^6.1.59 # still available
-  # "@ax/target-mc7plus": ^7.0.52                 # new version available
-  "@ax/simatic-pragma-stc-plugin": ^2.0.12 # still available
-  # "@ax/simatic-pragma-stc-plugin": ^4.0.18      # new version available
-  "@ax/hardware-diagnostics": ^0.1.0 # still available, nothing new
-  "@ax/certificate-management": ^1.1.1 # still available
-  # "@ax/certificate-management": ^1.1.2          # new version available
-  "@ax/plc-info": ^2.3.0 # still available
-  # "@ax/plc-info": ^2.4.0                        # new version available
+  "@ax/sdk": ^2405.0.0  
 installStrategy: strict
 apaxVersion: 3.1.1

--- a/src/simatic1500/app/apax.yml
+++ b/src/simatic1500/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   download:

--- a/src/simatic1500/ctrl/apax.yml
+++ b/src/simatic1500/ctrl/apax.yml
@@ -13,7 +13,7 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 installStrategy: strict
 apaxVersion: 3.1.1
 ...

--- a/src/simatic1500/ctrl/apax.yml
+++ b/src/simatic1500/ctrl/apax.yml
@@ -13,7 +13,7 @@ scripts:
     - dotnet ixc
 dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.hwlibrary" : '0.0.0-dev.0'
 installStrategy: strict
 apaxVersion: 3.1.1
 ...

--- a/src/template.axolibrary/app/apax.yml
+++ b/src/template.axolibrary/app/apax.yml
@@ -16,7 +16,7 @@ dependencies:
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/apaxlibname": '0.0.0-dev.0'
   "@ix-ax/axopen.simatic1500": '0.0.0-dev.0'
-  "@ax/simatic-1500-clocks": ^6.0.37
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
     
   # For proper execution of these scripts, the following variables need to be defined as environment variables or local variables.

--- a/src/template.axolibrary/ctrl/apax.yml
+++ b/src/template.axolibrary/ctrl/apax.yml
@@ -17,7 +17,7 @@ dependencies:
   "@ix-ax/axopen.timers": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
   "@ix-ax/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-1500-diagnostics-hardware": ^6.0.1
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/traversals/apax/apax.yml
+++ b/src/traversals/apax/apax.yml
@@ -9,6 +9,9 @@ devDependencies:
 dependencies:
   abstractions-app: 0.0.0-dev.0
   '@ix-ax/axopen.abstractions': 0.0.0-dev.0
+  '@ix-ax/ax.axopen.app': 0.0.0-dev.0
+  '@ix-ax/ax.axopen.hwlibrary': 0.0.0-dev.0
+  '@ix-ax/ax.axopen.min': 0.0.0-dev.0
   app_axopen.components.abb.robotics: 0.0.0-dev.0
   '@ix-ax/axopen.components.abb.robotics': 0.0.0-dev.0
   components.abstractions-app: 0.0.0-dev.0

--- a/src/utils/app/apax.yml
+++ b/src/utils/app/apax.yml
@@ -16,8 +16,7 @@ dependencies:
   "@ix-ax/axopen.utils": '0.0.0-dev.0'
   "@ix-ax/axopen.core": '0.0.0-dev.0'
   "@ix-ax/axopen.abstractions": '0.0.0-dev.0'
-  "@ax/system-serde": ^6.0.94
-  "@ax/system-strings": ^6.0.94
+  "@ix-ax/ax.axopen.app": '0.0.0-dev.0'  
 scripts:
   # Obsolete scripts, could be  removed at some point ====>
   download:

--- a/src/utils/ctrl/apax.yml
+++ b/src/utils/ctrl/apax.yml
@@ -12,8 +12,7 @@ scripts:
   postbuild:
     - dotnet ixc
 dependencies:
-  "@ax/system-serde": ^6.0.94
-  "@ax/system-strings": ^6.0.94
+  "@ix-ax/ax.axopen.hwlibrary": '0.0.0-dev.0'
 publicKeys:
   "@ix-ax": 30c06ef7830b4dfd8f16e003508da1ac2d187714d0e1f38279a9332cbe4e4e17
 installStrategy: strict

--- a/src/utils/ctrl/src/AXOpenUtils/AxoCRC_16.st
+++ b/src/utils/ctrl/src/AXOpenUtils/AxoCRC_16.st
@@ -8,8 +8,8 @@ NAMESPACE AXOpen.Utils
 		END_VAR
 		VAR
 			crc : WORD := WORD#16#FFFF;
-			i : UINT;
-			maxIndex : UINT;
+			i : UDINT;
+			maxIndex : UDINT;
 			serialized : ARRAY[0..255] OF BYTE;
 		END_VAR
 		VAR 
@@ -36,13 +36,13 @@ NAMESPACE AXOpen.Utils
 
 		maxIndex := UINT#0;
 
-		maxIndex := Serialize(UINT#0, In, serialized,System.Serialization.Endianness#Little) - UINT#1;
+		maxIndex := Serialize(UDINT#0, In, serialized,System.Serialization.Endianness#Little) - UDINT#1;
 
 		IF maxIndex < UINT#1 THEN
 			RETURN;
 		END_IF;
 
-		FOR i := UINT#1 TO maxIndex BY UINT#1 DO
+		FOR i := UDINT#1 TO maxIndex BY UDINT#1 DO
 			crc :=SHL(crc, UINT#8) XOR CRC_TABLE[TO_INT(SHR(crc, UINT#8) XOR serialized[i])];
 		END_FOR;
 

--- a/src/utils/ctrl/src/AXOpenUtils/AxoCRC_32.st
+++ b/src/utils/ctrl/src/AXOpenUtils/AxoCRC_32.st
@@ -8,8 +8,8 @@ NAMESPACE AXOpen.Utils
 		END_VAR
 		VAR
 			crc : DWORD := DWORD#16#FFFFFFFF;
-			i : UINT;
-			maxIndex : UINT;
+			i : UDINT;
+			maxIndex : UDINT;
 			serialized : ARRAY[0..255] OF BYTE;
 		END_VAR
 		VAR 
@@ -42,7 +42,7 @@ NAMESPACE AXOpen.Utils
 			RETURN;
 		END_IF;
 
-		FOR i := UINT#1 TO maxIndex BY UINT#1 DO
+		FOR i := UDINT#1 TO maxIndex BY UDINT#1 DO
 			crc := SHL(crc, UINT#8) XOR CRC_TABLE[TO_INT(SHR(crc, UINT#24) XOR serialized[i])];
 		END_FOR;
 

--- a/src/utils/ctrl/src/AXOpenUtils/AxoCRC_8.st
+++ b/src/utils/ctrl/src/AXOpenUtils/AxoCRC_8.st
@@ -8,8 +8,8 @@ NAMESPACE AXOpen.Utils
 		END_VAR
 		VAR
 			crc : BYTE := BYTE#16#FF;
-			i : UINT;
-			maxIndex : UINT;
+			i : UDINT;
+			maxIndex : UDINT;
 			serialized : ARRAY[0..255] OF BYTE;
 		END_VAR
 		VAR 
@@ -37,12 +37,12 @@ NAMESPACE AXOpen.Utils
 		maxIndex := UINT#0;
 
 		maxIndex := Serialize(UINT#0, In, serialized, System.Serialization.Endianness#Little) - UINT#1;
-
+				
 		IF maxIndex < UINT#1 THEN
 			RETURN;
 		END_IF;
 		
-		FOR i := UINT#1 TO maxIndex BY UINT#1 DO
+		FOR i := UDINT#1 TO maxIndex BY UDINT#1 DO
 			crc := CRC_TABLE[TO_INT(crc XOR TO_BYTE(TO_CHAR(serialized[i])))];
 		END_FOR;
 		AxoCRC_8 := crc;


### PR DESCRIPTION
This PR update AXOpen to '@ax/simatic-ax@2405.0.0'.

Direct `ax` dependencies were removed from the libraries and testing applications.
`ax` dependencies are now grouped into the following projects:

- @ix-ax/ax.axopen.min
- @ix-ax/ax.axopen.hwlibary
- @ix-ax/ax.axopen.app