### PR TITLE
Add Guid and DateOnly serializers to MongoDb settings

### DIFF
--- a/src/data/src/repositories/MongoDb/Mongo/MongoDbRepositorySettings.cs
+++ b/src/data/src/repositories/MongoDb/Mongo/MongoDbRepositorySettings.cs
@@ -236,6 +236,8 @@ namespace AXOpen.Data.MongoDb
                 BsonSerializer.RegisterSerializer(typeof(UInt64), new UInt64Serializer(BsonType.Int64, new RepresentationConverter(true, false)));
                 BsonSerializer.RegisterSerializer(typeof(UInt32), new UInt32Serializer(BsonType.Int64, new RepresentationConverter(true, false)));
 
+                BsonSerializer.RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
+
                 BsonSerializer.RegisterSerializer(new DateOnlySerializer());
                 BsonSerializer.RegisterSerializer(DateTimeSerializer.LocalInstance);
                 BsonSerializer.RegisterSerializer(typeof(float), new FloatTruncationSerializer());


### PR DESCRIPTION
Added GuidSerializer with GuidRepresentation.Standard and DateOnlySerializer to MongoDbRepositorySettings.cs in the AXOpen.Data.MongoDb namespace. These serializers ensure proper serialization of GUIDs and DateOnly types with MongoDB.

