### PR TITLE
Consider limiting what packages need to be released.

### DIFF
--- a/cake/Helpers.cs
+++ b/cake/Helpers.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 
 internal class Helpers
 {
-    public static readonly IEnumerable<string> PublishInternal = new List<string>() { "dev", "dev-2311", "main", "master", "release" };
+    public static readonly IEnumerable<string> PublishInternal = new List<string>() { "dev", "main", "master", "release" };
     public static readonly IEnumerable<string> PublishExternal = new List<string>() { "main", "master", "release" };
 
     public static bool CanReleaseInternal()

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -872,11 +872,14 @@ public sealed class PushPackages : FrostingTask<BuildContext>
         }
 
         if (Helpers.CanReleaseInternal())
-        {
-            context.ApaxPublish();
+        {      
+            if(int.Parse(GitVersionInformation.Major) >= 1)
+            {
+                context.ApaxPublish();
+            }
        
 
-        foreach (var nugetFile in Directory.EnumerateFiles(Path.Combine(context.Artifacts, @"nugets"), "*.nupkg")
+            foreach (var nugetFile in Directory.EnumerateFiles(Path.Combine(context.Artifacts, @"nugets"), "*.nupkg")
                          .Select(p => new FileInfo(p)))
             {
                 context.DotNetNuGetPush(nugetFile.FullName,
@@ -906,7 +909,7 @@ public sealed class PublishReleaseTask : FrostingTask<BuildContext>
         if (Helpers.CanReleaseInternal())
         {
             var githubToken = context.Environment.GetEnvironmentVariable("GH_TOKEN");
-            var githubClient = new GitHubClient(new ProductHeaderValue("IX"));
+            var githubClient = new GitHubClient(new ProductHeaderValue("INXTON"));
             githubClient.Credentials = new Credentials(githubToken);
 
             var release = githubClient.Repository.Release.Create(


### PR DESCRIPTION
This pull request includes several changes to the `cake` project, focusing on refining internal publishing logic and updating GitHub client usage. The most important changes are:

### Refinements to Internal Publishing Logic:
* [`cake/Helpers.cs`](diffhunk://#diff-b21fb096f33b34d43572b3aedab6b8c43c6f842bc73fcd6121526a17d923505aL17-R17): Removed the "dev-2311" branch from the `PublishInternal` list to streamline the internal publishing branches.
* [`cake/Program.cs`](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826R875-R879): Added a condition to check if the major version is greater than or equal to 1 before calling `context.ApaxPublish()`.

### Updates to GitHub Client Usage:
* [`cake/Program.cs`](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L909-R912): Changed the `ProductHeaderValue` from "IX" to "INXTON" for the GitHub client to reflect the updated product name.


closes #528