### PR TITLE
Remove plcsim targets

### DIFF
--- a/cake/ApaxTraversal.cs
+++ b/cake/ApaxTraversal.cs
@@ -105,7 +105,7 @@ public static class ApaxTraversal
         var yamlContent = serializer.Serialize(new { name = "apax.traversal", 
                                                                 version = "0.0.0-dev.0", 
                                                                 type = "app",
-                                                                targets = new string[] {"plcsim", "llvm"},
+                                                                targets = new string[] {"llvm"},
                                                                 devDependencies = new Dictionary<string, string>() { {"@ix-ax/ax-sdk", dependencies.First(p => p.Name == "@ix-ax/ax-sdk").Version} }, 
                                                                 dependencies = dependenciesDictionary});
 

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -156,7 +156,7 @@ public sealed class BuildTask : FrostingTask<BuildContext>
             {
                 foreach (var apaxfile in context.GetApaxFiles(lib))
                 {
-                    context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"", "llvm", "plcsim" }, new[] { "src", "axsharp.companion.json" });
+                    context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"", "llvm" }, new[] { "src", "axsharp.companion.json" });
                 }
             });
         }

--- a/src/abstractions/app/apax.yml
+++ b/src/abstractions/app/apax.yml
@@ -2,7 +2,6 @@ name: "abstractions-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/components.abb.robotics/app/apax.yml
+++ b/src/components.abb.robotics/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.abb.robotics"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.abstractions/app/apax.yml
+++ b/src/components.abstractions/app/apax.yml
@@ -2,7 +2,6 @@ name: "components.abstractions-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.balluff.identification/app/apax.yml
+++ b/src/components.balluff.identification/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.balluff.identification"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.cognex.vision/app/apax.yml
+++ b/src/components.cognex.vision/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.cognex.vision"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.desoutter.tightening/app/apax.yml
+++ b/src/components.desoutter.tightening/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.desoutter.tightening"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.drives/app/apax.yml
+++ b/src/components.drives/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.drives"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/components.elements/app/apax.yml
+++ b/src/components.elements/app/apax.yml
@@ -3,7 +3,6 @@ version: '0.0.0-dev.0'
 type: app
 targets:
   - "1500"
-  - plcsim
   - llvm
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.festo.drives/app/apax.yml
+++ b/src/components.festo.drives/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.festo.drives"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.kuka.robotics/app/apax.yml
+++ b/src/components.kuka.robotics/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.kuka.robotics"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.mitsubishi.robotics/app/apax.yml
+++ b/src/components.mitsubishi.robotics/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.mitsubishi.robotics"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.pneumatics/app/apax.yml
+++ b/src/components.pneumatics/app/apax.yml
@@ -3,7 +3,6 @@ version: '0.0.0-dev.0'
 type: app
 targets:
   - llvm
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.rexroth.drives/app/apax.yml
+++ b/src/components.rexroth.drives/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.rexroth.drives"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.rexroth.press/app/apax.yml
+++ b/src/components.rexroth.press/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.rexroth.press"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.robotics/app/apax.yml
+++ b/src/components.robotics/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.robotics"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/components.siemens.identification/app/apax.yml
+++ b/src/components.siemens.identification/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.siemens.identification"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/components.ur.robotics/app/apax.yml
+++ b/src/components.ur.robotics/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.components.ur.robotics"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/core/app/apax.yml
+++ b/src/core/app/apax.yml
@@ -2,7 +2,6 @@ name: "ix_axopencore"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/data/app/apax.yml
+++ b/src/data/app/apax.yml
@@ -2,7 +2,6 @@ name: "axopen.data-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/inspectors/app/apax.yml
+++ b/src/inspectors/app/apax.yml
@@ -2,7 +2,6 @@ name: "axopen.inspectors"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/integrations/app/apax.yml
+++ b/src/integrations/app/apax.yml
@@ -3,7 +3,6 @@ version: '0.0.0-dev.0'
 type: app
 targets:
   - llvm
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/io/app/apax.yml
+++ b/src/io/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_axopen.io"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/probers/app/apax.yml
+++ b/src/probers/app/apax.yml
@@ -2,7 +2,6 @@ name: "probers-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/simatic1500/app/apax.yml
+++ b/src/simatic1500/app/apax.yml
@@ -2,7 +2,6 @@ name: "simatic1500-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/template.axolibrary/app/apax.yml
+++ b/src/template.axolibrary/app/apax.yml
@@ -2,7 +2,6 @@ name: "app_apaxappname"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - "1500"
 variables:
   APAX_BUILD_ARGS:

--- a/src/timers/app/apax.yml
+++ b/src/timers/app/apax.yml
@@ -2,7 +2,6 @@ name: "timers-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:

--- a/src/traversals/apax/apax.yml
+++ b/src/traversals/apax/apax.yml
@@ -2,7 +2,6 @@ name: apax.traversal
 version: 0.0.0-dev.0
 type: app
 targets:
-- plcsim
 - llvm
 devDependencies:
   '@ix-ax/ax-sdk': 0.0.0-dev.0

--- a/src/utils/app/apax.yml
+++ b/src/utils/app/apax.yml
@@ -2,7 +2,6 @@ name: "utils-app"
 version: '0.0.0-dev.0'
 type: app
 targets:
-  - plcsim
   - llvm
   - "1500"
 variables:


### PR DESCRIPTION
Removes 'plcsim' targets and replaces with "1500" where necessary. This is to comply with new AX release 2405 sld versions.