### PR TITLE
Fix nuget packages restoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -425,3 +425,5 @@ hwc.gen/
 
 #DCP export 
 dcp_export/
+
+*.apax.tgz

--- a/scripts/check_requisites.ps1
+++ b/scripts/check_requisites.ps1
@@ -247,3 +247,73 @@ Note: Treat your personal access token like a password. Keep it secure and do no
 "@    
     Write-Host "You need to add the GitHub NuGet feed to your sources manually." $nugetGuide
 }
+
+# Function to download VS Build Tools
+function Download-VSBuildTools {
+    $url = "https://aka.ms/vs/16/release/vs_buildtools.exe"
+    $output = "vs_buildtools.exe"
+    
+    Write-Host "Downloading Visual Studio Build Tools..."
+    Invoke-WebRequest -Uri $url -OutFile $output
+    
+    if (Test-Path $output) {
+        Write-Host "Visual Studio Build Tools downloaded successfully."
+    } else {
+        Write-Host "Failed to download Visual Studio Build Tools."
+        exit 1
+    }
+}
+
+# Function to install VS Build Tools
+function Install-VSBuildTools {
+    Write-Host "Installing Visual Studio Build Tools..."
+    
+    #Start-Process -FilePath ".\vs_buildtools.exe --wait --norestart --nocache --passive --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.18362" -Wait
+    .\vs_buildtools.exe --wait --norestart --nocache --passive --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK --add Microsoft.VisualStudio.Component.Windows10SDK.18362
+    Write-Host "Visual Studio Build Tools installation completed."
+}
+
+# Expected path from the environment variable
+$expectedVCToolsInstallDir = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133"
+
+# Check if the environment variable exists
+$vctoolsDir = [System.Environment]::GetEnvironmentVariable("VCToolsInstallDir", [System.EnvironmentVariableTarget]::Machine)
+
+if ($vctoolsDir -and (Test-Path $vctoolsDir)) {
+    # If the environment variable exists and the path is valid
+    Write-Host "VCToolsInstallDir is set and the path exists: $vctoolsDir" -foregroundcolor green
+} else {
+    # If the environment variable doesn't exist or the path is invalid
+    Write-Host "VCToolsInstallDir is not set correctly or the path does not exist." -foregroundcolor red
+
+    # Prompt the user to confirm installation
+    $userResponse = Read-Host "Would you like to download and install Visual Studio Build Tools? (Y/N)"
+    
+    if ($userResponse -eq 'Y' -or $userResponse -eq 'y') {
+        # If the user confirms, download and install Visual Studio Build Tools
+        Download-VSBuildTools
+        Install-VSBuildTools
+
+        try
+        {
+            # Set the environment variable after installation
+            [System.Environment]::SetEnvironmentVariable("VCToolsInstallDir", $expectedVCToolsInstallDir, [System.EnvironmentVariableTarget]::Machine)
+        }
+        catch
+        {
+            Write-Host "Failed to set VCToolsInstallDir environment variable or path. You will need to set it manually." -foregroundcolor red
+            Write-Host "VCToolsInstallDir = $expectedVCToolsInstallDir" -foregroundcolor red
+        }
+        # Verify that the environment variable and path are now correct
+        $finalVCToolsInstallDir = [System.Environment]::GetEnvironmentVariable("VCToolsInstallDir", [System.EnvironmentVariableTarget]::Machine)
+        
+        if ($finalVCToolsInstallDir -eq $expectedVCToolsInstallDir -and (Test-Path $finalVCToolsInstallDir)) {
+            Write-Host "VCToolsInstallDir is now set correctly: $finalVCToolsInstallDir"
+        } else {
+            Write-Host "Failed to set VCToolsInstallDir environment variable or path."
+        }
+    } else {
+        # If the user declines installation
+        Write-Host "Installation aborted by the user."
+    }
+}

--- a/scripts/check_requisites.ps1
+++ b/scripts/check_requisites.ps1
@@ -239,9 +239,9 @@ To manually add the GitHub NuGet feed to your sources:
 1. Generate a Personal Access Token on GitHub with 'read:packages', 'write:packages', and 'delete:packages' (if needed) permissions.
 2. Open a command prompt or terminal.
 3. Use the following command to add the feed to your NuGet sources:
