### PR TITLE
0.22.0-alpha.318

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.22.0-alpha.314",
+      "version": "0.22.0-alpha.318",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.22.0-alpha.314",
+      "version": "0.22.0-alpha.318",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.22.0-alpha.314",
+      "version": "0.22.0-alpha.318",
       "commands": [
         "ixr"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.22.0-alpha.294",
+      "version": "0.22.0-alpha.314",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.22.0-alpha.294",
+      "version": "0.22.0-alpha.314",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.22.0-alpha.294",
+      "version": "0.22.0-alpha.314",
       "commands": [
         "ixr"
       ],

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,11 +8,11 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.314" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.314" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.314" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.314" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.314" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.318" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.318" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.318" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.318" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.318" />
     <!-- AX# END -->
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,11 +8,11 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.294" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.294" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.294" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.294" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.294" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.314" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.314" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.314" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.314" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.314" />
     <!-- AX# END -->
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />

--- a/src/abstractions/app/AXSharp.config.json
+++ b/src/abstractions/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"abstractions_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"abstractions_app.csproj"}

--- a/src/abstractions/ctrl/AXSharp.config.json
+++ b/src/abstractions/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Abstractions","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_abstractions.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Abstractions","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_abstractions.csproj"}

--- a/src/components.abb.robotics/app/AXSharp.config.json
+++ b/src/components.abb.robotics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_abb_robotics.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_abb_robotics.csproj"}

--- a/src/components.abb.robotics/ctrl/AXSharp.config.json
+++ b/src/components.abb.robotics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Abb.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_abb_robotics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Abb.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_abb_robotics.csproj"}

--- a/src/components.abstractions/app/AXSharp.config.json
+++ b/src/components.abstractions/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"components_abstractions_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"components_abstractions_app.csproj"}

--- a/src/components.abstractions/ctrl/AXSharp.config.json
+++ b/src/components.abstractions/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Abstractions","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_abstractions.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Abstractions","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_abstractions.csproj"}

--- a/src/components.balluff.identification/app/AXSharp.config.json
+++ b/src/components.balluff.identification/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_balluff_identification.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_balluff_identification.csproj"}

--- a/src/components.balluff.identification/ctrl/AXSharp.config.json
+++ b/src/components.balluff.identification/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Balluff.Identification","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_balluff_identification.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Balluff.Identification","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_balluff_identification.csproj"}

--- a/src/components.cognex.vision/app/AXSharp.config.json
+++ b/src/components.cognex.vision/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_cognex_vision.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_cognex_vision.csproj"}

--- a/src/components.cognex.vision/ctrl/AXSharp.config.json
+++ b/src/components.cognex.vision/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Cognex.Vision","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_cognex_vision.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Cognex.Vision","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_cognex_vision.csproj"}

--- a/src/components.desoutter.tightening/app/AXSharp.config.json
+++ b/src/components.desoutter.tightening/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_desoutter_tightening.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_desoutter_tightening.csproj"}

--- a/src/components.desoutter.tightening/ctrl/AXSharp.config.json
+++ b/src/components.desoutter.tightening/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Desoutter.Tightening","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_desoutter_tightening.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Desoutter.Tightening","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_desoutter_tightening.csproj"}

--- a/src/components.drives/app/AXSharp.config.json
+++ b/src/components.drives/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_drives.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_drives.csproj"}

--- a/src/components.drives/ctrl/AXSharp.config.json
+++ b/src/components.drives/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_drives.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_drives.csproj"}

--- a/src/components.elements/app/AXSharp.config.json
+++ b/src/components.elements/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"elementscomponents.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"elementscomponents.csproj"}

--- a/src/components.elements/ctrl/AXSharp.config.json
+++ b/src/components.elements/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Elements","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_elements.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Elements","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_elements.csproj"}

--- a/src/components.festo.drives/app/AXSharp.config.json
+++ b/src/components.festo.drives/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_festo_drives.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_festo_drives.csproj"}

--- a/src/components.festo.drives/ctrl/AXSharp.config.json
+++ b/src/components.festo.drives/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Festo.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_festo_drives.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Festo.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_festo_drives.csproj"}

--- a/src/components.kuka.robotics/app/AXSharp.config.json
+++ b/src/components.kuka.robotics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_kuka_robotics.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_kuka_robotics.csproj"}

--- a/src/components.kuka.robotics/ctrl/AXSharp.config.json
+++ b/src/components.kuka.robotics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Kuka.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_kuka_robotics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Kuka.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_kuka_robotics.csproj"}

--- a/src/components.mitsubishi.robotics/app/AXSharp.config.json
+++ b/src/components.mitsubishi.robotics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_mitsubishi_robotics.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_mitsubishi_robotics.csproj"}

--- a/src/components.mitsubishi.robotics/ctrl/AXSharp.config.json
+++ b/src/components.mitsubishi.robotics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Mitsubishi.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_mitsubishi_robotics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Mitsubishi.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_mitsubishi_robotics.csproj"}

--- a/src/components.pneumatics/app/AXSharp.config.json
+++ b/src/components.pneumatics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"pneumaticcomponents.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"pneumaticcomponents.csproj"}

--- a/src/components.pneumatics/ctrl/AXSharp.config.json
+++ b/src/components.pneumatics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Pneumatics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_pneumatics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Pneumatics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_pneumatics.csproj"}

--- a/src/components.rexroth.drives/app/AXSharp.config.json
+++ b/src/components.rexroth.drives/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_rexroth_drives.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_rexroth_drives.csproj"}

--- a/src/components.rexroth.drives/ctrl/AXSharp.config.json
+++ b/src/components.rexroth.drives/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Rexroth.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_rexroth_drives.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Rexroth.Drives","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_rexroth_drives.csproj"}

--- a/src/components.rexroth.press/app/AXSharp.config.json
+++ b/src/components.rexroth.press/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_rexroth_press.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_rexroth_press.csproj"}

--- a/src/components.rexroth.press/ctrl/AXSharp.config.json
+++ b/src/components.rexroth.press/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Rexroth.Press","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_rexroth_press.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Rexroth.Press","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_rexroth_press.csproj"}

--- a/src/components.robotics/app/AXSharp.config.json
+++ b/src/components.robotics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_robotics.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_robotics.csproj"}

--- a/src/components.robotics/ctrl/AXSharp.config.json
+++ b/src/components.robotics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_robotics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_robotics.csproj"}

--- a/src/components.siem.identification/app/AXSharp.config.json
+++ b/src/components.siem.identification/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_siem_identification.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_siem_identification.csproj"}

--- a/src/components.siem.identification/ctrl/AXSharp.config.json
+++ b/src/components.siem.identification/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Siem.Identification","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_siem_identification.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Siem.Identification","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_siem_identification.csproj"}

--- a/src/components.ur.robotics/app/AXSharp.config.json
+++ b/src/components.ur.robotics/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_components_ur_robotics.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_components_ur_robotics.csproj"}

--- a/src/components.ur.robotics/ctrl/AXSharp.config.json
+++ b/src/components.ur.robotics/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Components.Ur.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_components_ur_robotics.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Components.Ur.Robotics","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_components_ur_robotics.csproj"}

--- a/src/core/app/AXSharp.config.json
+++ b/src/core/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"ix_axopencore.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"ix_axopencore.csproj"}

--- a/src/core/ctrl/AXSharp.config.json
+++ b/src/core/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Core","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_core.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Core","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_core.csproj"}

--- a/src/data/app/AXSharp.config.json
+++ b/src/data/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"axopen_data_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"axopen_data_app.csproj"}

--- a/src/data/ctrl/AXSharp.config.json
+++ b/src/data/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Data","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_data.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Data","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_data.csproj"}

--- a/src/inspectors/app/AXSharp.config.json
+++ b/src/inspectors/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"axopen_inspectors.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"axopen_inspectors.csproj"}

--- a/src/inspectors/ctrl/AXSharp.config.json
+++ b/src/inspectors/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Inspectors","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_inspectors.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Inspectors","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_inspectors.csproj"}

--- a/src/integrations/app/AXSharp.config.json
+++ b/src/integrations/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Integrations","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"axopen_integrations.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Integrations","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"axopen_integrations.csproj"}

--- a/src/io/app/AXSharp.config.json
+++ b/src/io/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_axopen_io.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_axopen_io.csproj"}

--- a/src/io/ctrl/AXSharp.config.json
+++ b/src/io/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Io","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_io.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Io","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_io.csproj"}

--- a/src/probers/app/AXSharp.config.json
+++ b/src/probers/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"probers_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"probers_app.csproj"}

--- a/src/probers/ctrl/AXSharp.config.json
+++ b/src/probers/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Probers","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_probers.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Probers","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_probers.csproj"}

--- a/src/simatic1500/app/AXSharp.config.json
+++ b/src/simatic1500/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"simatic1500_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"simatic1500_app.csproj"}

--- a/src/simatic1500/ctrl/AXSharp.config.json
+++ b/src/simatic1500/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_simatic1500.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_simatic1500.csproj"}

--- a/src/template.axolibrary/app/AXSharp.config.json
+++ b/src/template.axolibrary/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"app_apaxappname.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"app_apaxappname.csproj"}

--- a/src/template.axolibrary/ctrl/AXSharp.config.json
+++ b/src/template.axolibrary/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\projname","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_apaxlibname.csproj"}
+{"OutputProjectFolder":"..\\src\\projname","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_apaxlibname.csproj"}

--- a/src/timers/app/AXSharp.config.json
+++ b/src/timers/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"timers_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"timers_app.csproj"}

--- a/src/timers/ctrl/AXSharp.config.json
+++ b/src/timers/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Timers","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_timers.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Timers","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_timers.csproj"}

--- a/src/traversals/apax/AXSharp.config.json
+++ b/src/traversals/apax/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"apax_traversal.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"apax_traversal.csproj"}

--- a/src/utils/app/AXSharp.config.json
+++ b/src/utils/app/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"utils_app.csproj"}
+{"OutputProjectFolder":"ix","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"utils_app.csproj"}

--- a/src/utils/ctrl/AXSharp.config.json
+++ b/src/utils/ctrl/AXSharp.config.json
@@ -1,1 +1,1 @@
-{"OutputProjectFolder":"..\\src\\AXOpen.Utils","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"ProjectFile":"inxton_axopen_utils.csproj"}
+{"OutputProjectFolder":"..\\src\\AXOpen.Utils","UseBase":false,"NoDependencyUpdate":false,"IgnoreS7Pragmas":false,"SkipDependencyCompilation":false,"TargetPlatfromMoniker":"ax","ProjectFile":"inxton_axopen_utils.csproj"}


### PR DESCRIPTION
This pull request includes updates to the version numbers of various AXSharp tools and packages. The changes ensure that the project uses the latest alpha versions of these dependencies.

Version updates:

* Updated `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` tools to version `0.22.0-alpha.314` in `.config/dotnet-tools.json`. [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)
* Updated `AXSharp.Abstractions`, `AXSharp.Connector`, `AXSharp.Connector.S71500.WebAPI`, `AXSharp.Presentation.Blazor`, and `AXSharp.Presentation.Blazor.Controls` packages to version `0.22.0-alpha.314` in `src/Directory.Packages.props`.

closes #536