### PR TITLE
refactors property data to avoid possible conflict

### DIFF
--- a/src/data/src/AXOpen.Data/DataExchange/AxoDataExchange.cs
+++ b/src/data/src/AXOpen.Data/DataExchange/AxoDataExchange.cs
@@ -32,11 +32,8 @@ namespace AXOpen.Data;
 public partial class AxoDataExchange<TOnline, TPlain> where TOnline : IAxoDataEntity
     where TPlain : Pocos.AXOpen.Data.IAxoDataEntity, new()
 {
-    /// <summary>
-    ///     Gets <see cref="AxoDataEntity" /> as <see cref="ITwinObject" /> that provides exchange mechanisms between this
-    ///     <see cref="AxoDataExchange{TOnline,TPlain}" /> and the controller.
-    /// </summary>
-    public ITwinObject? Data => DataEntity as ITwinObject;
+    /// <inheritdoc />
+    public ITwinObject? DataExchangeTwinObject => DataEntity as ITwinObject;
 
     private TOnline _dataEntity;
 

--- a/src/data/src/AXOpen.Data/DataExchange/IAxoDataExchange.cs
+++ b/src/data/src/AXOpen.Data/DataExchange/IAxoDataExchange.cs
@@ -15,7 +15,11 @@ namespace AXOpen.Data
     {
         ITwinObject CloneDataObject();
 
-        ITwinObject Data { get; }
+        /// <summary>
+        ///     Gets <see cref="AxoDataEntity" /> as <see cref="ITwinObject" /> that provides exchange mechanisms between this
+        ///     data exchange instance and the controller.
+        /// </summary>
+        ITwinObject DataExchangeTwinObject { get; }
 
         /// <summary>
         /// Gets repository associated with this <see cref="IAxoDataExchange"/> object.

--- a/src/data/src/AXOpen.Data/DataFragmentExchange/AxoDataFragmentExchange.cs
+++ b/src/data/src/AXOpen.Data/DataFragmentExchange/AxoDataFragmentExchange.cs
@@ -16,7 +16,8 @@ namespace AXOpen.Data;
 
 public partial class AxoDataFragmentExchange
 {
-    public ITwinObject? Data { get; private set; }
+    /// <inheritdoc />
+    public ITwinObject? DataExchangeTwinObject { get; private set; }
 
     private IRepository? _repository;
     protected IAxoDataExchange[] DataFragments { get; private set; }
@@ -42,7 +43,7 @@ public partial class AxoDataFragmentExchange
     public object CreateDataFragments()
     {
         DataFragments = GetDataSetProperty<AxoDataFragmentAttribute, IAxoDataExchange>().ToArray();
-        Data = new AxoFragmentedDataCompound(this, DataFragments.Select(p => p.Data).Cast<ITwinElement>().ToList());
+        DataExchangeTwinObject = new AxoFragmentedDataCompound(this, DataFragments.Select(p => p.DataExchangeTwinObject).Cast<ITwinElement>().ToList());
         Repository = new AxoCompoundRepository(DataFragments);
 
         foreach (var prop in this.GetType().GetProperties())
@@ -208,7 +209,7 @@ public partial class AxoDataFragmentExchange
 
     private static void CreateNewPocoInFragmentRepository(string identifier, IAxoDataExchange fragment)
     {
-        Pocos.AXOpen.Data.IAxoDataEntity poco = (Pocos.AXOpen.Data.IAxoDataEntity)fragment.Data.CreatePoco();
+        Pocos.AXOpen.Data.IAxoDataEntity poco = (Pocos.AXOpen.Data.IAxoDataEntity)fragment.DataExchangeTwinObject.CreatePoco();
         poco.DataEntityId = identifier;
         poco.Hash = HashHelper.CreateHash(poco);
 
@@ -254,7 +255,7 @@ public partial class AxoDataFragmentExchange
 
         foreach (var fragment in interfaceFragments)
         {
-            var fr = DataFragments.FirstOrDefault(p => p.Data.GetType() == fragment.GetType());
+            var fr = DataFragments.FirstOrDefault(p => p.DataExchangeTwinObject.GetType() == fragment.GetType());
             yield return (fr, fr.Repository, fragment); 
         }
     }

--- a/src/data/tests/AXOpen.Data.Tests/DataExchange/AxoDataExchangeTests.cs
+++ b/src/data/tests/AXOpen.Data.Tests/DataExchange/AxoDataExchangeTests.cs
@@ -521,7 +521,7 @@ namespace AXOpen.Data.Tests
             sut.Set.GoesTo.Shadow = 201;
 
 
-            await sut.CreateCopyCurrentShadowsAsync("hey remote create - new", sut.Data);
+            await sut.CreateCopyCurrentShadowsAsync("hey remote create - new", sut.DataExchangeTwinObject);
 
             var record = repo.Read("hey remote create - new");
             Assert.Equal("hey remote create - new", record.DataEntityId);

--- a/src/data/tests/AXOpen.Data.Tests/DataExchangeFragments/AxoDataFragmentExchange.cs
+++ b/src/data/tests/AXOpen.Data.Tests/DataExchangeFragments/AxoDataFragmentExchange.cs
@@ -268,7 +268,7 @@ namespace AXOpen.Data.Fragments.Tests
             { ComesFrom = 185, GoesTo = 398 });
             manipRepo.Create("hey remote create", new() { CounterDelay = 898577ul });
 
-            await sut.FromRepositoryToShadowsAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.Data);
+            await sut.FromRepositoryToShadowsAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.DataExchangeTwinObject);
 
 
             Assert.Equal("hey remote create", sut.Set.Set.DataEntityId.Shadow);
@@ -294,7 +294,7 @@ namespace AXOpen.Data.Fragments.Tests
             { ComesFrom = 485, GoesTo = 898 });
             manipRepo.Create("hey remote create", new() { CounterDelay = 5898577ul });
 