-   nuget sources Add -Name "GitHub" -Source "$feedUrl" -Username [YOUR_GITHUB_USERNAME] -Password [YOUR_PERSONAL_ACCESS_TOKEN]
-
-Replace [YOUR_GITHUB_USERNAME] with your actual GitHub username and [YOUR_PERSONAL_ACCESS_TOKEN] with the token you generated.
+   dotnet nuget add source --username [YOUR_GITHUB_USERNAME] --password [YOUR_PERSONAL_ACCESS_TOKEN]  --store-password-in-clear-text --name gh-packages-ix-ax "https://nuget.pkg.github.com/ix-ax/index.json"
+   
+   Replace [YOUR_GITHUB_USERNAME] with your actual GitHub username and [YOUR_PERSONAL_ACCESS_TOKEN] with the token you generated.
 
 Note: Treat your personal access token like a password. Keep it secure and do not share it.
 "@    

--- a/src/AXOpen-L1-tests.sln
+++ b/src/AXOpen-L1-tests.sln
@@ -1,5 +1,5 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXOpen-L1-tests", "AXOpen-L1-tests.proj", "{091BFA68-B549-45AF-9857-3932996D7C60}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXOpen-L1-tests", "AXOpen-L1-tests.proj", "{091BFA68-B549-45AF-9857-3932996D7C60}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ix_ax_axopen_abstractions", "abstractions\src\AXOpen.Abstractions\ix_ax_axopen_abstractions.csproj", "{02DDDB95-D6BC-4718-BA35-3454EAB5DF67}"
 EndProject
