### PR TITLE
Update ax.catalog due to version misalignment in 2411.1.0

### DIFF
--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -6,13 +6,13 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@ax/simatic-ax" : 2411.1.0
+  "@inxton/ax.catalog": 0.0.5
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
   "@ax/simatic-1500-clocks": 8.0.8
   "@ax/system-bitaccess": 8.0.7
-  "@ax/system-math": 8.0.7
+  "@ax/system-math": 8.0.8
   "@ax/system-serde": 8.0.7
 installStrategy: strict
 apaxVersion: 3.4.2

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.4
+  "@ax/simatic-ax" : 2411.1.0
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@ax/simatic-ax" : 2411.1.0
+  "@inxton/ax.catalog": 0.0.5
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.4
+  "@ax/simatic-ax" : 2411.1.0
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@ax/simatic-ax" : 2411.1.0
+  "@inxton/ax.catalog": 0.0.5
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.4
+  "@ax/simatic-ax" : 2411.1.0
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -9,11 +9,11 @@ devDependencies:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@ax/simatic-ax" : 2411.1.0
+  "@inxton/ax.catalog": 0.0.5
 dependencies:
   "@ax/simatic-1500-clocks": 8.0.8
   "@ax/system-bitaccess": 8.0.7
-  "@ax/system-math": 8.0.7
+  "@ax/system-math": 8.0.8
   "@ax/system-serde": 8.0.7
   "@ax/hwc": 2.0.65
   "@ax/hw-s7-1500": 2.0.65

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -9,7 +9,7 @@ devDependencies:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.4
+  "@ax/simatic-ax" : 2411.1.0
 dependencies:
   "@ax/simatic-1500-clocks": 8.0.8
   "@ax/system-bitaccess": 8.0.7

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@ax/simatic-ax" : 2411.1.0
+  "@inxton/ax.catalog": 0.0.5
 dependencies:
   '@ax/apax-build': 2.0.20
   '@ax/axunitst': 6.0.6

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.4
+  "@ax/simatic-ax" : 2411.1.0
 dependencies:
   '@ax/apax-build': 2.0.20
   '@ax/axunitst': 6.0.6


### PR DESCRIPTION
This pull request includes updates to the `apax.yml` files across multiple directories to bump the versions of `@inxton/ax.catalog` and `@ax/system-math` dependencies.

Dependency updates:

* [`src/ax.axopen.app/ctrl/apax.yml`](diffhunk://#diff-5b95e3fc6089719f9f93af8ade09855489c751ae1ed8428143aa7118d7fc38adL9-R15): Updated `@inxton/ax.catalog` to version 0.0.5 and `@ax/system-math` to version 8.0.8.
* [`src/ax.axopen.hwlibrary/ctrl/apax.yml`](diffhunk://#diff-8e9251619262f638b80a695996e639e8e3ee5835b15fa8dacff2f581771d355dL9-R9): Updated `@inxton/ax.catalog` to version 0.0.5.
* [`src/ax.axopen.min/ctrl/apax.yml`](diffhunk://#diff-89e01002b9b9a648ebf8805d0bb03d193c0b56d7cdb9d797e1d253b244d6fc37L9-R9): Updated `@inxton/ax.catalog` to version 0.0.5.
* [`src/ax.latest.packages/ctrl/apax.yml`](diffhunk://#diff-b7adc7d14d8f3cd2fa69625674b9dd8c3233b6bdc5651e126858427018481be9L12-R16): Updated `@inxton/ax.catalog` to version 0.0.5 and `@ax/system-math` to version 8.0.8.
* [`src/sdk-ax/ctrl/apax.yml`](diffhunk://#diff-5ecf0591f7d0e0980987da286bf20767696876ddb0bc000b2f392fbd4483645dL9-R9): Updated `@inxton/ax.catalog` to version 0.0.5.