### PR TITLE
update to ax# 0.22.0-alpha.326

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.22.0-alpha.323",
+      "version": "0.22.0-alpha.326",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.22.0-alpha.323",
+      "version": "0.22.0-alpha.326",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.22.0-alpha.323",
+      "version": "0.22.0-alpha.326",
       "commands": [
         "ixr"
       ],

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,11 +8,11 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.323" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.323" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.323" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.323" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.323" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.22.0-alpha.326" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.22.0-alpha.326" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.22.0-alpha.326" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.22.0-alpha.326" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.22.0-alpha.326" />
     <!-- AX# END -->
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />


### PR DESCRIPTION
This pull request includes updates to several package versions in the `AXSharp` suite. The changes ensure that the tools and packages are using the latest alpha version.

Version updates:

* [`.config/dotnet-tools.json`](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6): Updated the version of `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` to `0.22.0-alpha.326` [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)
* [`src/Directory.Packages.props`](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L11-R15): Updated the version of `AXSharp.Abstractions`, `AXSharp.Connector`, `AXSharp.Connector.S71500.WebAPI`, `AXSharp.Presentation.Blazor`, and `AXSharp.Presentation.Blazor.Controls` to `0.22.0-alpha.326`
closes #552