-            await sut.FromRepositoryToControllerAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.Data);
+            await sut.FromRepositoryToControllerAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.DataExchangeTwinObject);
 
             // TODO: @kuh0005 : This test is not working as originally written
             // seems to have something to do with later additions to `LethargicWrite` in the generated code
@@ -319,7 +319,7 @@ namespace AXOpen.Data.Fragments.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                await sut.CreateNewAsync($"{i}Record", s.Data);
+                await sut.CreateNewAsync($"{i}Record", s.DataExchangeTwinObject);
             }
 
             var actual = sut.GetRecords("Rec", 3, 0, eSearchMode.Contains, "Default", true);
@@ -339,7 +339,7 @@ namespace AXOpen.Data.Fragments.Tests
 
             for (int i = 0; i < 10; i++)
             {
-                await sut.CreateNewAsync($"{i}Record", s.Data);
+                await sut.CreateNewAsync($"{i}Record", s.DataExchangeTwinObject);
             }
 
             var actual = sut.GetRecords("*");
@@ -394,7 +394,7 @@ namespace AXOpen.Data.Fragments.Tests
             sut.Manip.Set.DataEntityId.Shadow = "hey remote create";
             sut.Manip.Set.CounterDelay.Shadow = 8566ul;
 
-            await sut.UpdateFromShadowsAsync(sut.Data);
+            await sut.UpdateFromShadowsAsync(sut.DataExchangeTwinObject);
 
 
             var shared = sut.Set.DataRepository.Read("hey remote create");
@@ -419,7 +419,7 @@ namespace AXOpen.Data.Fragments.Tests
             await sut.Set.Set.GoesTo.SetAsync(222);
             await sut.Manip.Set.CounterDelay.SetAsync(4859);
 
-            await sut.CreateDataFromControllerAsync("hey remote create", sut.Data);
+            await sut.CreateDataFromControllerAsync("hey remote create", sut.DataExchangeTwinObject);
 
             var shared = sut.Set.DataRepository.Read("hey remote create");
 
@@ -448,11 +448,11 @@ namespace AXOpen.Data.Fragments.Tests
 
             
 
-            await sut.CreateDataFromControllerAsync("hey remote create", sut.Data);
+            await sut.CreateDataFromControllerAsync("hey remote create", sut.DataExchangeTwinObject);
 
 
 
-            await sut.CreateCopyCurrentShadowsAsync("hey remote create - copy", sut.Data);
+            await sut.CreateCopyCurrentShadowsAsync("hey remote create - copy", sut.DataExchangeTwinObject);
 
 
             var shared = sut.Set.DataRepository.Read("hey remote create - copy");
@@ -482,7 +482,7 @@ namespace AXOpen.Data.Fragments.Tests
             manipRepo.Create("hey remote create", new() { CounterDelay = 898577ul });
             manipRepo.Delete("hey remote create");
 
-            await sut.FromRepositoryToShadowsAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.Data);
+            await sut.FromRepositoryToShadowsAsync(new SharedProductionData() { DataEntityId = "hey remote create" }, s.DataExchangeTwinObject);
 
             Assert.Equal("hey remote create", sut.Set.Set.DataEntityId.Shadow);
             Assert.Equal(185, sut.Set.Set.ComesFrom.Shadow);

--- a/src/integrations/tests/AXOpen.Integration.Data.Blazor.Tests/AxoDataViewModelTests.cs
+++ b/src/integrations/tests/AXOpen.Integration.Data.Blazor.Tests/AxoDataViewModelTests.cs
@@ -99,7 +99,7 @@ namespace integration.data.blazor.tests
             };
 
             //await _vm.DataExchange.RefUIData.PlainToShadow(_vm.SelectedRecord);
-            await _vm.DataExchange.FromRepositoryToShadowsAsync(_vm.SelectedRecord, _vm.DataExchange.Data);
+            await _vm.DataExchange.FromRepositoryToShadowsAsync(_vm.SelectedRecord, _vm.DataExchange.DataExchangeTwinObject);
             await _vm.Edit();
 
             //assert


### PR DESCRIPTION
This pull request focuses on renaming the `Data` property to `DataExchangeTwinObject` across several classes and interfaces in the `AXOpen.Data` namespace. The changes also include corresponding updates to the test files to reflect this renaming.

### Renaming of `Data` to `DataExchangeTwinObject`:

* [`src/data/src/AXOpen.Data/DataExchange/AxoDataExchange.cs`](diffhunk://#diff-e92b51e28b955b43e8188551278c12eb80ca9952136a5baaf7cf8f17d962803fL35-R36): Renamed the `Data` property to `DataExchangeTwinObject` and updated its documentation.
* [`src/data/src/AXOpen.Data/DataExchange/IAxoDataExchange.cs`](diffhunk://#diff-0fcb9201c2e98a97d02b6b3d6d64d550e10dd7c6734db8cf79b21a52399efce7L18-R22): Updated the `Data` property to `DataExchangeTwinObject` with appropriate documentation.
* `src/data/src/AXOpen.Data/DataFragmentExchange/AxoDataFragmentExchange.cs`: 
  * Renamed the `Data` property to `DataExchangeTwinObject` and updated its documentation.
  * Updated internal usage of `Data` to `DataExchangeTwinObject` in methods such as `CreateDataFragments`, `SetLockedBy`, `ExistsAsync`, etc. [[1]](diffhunk://#diff-1e70b3b89e73244e5b60251cf327cc690ed8bf78f33ae88e094b1ae8167f8c03L45-R46) [[2]](diffhunk://#diff-1e70b3b89e73244e5b60251cf327cc690ed8bf78f33ae88e094b1ae8167f8c03L211-R212) [[3]](diffhunk://#diff-1e70b3b89e73244e5b60251cf327cc690ed8bf78f33ae88e094b1ae8167f8c03L257-R258)

### Test Updates:

* [`src/data/tests/AXOpen.Data.Tests/DataExchange/AxoDataExchangeTests.cs`](diffhunk://#diff-23eeab4a281ab2e537252038d5b944f1ebb940ae097cd929fe73a194626a2f7bL524-R524): Updated test cases to use `DataExchangeTwinObject` instead of `Data`.
* [`src/data/tests/AXOpen.Data.Tests/DataExchangeFragments/AxoDataFragmentExchange.cs`](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL271-R271): Modified multiple test methods to reflect the renaming of the `Data` property to `DataExchangeTwinObject`. [[1]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL271-R271) [[2]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL297-R297) [[3]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL322-R322) [[4]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL342-R342) [[5]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL397-R397) [[6]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL422-R422) [[7]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL451-R455) [[8]](diffhunk://#diff-1563478463bb81f91302108d04994de25b0bb5738ce2ab7699e1bdb488cb7e2aL485-R485)
* [`src/integrations/tests/AXOpen.Integration.Data.Blazor.Tests/AxoDataViewModelTests.cs`](diffhunk://#diff-c58ef0911a33f3e624c12b296bf2273f6c9b2fa51771ddf86c4e57e1bb285ea4L102-R102): Updated the test method to use `DataExchangeTwinObject`.

closes #588 