@@ -165,8 +165,7 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{091BFA68-B549-45AF-9857-3932996D7C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{091BFA68-B549-45AF-9857-3932996D7C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{091BFA68-B549-45AF-9857-3932996D7C60}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{091BFA68-B549-45AF-9857-3932996D7C60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{091BFA68-B549-45AF-9857-3932996D7C60}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{02DDDB95-D6BC-4718-BA35-3454EAB5DF67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{02DDDB95-D6BC-4718-BA35-3454EAB5DF67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02DDDB95-D6BC-4718-BA35-3454EAB5DF67}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/AXOpen-L2-tests.sln
+++ b/src/AXOpen-L2-tests.sln
@@ -1,16 +1,13 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXOpen-L2-tests", "AXOpen-L2-tests.proj", "{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXOpen-L2-tests", "AXOpen-L2-tests.proj", "{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A85BB89-8946-42C7-AEEC-C777BBE31FCA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AXOpen-L3-tests.sln
+++ b/src/AXOpen-L3-tests.sln
@@ -1,5 +1,5 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXOpen-L3-tests", "AXOpen-L3-tests.proj", "{6D090A35-7564-4D14-8531-7081D858A4F3}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXOpen-L3-tests", "AXOpen-L3-tests.proj", "{6D090A35-7564-4D14-8531-7081D858A4F3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ix_ax_axopen_abstractions", "abstractions\src\AXOpen.Abstractions\ix_ax_axopen_abstractions.csproj", "{64E2240B-1DFE-4939-BB2C-8A40FB81329D}"
 EndProject
@@ -199,8 +199,7 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6D090A35-7564-4D14-8531-7081D858A4F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6D090A35-7564-4D14-8531-7081D858A4F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6D090A35-7564-4D14-8531-7081D858A4F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6D090A35-7564-4D14-8531-7081D858A4F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D090A35-7564-4D14-8531-7081D858A4F3}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{64E2240B-1DFE-4939-BB2C-8A40FB81329D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{64E2240B-1DFE-4939-BB2C-8A40FB81329D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64E2240B-1DFE-4939-BB2C-8A40FB81329D}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/AXOpen.sln
+++ b/src/AXOpen.sln
@@ -1,5 +1,5 @@
 ﻿Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AXOpen", "AXOpen.proj", "{51D303B0-6291-4BAB-939B-8C378F619298}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AXOpen", "AXOpen.proj", "{51D303B0-6291-4BAB-939B-8C378F619298}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "librarytemplate.blazor", "abstractions\app\ix-blazor\librarytemplate.blazor\librarytemplate.blazor.csproj", "{CDA29D58-7DD5-46C8-946C-CD4B04F5EB49}"
 EndProject
@@ -835,8 +835,7 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{51D303B0-6291-4BAB-939B-8C378F619298}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{51D303B0-6291-4BAB-939B-8C378F619298}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{51D303B0-6291-4BAB-939B-8C378F619298}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{51D303B0-6291-4BAB-939B-8C378F619298}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51D303B0-6291-4BAB-939B-8C378F619298}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{CDA29D58-7DD5-46C8-946C-CD4B04F5EB49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CDA29D58-7DD5-46C8-946C-CD4B04F5EB49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDA29D58-7DD5-46C8-946C-CD4B04F5EB49}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="ixax" value="https://nuget.pkg.github.com/yourorg/index.json" />
+    <add key="gh-packages-ix-ax" value="https://nuget.pkg.github.com/ix-ax/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
+  
   <packageSourceMapping>
-    <packageSource key="github">
+    <!-- Get AXSharp.* & AXOpen packages from ax -->
+    <packageSource key="gh-packages-ix-ax">
+      <package pattern="AXSharp.*"/>
+      <package pattern="AXOpen.*"/>
+    </packageSource>
+    
+    <!-- Get all other packages from nuget.org -->
+    <packageSource key="nuget.org">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>

--- a/src/components.abb.robotics/src/AXOpen.Components.Abb.Robotics/ix_ax_axopen_components_abb_robotics.csproj
+++ b/src/components.abb.robotics/src/AXOpen.Components.Abb.Robotics/ix_ax_axopen_components_abb_robotics.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.balluff.identification/src/AXOpen.Components.Balluff.Identification/ix_ax_axopen_components_balluff_identification.csproj
+++ b/src/components.balluff.identification/src/AXOpen.Components.Balluff.Identification/ix_ax_axopen_components_balluff_identification.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.cognex.vision/src/AXOpen.Components.Cognex.Vision/ix_ax_axopen_components_cognex_vision.csproj
+++ b/src/components.cognex.vision/src/AXOpen.Components.Cognex.Vision/ix_ax_axopen_components_cognex_vision.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.desoutter.tightening/src/AXOpen.Components.Desoutter.Tightening/ix_ax_axopen_components_desoutter_tightening.csproj
+++ b/src/components.desoutter.tightening/src/AXOpen.Components.Desoutter.Tightening/ix_ax_axopen_components_desoutter_tightening.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.drives/src/AXOpen.Components.Drives/ix_ax_axopen_components_drives.csproj
+++ b/src/components.drives/src/AXOpen.Components.Drives/ix_ax_axopen_components_drives.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.festo.drives/src/AXOpen.Components.Festo.Drives/ix_ax_axopen_components_festo_drives.csproj
+++ b/src/components.festo.drives/src/AXOpen.Components.Festo.Drives/ix_ax_axopen_components_festo_drives.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.kuka.robotics/src/AXOpen.Components.Kuka.Robotics/ix_ax_axopen_components_kuka_robotics.csproj
+++ b/src/components.kuka.robotics/src/AXOpen.Components.Kuka.Robotics/ix_ax_axopen_components_kuka_robotics.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.mitsubishi.robotics/src/AXOpen.Components.Mitsubishi.Robotics/ix_ax_axopen_components_mitsubishi_robotics.csproj
+++ b/src/components.mitsubishi.robotics/src/AXOpen.Components.Mitsubishi.Robotics/ix_ax_axopen_components_mitsubishi_robotics.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.rexroth.drives/src/AXOpen.Components.Rexroth.Drives/ix_ax_axopen_components_rexroth_drives.csproj
+++ b/src/components.rexroth.drives/src/AXOpen.Components.Rexroth.Drives/ix_ax_axopen_components_rexroth_drives.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.rexroth.press/src/AXOpen.Components.Rexroth.Press/ix_ax_axopen_components_rexroth_press.csproj
+++ b/src/components.rexroth.press/src/AXOpen.Components.Rexroth.Press/ix_ax_axopen_components_rexroth_press.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.robotics/src/AXOpen.Components.Robotics/ix_ax_axopen_components_robotics.csproj
+++ b/src/components.robotics/src/AXOpen.Components.Robotics/ix_ax_axopen_components_robotics.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.siemens.identification/src/AXOpen.Components.Siemens.Identification/ix_ax_axopen_components_siemens_identification.csproj
+++ b/src/components.siemens.identification/src/AXOpen.Components.Siemens.Identification/ix_ax_axopen_components_siemens_identification.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/components.ur.robotics/src/AXOpen.Components.Ur.Robotics/ix_ax_axopen_components_ur_robotics.csproj
+++ b/src/components.ur.robotics/src/AXOpen.Components.Ur.Robotics/ix_ax_axopen_components_ur_robotics.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 		<PackageReference Include="SSH.NET" />
 	</ItemGroup>
 

--- a/src/inspectors/src/AxOpen.Inspectors/ix_ax_axopen_inspectors.csproj
+++ b/src/inspectors/src/AxOpen.Inspectors/ix_ax_axopen_inspectors.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/io/src/AXOpen.Io/ix_ax_axopen_io.csproj
+++ b/src/io/src/AXOpen.Io/ix_ax_axopen_io.csproj
@@ -43,10 +43,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/template.axolibrary/src/projname/ix_ax_apaxlibname.csproj
+++ b/src/template.axolibrary/src/projname/ix_ax_apaxlibname.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/template.axolibrary/src/projname/ix_ax_axolib.csproj
+++ b/src/template.axolibrary/src/projname/ix_ax_axolib.csproj
@@ -42,10 +42,10 @@
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
 		<PackageReference Include="AXSharp.Connector" />
-		<PackageReference Include="GitVersion.MsBuild">
+		<!-- <PackageReference Include="GitVersion.MsBuild">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
+		</PackageReference> -->
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Summary of Pull Request #436
**Title:** Fix nuget packages restoring
**Author:** [PTKu](https://github.com/PTKu)
**Created at:** 2024-10-04T08:55:28Z
**State:** Open

### Description:
This pull request includes the following changes:
- Adjustments to NuGet mapping.
- Removal of redundant GitVersion references from csproj files to address warning about duplicates to CPM.
- Adds checking of VS build tools to prerequisites.
- Adds `apax.tgz` to the general `.gitignore`.

### Commits:
1. [bfa5ba1](https://github.com/ix-ax/AXOpen/commit/bfa5ba10d7c9741f02def39f67cfc0b669d71e22): "Adjustments to NuGet mapping, removal of redundant GitVersion references in projects"
2. [7513b2a](https://github.com/ix-ax/AXOpen/commit/7513b2a98080387677eb4c4c2ee5af8ada25f98b): "Adds checking of vsbuild tools to prerequisites"
3. [45607a0](https://github.com/ix-ax/AXOpen/commit/45607a068551bd61dc5bd4b66307f1b6a9205555): "Adds apax.tgz to general .gitingore"

### Files Changed:
1. [.gitignore](https://github.com/ix-ax/AXOpen/blob/45607a068551bd61dc5bd4b66307f1b6a9205555/.gitignore):
   - Added: `*.apax.tgz`
   
2. [scripts/check_requisites.ps1](https://github.com/ix-ax/AXOpen/blob/45607a068551bd61dc5bd4b66307f1b6a9205555/scripts%2Fcheck_requisites.ps1):
   - Major updates to include functions for downloading and installing Visual Studio Build Tools.

3. [src/AXOpen-L1-tests.sln](https://github.com/ix-ax/AXOpen/blob/45607a068551bd61dc5bd4b66307f1b6a9205555/src%2FAXOpen-L1-tests.sln):
   - Adjustments to the solution file format and project configuration settings.

For more details, view the [pull request](https://github.com/ix-ax/AXOpen/pull/436).