### PR TITLE
Hide _context and _parent and implement safe retrieval methods

### DIFF
--- a/src/abstractions/ctrl/src/AxoObject/IAxoObject.st
+++ b/src/abstractions/ctrl/src/AxoObject/IAxoObject.st
@@ -4,6 +4,7 @@ NAMESPACE AXOpen.Core
     METHOD GetContext : IAxoContext END_METHOD
     METHOD GetContextUnsafe : IAxoContext END_METHOD    
     METHOD AggregateMessage VAR_INPUT inCount : LINT; END_VAR END_METHOD  
+    METHOD GetParent : IAxoObject END_METHOD
   END_INTERFACE  
 END_NAMESPACE
 

--- a/src/components.abb.robotics/ctrl/src/AxoIrc5_v_1_x_x.st
+++ b/src/components.abb.robotics/ctrl/src/AxoIrc5_v_1_x_x.st
@@ -156,44 +156,44 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                hwID            :   WORD;   
-                hwIdDI_64_bytes :   WORD;   //  Hardware Id of the input data of the robot
-                hwIdDO_64_bytes :   WORD;   //  Hardware Id of the output data of the robot
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         hwID            :   WORD;   
+        //         hwIdDI_64_bytes :   WORD;   //  Hardware Id of the input data of the robot
+        //         hwIdDO_64_bytes :   WORD;   //  Hardware Id of the output data of the robot
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwIdDI_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwIdDO_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwIdDI_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwIdDO_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                RobotStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdDI_64_bytes = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdDO_64_bytes = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#702;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         RobotStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdDI_64_bytes = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdDO_64_bytes = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#702;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID            :=  hwID           ;
-            _hwIdDI_64_bytes :=  hwIdDI_64_bytes;
-            _hwIdDO_64_bytes :=  hwIdDO_64_bytes;
+        //     _hwID            :=  hwID           ;
+        //     _hwIdDI_64_bytes :=  hwIdDI_64_bytes;
+        //     _hwIdDO_64_bytes :=  hwIdDO_64_bytes;
 
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.abb.robotics/ctrl/src/AxoOmnicore_v_1_x_x.st
+++ b/src/components.abb.robotics/ctrl/src/AxoOmnicore_v_1_x_x.st
@@ -156,44 +156,44 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                hwID            :   WORD;   
-                hwIdDI_64_bytes :   WORD;   //  Hardware Id of the input data of the robot
-                hwIdDO_64_bytes :   WORD;   //  Hardware Id of the output data of the robot
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         hwID            :   WORD;   
+        //         hwIdDI_64_bytes :   WORD;   //  Hardware Id of the input data of the robot
+        //         hwIdDO_64_bytes :   WORD;   //  Hardware Id of the output data of the robot
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwIdDI_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwIdDO_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwIdDI_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwIdDO_64_bytes = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                RobotStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdDI_64_bytes = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdDO_64_bytes = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#702;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         RobotStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdDI_64_bytes = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdDO_64_bytes = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#702;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID            :=  hwID           ;
-            _hwIdDI_64_bytes :=  hwIdDI_64_bytes;
-            _hwIdDO_64_bytes :=  hwIdDO_64_bytes;
+        //     _hwID            :=  hwID           ;
+        //     _hwIdDI_64_bytes :=  hwIdDI_64_bytes;
+        //     _hwIdDO_64_bytes :=  hwIdDO_64_bytes;
 
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.balluff.identification/ctrl/src/Axo_BIS_M_4XX_045.st
+++ b/src/components.balluff.identification/ctrl/src/Axo_BIS_M_4XX_045.st
@@ -180,34 +180,34 @@ NAMESPACE AXOpen.Components.Balluff.Identification
         /// Runs tasks and logic of this component.
         /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
         ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                hwID            :   WORD;   
-                hwId_BISM       :   WORD;   //  Hardware Id of the reader 
-            END_VAR
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         hwID            :   WORD;   
+        //         hwId_BISM       :   WORD;   //  Hardware Id of the reader 
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
             
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwId_BISM = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwId_BISM = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                ReaderStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwId_BISM = WORD#0 THEN
-                ReaderStatus.Error.Id := UINT#701;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         ReaderStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwId_BISM = WORD#0 THEN
+        //         ReaderStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID       :=  hwID;
-            _hwId_BISM  :=  hwId_BISM;
+        //     _hwID       :=  hwID;
+        //     _hwId_BISM  :=  hwId_BISM;
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.cognex.vision/ctrl/src/AxoDataman/v_6_0_0/AxoDataman.st
+++ b/src/components.cognex.vision/ctrl/src/AxoDataman/v_6_0_0/AxoDataman.st
@@ -213,79 +213,79 @@ NAMESPACE AXOpen.Components.Cognex.Vision.v_6_0_0_0
             THIS.Close();                   
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent                  :   IAxoContext; 
-                ResultDataSize          :   eAxoDataman_ResultDataSize;
-                UserDataSize            :   eAxoDataman_UserDataSize;
-                hwID                    :   WORD;
-                hwIdAcquisitionControl  :   WORD;
-                hwIdAcquisitionStatus   :   WORD;
-                hwIdResultsControl      :   WORD;
-                hwIdResultsStatus       :   WORD;
-                hwIdSoftEventControl    :   WORD;
-                hwIdResultData          :   WORD;
-                hwIdUserData            :   WORD;
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent                  :   IAxoContext; 
+        //         ResultDataSize          :   eAxoDataman_ResultDataSize;
+        //         UserDataSize            :   eAxoDataman_UserDataSize;
+        //         hwID                    :   WORD;
+        //         hwIdAcquisitionControl  :   WORD;
+        //         hwIdAcquisitionStatus   :   WORD;
+        //         hwIdResultsControl      :   WORD;
+        //         hwIdResultsStatus       :   WORD;
+        //         hwIdSoftEventControl    :   WORD;
+        //         hwIdResultData          :   WORD;
+        //         hwIdUserData            :   WORD;
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
             
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwIdAcquisitionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwIdAcquisitionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,hwIdResultsControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,hwIdResultsStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705,hwIdSoftEventControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#706,hwIdResultData = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#707,hwIdUserData = WORD#0, eAxoMessageCategory#ProgrammingError);            
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwIdAcquisitionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwIdAcquisitionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,hwIdResultsControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,hwIdResultsStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705,hwIdSoftEventControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#706,hwIdResultData = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#707,hwIdUserData = WORD#0, eAxoMessageCategory#ProgrammingError);            
 
-            IF parent = NULL THEN
-                Status.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdAcquisitionControl = WORD#0 THEN
-                Status.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdAcquisitionStatus = WORD#0 THEN
-                Status.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwIdResultsControl = WORD#0 THEN
-                Status.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwIdResultsStatus = WORD#0 THEN
-                Status.Error.Id := UINT#704;
-                RETURN;
-            ELSIF hwIdSoftEventControl = WORD#0 THEN
-                Status.Error.Id := UINT#705;
-                RETURN;
-            ELSIF hwIdResultData = WORD#0 THEN
-                Status.Error.Id := UINT#706;
-                RETURN;
-            ELSIF hwIdUserData = WORD#0 THEN
-                Status.Error.Id := UINT#707;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         Status.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdAcquisitionControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdAcquisitionStatus = WORD#0 THEN
+        //         Status.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwIdResultsControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwIdResultsStatus = WORD#0 THEN
+        //         Status.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF hwIdSoftEventControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#705;
+        //         RETURN;
+        //     ELSIF hwIdResultData = WORD#0 THEN
+        //         Status.Error.Id := UINT#706;
+        //         RETURN;
+        //     ELSIF hwIdUserData = WORD#0 THEN
+        //         Status.Error.Id := UINT#707;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID                    := hwID;
-            _ResultDataSize          := ResultDataSize;
-            _UserDataSize            := UserDataSize;
-            _hwIdAcquisitionControl  := hwIdAcquisitionControl;
-            _hwIdAcquisitionStatus   := hwIdAcquisitionStatus;
-            _hwIdResultsControl      := hwIdResultsControl;
-            _hwIdResultsStatus       := hwIdResultsStatus;
-            _hwIdSoftEventControl    := hwIdSoftEventControl;
-            _hwIdResultData          := hwIdResultData;
-            _hwIdUserData            := hwIdUserData;     
+        //     _hwID                    := hwID;
+        //     _ResultDataSize          := ResultDataSize;
+        //     _UserDataSize            := UserDataSize;
+        //     _hwIdAcquisitionControl  := hwIdAcquisitionControl;
+        //     _hwIdAcquisitionStatus   := hwIdAcquisitionStatus;
+        //     _hwIdResultsControl      := hwIdResultsControl;
+        //     _hwIdResultsStatus       := hwIdResultsStatus;
+        //     _hwIdSoftEventControl    := hwIdSoftEventControl;
+        //     _hwIdResultData          := hwIdResultData;
+        //     _hwIdUserData            := hwIdUserData;     
 
-            THIS.Open();
-            THIS.Execute();
-            THIS.Close();       
-        END_METHOD
+        //     THIS.Open();
+        //     THIS.Execute();
+        //     THIS.Close();       
+        // END_METHOD
 
         METHOD PRIVATE UpdateInputs : BOOL
             VAR

--- a/src/components.cognex.vision/ctrl/src/AxoInsight/v_6_0_0/AxoInsight.st
+++ b/src/components.cognex.vision/ctrl/src/AxoInsight/v_6_0_0/AxoInsight.st
@@ -257,85 +257,85 @@ NAMESPACE AXOpen.Components.Cognex.Vision.v_6_0_0_0
             THIS.Close();            
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent                  :   IAxoContext; 
-                ResultDataSize          :   eAxoInsight_ResultDataSize;
-                UserDataSize            :   eAxoInsight_UserDataSize;
-                hwID                    :   WORD;
-                hwIdAcquisitionControl  :   WORD;
-                hwIdAcquisitionStatus   :   WORD;
-                hwIdInspectionControl   :   WORD;
-                hwIdInspectionStatus    :   WORD;
-                hwIdCommandControl      :   WORD;
-                hwIdSoftEventControl    :   WORD;
-                hwIdResultData          :   WORD;
-                hwIdUserData            :   WORD;
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent                  :   IAxoContext; 
+        //         ResultDataSize          :   eAxoInsight_ResultDataSize;
+        //         UserDataSize            :   eAxoInsight_UserDataSize;
+        //         hwID                    :   WORD;
+        //         hwIdAcquisitionControl  :   WORD;
+        //         hwIdAcquisitionStatus   :   WORD;
+        //         hwIdInspectionControl   :   WORD;
+        //         hwIdInspectionStatus    :   WORD;
+        //         hwIdCommandControl      :   WORD;
+        //         hwIdSoftEventControl    :   WORD;
+        //         hwIdResultData          :   WORD;
+        //         hwIdUserData            :   WORD;
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
             
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwIdAcquisitionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwIdAcquisitionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,hwIdInspectionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,hwIdInspectionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705,hwIdCommandControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#706,hwIdSoftEventControl = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#707,hwIdResultData = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#708,hwIdUserData = WORD#0, eAxoMessageCategory#ProgrammingError);            
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwIdAcquisitionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwIdAcquisitionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,hwIdInspectionControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,hwIdInspectionStatus = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705,hwIdCommandControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#706,hwIdSoftEventControl = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#707,hwIdResultData = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#708,hwIdUserData = WORD#0, eAxoMessageCategory#ProgrammingError);            
 
-            IF parent = NULL THEN
-                Status.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdAcquisitionControl = WORD#0 THEN
-                Status.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdAcquisitionStatus = WORD#0 THEN
-                Status.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwIdInspectionControl = WORD#0 THEN
-                Status.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwIdInspectionStatus = WORD#0 THEN
-                Status.Error.Id := UINT#704;
-                RETURN;
-            ELSIF hwIdCommandControl  = WORD#0 THEN
-                Status.Error.Id := UINT#705;
-                RETURN;
-            ELSIF hwIdSoftEventControl = WORD#0 THEN
-                Status.Error.Id := UINT#706;
-                RETURN;
-            ELSIF hwIdResultData = WORD#0 THEN
-                Status.Error.Id := UINT#707;
-                RETURN;
-            ELSIF hwIdUserData = WORD#0 THEN
-                Status.Error.Id := UINT#708;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         Status.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdAcquisitionControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdAcquisitionStatus = WORD#0 THEN
+        //         Status.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwIdInspectionControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwIdInspectionStatus = WORD#0 THEN
+        //         Status.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF hwIdCommandControl  = WORD#0 THEN
+        //         Status.Error.Id := UINT#705;
+        //         RETURN;
+        //     ELSIF hwIdSoftEventControl = WORD#0 THEN
+        //         Status.Error.Id := UINT#706;
+        //         RETURN;
+        //     ELSIF hwIdResultData = WORD#0 THEN
+        //         Status.Error.Id := UINT#707;
+        //         RETURN;
+        //     ELSIF hwIdUserData = WORD#0 THEN
+        //         Status.Error.Id := UINT#708;
+        //         RETURN;
+        //     END_IF;
 
-            _ResultDataSize         :=  ResultDataSize;
-            _UserDataSize           :=  UserDataSize;
-            _hwID                   :=  hwID;
-            _hwIdAcquisitionControl :=  hwIdAcquisitionControl;
-            _hwIdAcquisitionStatus  :=  hwIdAcquisitionStatus;
-            _hwIdInspectionControl  :=  hwIdInspectionControl;
-            _hwIdInspectionStatus   :=  hwIdInspectionStatus;
-            _hwIdCommandControl     :=  hwIdCommandControl;
-            _hwIdSoftEventControl   :=  hwIdSoftEventControl;
-            _hwIdResultData         :=  hwIdResultData;
-            _hwIdUserData           :=  hwIdUserData;
+        //     _ResultDataSize         :=  ResultDataSize;
+        //     _UserDataSize           :=  UserDataSize;
+        //     _hwID                   :=  hwID;
+        //     _hwIdAcquisitionControl :=  hwIdAcquisitionControl;
+        //     _hwIdAcquisitionStatus  :=  hwIdAcquisitionStatus;
+        //     _hwIdInspectionControl  :=  hwIdInspectionControl;
+        //     _hwIdInspectionStatus   :=  hwIdInspectionStatus;
+        //     _hwIdCommandControl     :=  hwIdCommandControl;
+        //     _hwIdSoftEventControl   :=  hwIdSoftEventControl;
+        //     _hwIdResultData         :=  hwIdResultData;
+        //     _hwIdUserData           :=  hwIdUserData;
 
-            THIS.Open();
-            THIS.Execute();
-            THIS.Close();            
-        END_METHOD
+        //     THIS.Open();
+        //     THIS.Execute();
+        //     THIS.Close();            
+        // END_METHOD
                
         METHOD PRIVATE UpdateInputs : BOOL
             VAR

--- a/src/components.desoutter.tightening/ctrl/src/CVIC_II/AxoCVIC_II.st
+++ b/src/components.desoutter.tightening/ctrl/src/CVIC_II/AxoCVIC_II.st
@@ -206,76 +206,76 @@ NAMESPACE AXOpen.Components.Desoutter.Tightening
                 
         END_METHOD   
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent                  :   IAxoContext; 
-                hwID                    :   WORD;
-                hwId_Input_1_byte_1     :   WORD;
-                hwId_Input_1_byte_2     :   WORD;
-                hwId_Input_2_word_1     :   WORD;
-                hwId_Input_1_word_1     :   WORD;
-                hwId_Input_2_word_2     :   WORD;
-                hwId_Input_1_word_2     :   WORD;
-                hwId_Output_1_byte_1    :   WORD;
-                hwId_Output_1_byte_2    :   WORD;
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent                  :   IAxoContext; 
+        //         hwID                    :   WORD;
+        //         hwId_Input_1_byte_1     :   WORD;
+        //         hwId_Input_1_byte_2     :   WORD;
+        //         hwId_Input_2_word_1     :   WORD;
+        //         hwId_Input_1_word_1     :   WORD;
+        //         hwId_Input_2_word_2     :   WORD;
+        //         hwId_Input_1_word_2     :   WORD;
+        //         hwId_Output_1_byte_1    :   WORD;
+        //         hwId_Output_1_byte_2    :   WORD;
+        //     END_VAR
 
-            THIS.Initialize(parent);
-            Messenger.Serve(THIS);
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwId_Input_1_byte_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwId_Input_1_byte_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,hwId_Input_2_word_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,hwId_Input_1_word_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705,hwId_Input_2_word_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#706,hwId_Input_1_word_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#707,hwId_Output_1_byte_1 = WORD#0, eAxoMessageCategory#ProgrammingError);            
-            Messenger.ActivateOnCondition(ULINT#708,hwId_Output_1_byte_2 = WORD#0, eAxoMessageCategory#ProgrammingError);            
+        //     THIS.Initialize(parent);
+        //     Messenger.Serve(THIS);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwId_Input_1_byte_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwId_Input_1_byte_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,hwId_Input_2_word_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,hwId_Input_1_word_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705,hwId_Input_2_word_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#706,hwId_Input_1_word_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#707,hwId_Output_1_byte_1 = WORD#0, eAxoMessageCategory#ProgrammingError);            
+        //     Messenger.ActivateOnCondition(ULINT#708,hwId_Output_1_byte_2 = WORD#0, eAxoMessageCategory#ProgrammingError);            
 
-            IF parent = NULL THEN
-                Status.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwId_Input_1_byte_2 = WORD#0 THEN
-                Status.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwId_Input_1_byte_2 = WORD#0 THEN
-                Status.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwId_Input_2_word_1 = WORD#0 THEN
-                Status.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwId_Input_1_word_1 = WORD#0 THEN
-                Status.Error.Id := UINT#704;
-                RETURN;
-            ELSIF hwId_Input_2_word_2 = WORD#0 THEN
-                Status.Error.Id := UINT#705;
-                RETURN;
-            ELSIF hwId_Input_1_word_2 = WORD#0 THEN
-                Status.Error.Id := UINT#706;
-                RETURN;
-            ELSIF hwId_Output_1_byte_1 = WORD#0 THEN
-                Status.Error.Id := UINT#707;
-                RETURN;
-            ELSIF hwId_Output_1_byte_2 = WORD#0 THEN
-                Status.Error.Id := UINT#708;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         Status.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwId_Input_1_byte_2 = WORD#0 THEN
+        //         Status.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwId_Input_1_byte_2 = WORD#0 THEN
+        //         Status.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwId_Input_2_word_1 = WORD#0 THEN
+        //         Status.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwId_Input_1_word_1 = WORD#0 THEN
+        //         Status.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF hwId_Input_2_word_2 = WORD#0 THEN
+        //         Status.Error.Id := UINT#705;
+        //         RETURN;
+        //     ELSIF hwId_Input_1_word_2 = WORD#0 THEN
+        //         Status.Error.Id := UINT#706;
+        //         RETURN;
+        //     ELSIF hwId_Output_1_byte_1 = WORD#0 THEN
+        //         Status.Error.Id := UINT#707;
+        //         RETURN;
+        //     ELSIF hwId_Output_1_byte_2 = WORD#0 THEN
+        //         Status.Error.Id := UINT#708;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID                   :=  hwID;
-            _hwId_Input_1_byte_1    :=  hwId_Input_1_byte_1;
-            _hwId_Input_1_byte_2    :=  hwId_Input_1_byte_2;
-            _hwId_Input_2_word_1    :=  hwId_Input_2_word_1;
-            _hwId_Input_1_word_1    :=  hwId_Input_1_word_1;
-            _hwId_Input_2_word_2    :=  hwId_Input_2_word_2;
-            _hwId_Input_1_word_2    :=  hwId_Input_1_word_2;
-            _hwId_Output_1_byte_1   :=  hwId_Output_1_byte_1;
-            _hwId_Output_1_byte_2   :=  hwId_Output_1_byte_2;
-            THIS.Execute();
-        END_METHOD
+        //     _hwID                   :=  hwID;
+        //     _hwId_Input_1_byte_1    :=  hwId_Input_1_byte_1;
+        //     _hwId_Input_1_byte_2    :=  hwId_Input_1_byte_2;
+        //     _hwId_Input_2_word_1    :=  hwId_Input_2_word_1;
+        //     _hwId_Input_1_word_1    :=  hwId_Input_1_word_1;
+        //     _hwId_Input_2_word_2    :=  hwId_Input_2_word_2;
+        //     _hwId_Input_1_word_2    :=  hwId_Input_1_word_2;
+        //     _hwId_Output_1_byte_1   :=  hwId_Output_1_byte_1;
+        //     _hwId_Output_1_byte_2   :=  hwId_Output_1_byte_2;
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute
 

--- a/src/components.drives/ctrl/src/AxoDrives/AxoDrive.st
+++ b/src/components.drives/ctrl/src/AxoDrives/AxoDrive.st
@@ -1262,43 +1262,43 @@ NAMESPACE AXOpen.Components.Drives
             THIS.Close();            
         END_METHOD   
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent          :   IAxoContext; 
-                refAxisIn       :   REF_TO  ARRAY[*] OF BYTE;   //  Reference to the input data of the axis
-                refAxisOut      :   REF_TO  ARRAY[*] OF BYTE;   //  Reference to the output data of the axis
-                Enable          :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
-                EnablePositive  :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
-                EnableNegative  :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent          :   IAxoContext; 
+        //         refAxisIn       :   REF_TO  ARRAY[*] OF BYTE;   //  Reference to the input data of the axis
+        //         refAxisOut      :   REF_TO  ARRAY[*] OF BYTE;   //  Reference to the output data of the axis
+        //         Enable          :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
+        //         EnablePositive  :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
+        //         EnableNegative  :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
+        //     END_VAR
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                DriveStatus.Error.Id := UINT#700;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         DriveStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     END_IF;
 
-            THIS.Initialize(parent);
-            // IF THIS._context_ = NULL THEN
-            //     THIS.Initialize(parent);
-            //     THIS.InitializeTasks();
-            // END_IF;
+        //     THIS.Initialize(parent);
+        //     // IF THIS._context_ = NULL THEN
+        //     //     THIS.Initialize(parent);
+        //     //     THIS.InitializeTasks();
+        //     // END_IF;
 
-            IF NOT THIS.IsValidReferences(refAxisIn,refAxisOut) THEN
-                RETURN;
-            END_IF;
+        //     IF NOT THIS.IsValidReferences(refAxisIn,refAxisOut) THEN
+        //         RETURN;
+        //     END_IF;
             
-            THIS.Open();
-            THIS.UpdateInputs(refAxisIn,_AxisRef);
-            THIS.Execute(_AxisRef,Enable,EnablePositive,EnableNegative);
-            THIS.UpdateOutputs(_AxisRef,refAxisIn);
-            THIS.Close();            
-        END_METHOD   
+        //     THIS.Open();
+        //     THIS.UpdateInputs(refAxisIn,_AxisRef);
+        //     THIS.Execute(_AxisRef,Enable,EnablePositive,EnableNegative);
+        //     THIS.UpdateOutputs(_AxisRef,refAxisIn);
+        //     THIS.Close();            
+        // END_METHOD   
 
         METHOD PRIVATE InitializeTasks
                 RestoreTask.Initialize(THIS);

--- a/src/components.elements/ctrl/src/AxoAi/AxoAi.st
+++ b/src/components.elements/ctrl/src/AxoAi/AxoAi.st
@@ -6,113 +6,121 @@ NAMESPACE AXOpen.Elements
     {S7.extern=ReadWrite}
     CLASS AxoAi EXTENDS AXOpen.Core.AxoComponent
 
-    VAR PUBLIC
+        VAR PUBLIC
 
-        /// configuration for calculations
-        {#ix-attr:[Container(Layout.Wrap)]}
-        {#ix-attr:[ComponentDetails("Config")]}
-        _config : AxoAiConfig;
+            /// configuration for calculations
+            {#ix-attr:[Container(Layout.Wrap)]}
+            {#ix-attr:[ComponentDetails("Config")]}
+            _config : AxoAiConfig;
 
-        /// status of input
-        {#ix-attr:[ComponentHeader()]}
-        {#ix-attr:[Container(Layout.Wrap)]}
-        {#ix-attr:[Group(GroupLayout.GroupBox)]}   
-        {#ix-attr:[ReadOnly()]}
-        {#ix-set:AttributeName = "<#Status#>"}
-        _status : AxoAiStatus;	
+            /// status of input
+            {#ix-attr:[ComponentHeader()]}
+            {#ix-attr:[Container(Layout.Wrap)]}
+            {#ix-attr:[Group(GroupLayout.GroupBox)]}   
+            {#ix-attr:[ReadOnly()]}
+            {#ix-set:AttributeName = "<#Status#>"}
+            _status : AxoAiStatus;	
 
-        {#ix-attr:[Container(Layout.Wrap)]}
-       
-        _rawRange : REAL;
-        _realRange : REAL;
-        _scaled : REAL;
+            {#ix-attr:[Container(Layout.Wrap)]}
+        
+            _rawRange : REAL;
+            _realRange : REAL;
+            _scaled : REAL;
 
 
-        {#ix-set:MessageText = "<#Division by zero: Verify values defined in config! (RawHigh,RawLow)#>"}
-        _messengerDivisionByZero : AXOpen.Messaging.Static.AxoMessenger;
+            {#ix-set:MessageText = "<#Division by zero: Verify values defined in config! (RawHigh,RawLow)#>"}
+            _messengerDivisionByZero : AXOpen.Messaging.Static.AxoMessenger;
 
-        {#ix-set:MessageText = "<#Invalid data: Gain is not defined!#>"}
-        _messengerGainNotDefined : AXOpen.Messaging.Static.AxoMessenger;
+            {#ix-set:MessageText = "<#Invalid data: Gain is not defined!#>"}
+            _messengerGainNotDefined : AXOpen.Messaging.Static.AxoMessenger;
 
-        {#ix-set:MessageText = "<#Out of boundaries,check correction parameters (Gain,Ofset) in config!#>"}
-        {#ix-set:Help = "<#Check your signal input.#>"}
-        _messengerOutOfBoundaries : AXOpen.Messaging.Static.AxoMessenger;
-    END_VAR
-
-    VAR
-        _signal : DINT;
-    END_VAR
-
-    /// <summary>
-    /// Method, which scales input signal based on configuration
-    /// </summary>
-    METHOD PUBLIC Run 
-
-        VAR_INPUT
-            parent : Axopen.Core.IAxoObject;
-            inSignal: DINT;
+            {#ix-set:MessageText = "<#Out of boundaries,check correction parameters (Gain,Ofset) in config!#>"}
+            {#ix-set:Help = "<#Check your signal input.#>"}
+            _messengerOutOfBoundaries : AXOpen.Messaging.Static.AxoMessenger;
         END_VAR
-        
-        IF (parent = NULL) THEN RETURN; END_IF;
 
-        IF THIS._context_ = NULL THEN
-            THIS.Initialize(parent);
-        end_if;
-
-        _messengerDivisionByZero.Serve(THIS); 
-        _messengerGainNotDefined.Serve(THIS); 
-        _messengerOutOfBoundaries.Serve(THIS);
-
-        _signal := inSignal;
-        //scaling
-        _rawRange  := TO_REAL(_config.RawHigh - _config.RawLow);
-        _realRange := _config.RealHigh - _config.RealLow;
-        _scaled    := 0;
-
-        IF (_rawRange = 0) THEN
-            _messengerDivisionByZero.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
-            RETURN;
-        END_IF;
-        
-        IF (_config.Gain = 0) THEN
-            _messengerGainNotDefined.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
-        END_IF;
-
-        _scaled := TO_REAL(_signal - _config.RawLow) / _rawRange;
-
-        _scaled := _scaled * _realRange;
-        _scaled := _scaled + _config.RealLow;
-
-        _scaled := _scaled * _config.Gain + _config.Offset;
-        
-        IF (_scaled > _config.RealHigh) AND (_config.Gain <> 1 OR _config.Offset <> 0) THEN
-            _messengerOutOfBoundaries.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
-        ELSIF (_scaled < _config.RealLow) AND (_config.Gain <> 1 OR _config.Offset <> 0) THEN
-            _messengerOutOfBoundaries.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
-        END_IF;
-
-        _status.RawRange  := _rawRange;
-        _status.RealRange := _realRange;
-        _status.Scaled    := _scaled;
-    END_METHOD
-
-       /// <summary>
-    /// Method, which scales input signal based on configuration
-    /// </summary>
-    METHOD PUBLIC Run 
-        VAR_INPUT
-            parent : Axopen.Core.IAxoObject;
-            inSignal: WORD;
+        VAR
+            _signal : DINT;
         END_VAR
-        THIS.Run(parent,TO_DINT(inSignal));
-    END_METHOD
 
-    METHOD PUBLIC OVERRIDE Restore 
-        ;
-    END_METHOD
+        VAR PRIVATE
+            _context : IAxoContext;
+        END_VAR
 
-    METHOD PROTECTED OVERRIDE ManualControl
-        THIS._isManuallyControllable := TRUE;
-    END_METHOD
-END_CLASS
+        /// <summary>
+        /// Method, which scales input signal based on configuration
+        /// </summary>
+        METHOD PUBLIC Run 
+
+            VAR_INPUT
+                parent : Axopen.Core.IAxoObject;
+                inSignal: DINT;
+            END_VAR
+            
+
+            IF (parent = NULL) THEN 
+                RETURN; 
+            END_IF;
+
+            IF _context = NULL THEN
+                THIS.Initialize(parent);
+                _context := THIS.GetContext();
+            END_IF;
+
+            _messengerDivisionByZero.Serve(THIS); 
+            _messengerGainNotDefined.Serve(THIS); 
+            _messengerOutOfBoundaries.Serve(THIS);
+
+            _signal := inSignal;
+            //scaling
+            _rawRange  := TO_REAL(_config.RawHigh - _config.RawLow);
+            _realRange := _config.RealHigh - _config.RealLow;
+            _scaled    := 0;
+
+            IF (_rawRange = 0) THEN
+                _messengerDivisionByZero.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
+                RETURN;
+            END_IF;
+            
+            IF (_config.Gain = 0) THEN
+                _messengerGainNotDefined.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
+            END_IF;
+
+            _scaled := TO_REAL(_signal - _config.RawLow) / _rawRange;
+
+            _scaled := _scaled * _realRange;
+            _scaled := _scaled + _config.RealLow;
+
+            _scaled := _scaled * _config.Gain + _config.Offset;
+            
+            IF (_scaled > _config.RealHigh) AND (_config.Gain <> 1 OR _config.Offset <> 0) THEN
+                _messengerOutOfBoundaries.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
+            ELSIF (_scaled < _config.RealLow) AND (_config.Gain <> 1 OR _config.Offset <> 0) THEN
+                _messengerOutOfBoundaries.Activate(AXOpen.Messaging.eAxoMessageCategory#Error);
+            END_IF;
+
+            _status.RawRange  := _rawRange;
+            _status.RealRange := _realRange;
+            _status.Scaled    := _scaled;
+        END_METHOD
+
+        /// <summary>
+        /// Method, which scales input signal based on configuration
+        /// </summary>
+        METHOD PUBLIC Run 
+            VAR_INPUT
+                parent : Axopen.Core.IAxoObject;
+                inSignal: WORD;
+            END_VAR
+            THIS.Run(parent,TO_DINT(inSignal));
+        END_METHOD
+
+        METHOD PUBLIC OVERRIDE Restore 
+            ;
+        END_METHOD
+
+        METHOD PROTECTED OVERRIDE ManualControl
+            THIS._isManuallyControllable := TRUE;
+        END_METHOD
+    END_CLASS
 END_NAMESPACE

--- a/src/components.elements/ctrl/src/AxoAo/AxoAo.st
+++ b/src/components.elements/ctrl/src/AxoAo/AxoAo.st
@@ -49,7 +49,11 @@ NAMESPACE AXOpen.Elements
             _signal : DINT;
 
         END_VAR   
-        
+
+        VAR PRIVATE
+            _context : IAxoContext;
+        END_VAR
+
         /// <summary>
         /// Method, which unscales input signal based on configuration and writes it to output
         /// </summary>
@@ -63,11 +67,15 @@ NAMESPACE AXOpen.Elements
                 oSignal: DINT;
             END_VAR
     
-            IF (parent = NULL) THEN RETURN; END_IF;
 
-            IF THIS._context_ = NULL THEN
+            IF (parent = NULL) THEN 
+                RETURN; 
+            END_IF;
+
+            IF _context = NULL THEN
                 THIS.Initialize(parent);
-            end_if;
+                _context := THIS.GetContext();
+            END_IF;
 
             _messengerDivisionByZero.Serve(THIS); 
             _messengerGainNotDefined.Serve(THIS); 

--- a/src/components.elements/ctrl/src/AxoDi/AxoDi.st
+++ b/src/components.elements/ctrl/src/AxoDi/AxoDi.st
@@ -35,7 +35,10 @@ NAMESPACE AXOpen.Elements
             
         END_VAR
        
-
+        VAR PRIVATE
+            _context : IAxoContext;
+        END_VAR
+        
         METHOD PUBLIC OVERRIDE Restore 
             _isFalseTask.Restore();
             _isTrueTask.Restore();
@@ -56,14 +59,17 @@ NAMESPACE AXOpen.Elements
                 inSignal: BOOL;
             END_VAR
 
-            IF (parent = NULL) THEN RETURN; END_IF;
+            IF (parent = NULL) THEN 
+                RETURN; 
+            END_IF;
 
-            IF THIS._context_ = NULL THEN
+            IF _context = NULL THEN
                 THIS.Initialize(parent);
                 _isTrueTask.Initialize(THIS);
                 _isFalseTask.Initialize(THIS);
-            end_if;
-          
+                _context := THIS.GetContext();
+            END_IF;
+
             _messengerInfoPositive.Serve(THIS); 
             _messengerInfoNegative.Serve(THIS); 
 

--- a/src/components.elements/ctrl/src/AxoDo/AxoDo.st
+++ b/src/components.elements/ctrl/src/AxoDo/AxoDo.st
@@ -33,6 +33,9 @@ NAMESPACE AXOpen.Elements
 
         END_VAR
 
+        VAR PRIVATE
+            _context : IAxoContext;
+        END_VAR
 
         METHOD PUBLIC OVERRIDE Restore 
             _setTask.Restore();
@@ -56,13 +59,16 @@ NAMESPACE AXOpen.Elements
                 oSignal: BOOL;
             END_VAR
 
-            IF (parent = NULL) THEN RETURN; END_IF;
+            IF (parent = NULL) THEN 
+                RETURN;
+            END_IF;
 
-            IF THIS._context_ = NULL THEN
+            IF _context = NULL THEN
                 THIS.Initialize(parent);
                 _setTask.Initialize(THIS);
                 _resetTask.Initialize(THIS);
-            end_if;
+                _context := THIS.GetContext();
+            END_IF;
 
             _messengerInfoPositive.Serve(THIS); 
             _messengerInfoNegative.Serve(THIS); 

--- a/src/components.elements/ctrl/test/TestContext.st
+++ b/src/components.elements/ctrl/test/TestContext.st
@@ -13,7 +13,7 @@ NAMESPACE AxoIO.Tests
         
             METHOD PUBLIC OVERRIDE Open : ULINT
                 SUPER.Open();
-                SignalParent.Initialize(THIS);
+                SignalParent.InitializeWithContext(THIS);
             END_METHOD
 
         METHOD PROTECTED OVERRIDE Main

--- a/src/components.festo.drives/ctrl/src/AxoCmmtAs/AxoCmmtAs.st
+++ b/src/components.festo.drives/ctrl/src/AxoCmmtAs/AxoCmmtAs.st
@@ -148,63 +148,63 @@ NAMESPACE AXOpen.Components.Festo.Drives
             THIS.Execute(_AxisRefExt);
         END_METHOD   
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent              :   IAxoContext; 
-                hwID                :   WORD;
-                hwIdTelegram111     :   WORD;                       //  Hardware ID of the Profidrive telegram 111 of this axis
-                hwIdTelegram750     :   WORD;                       //  Hardware ID of the Profidrive telegram 750 of this axis
-                MAP_HW_ID           :   WORD;                       //  Hardware identifier of the module acces point submodule 
-                Enable              :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
-                EnablePositive      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
-                EnableNegative      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent              :   IAxoContext; 
+        //         hwID                :   WORD;
+        //         hwIdTelegram111     :   WORD;                       //  Hardware ID of the Profidrive telegram 111 of this axis
+        //         hwIdTelegram750     :   WORD;                       //  Hardware ID of the Profidrive telegram 750 of this axis
+        //         MAP_HW_ID           :   WORD;                       //  Hardware identifier of the module acces point submodule 
+        //         Enable              :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
+        //         EnablePositive      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
+        //         EnableNegative      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#742, Enable AND NOT EnablePositive, eAxoMessageCategory#Warning);
-            Messenger.ActivateOnCondition(ULINT#743, Enable AND NOT EnableNegative, eAxoMessageCategory#Warning);
-            Messenger.ActivateOnCondition(ULINT#701, hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702, hwIdTelegram111 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703, hwIdTelegram750 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704, MAP_HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#742, Enable AND NOT EnablePositive, eAxoMessageCategory#Warning);
+        //     Messenger.ActivateOnCondition(ULINT#743, Enable AND NOT EnableNegative, eAxoMessageCategory#Warning);
+        //     Messenger.ActivateOnCondition(ULINT#701, hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702, hwIdTelegram111 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703, hwIdTelegram750 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704, MAP_HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                DriveStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwID = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdTelegram111 = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwIdTelegram750 = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#703;
-                RETURN;
-            ELSIF MAP_HW_ID = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#704;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         DriveStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwID = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdTelegram111 = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwIdTelegram750 = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF MAP_HW_ID = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#704;
+        //         RETURN;
+        //     END_IF;
 
-            THIS.Open();
+        //     THIS.Open();
 
-            _AxisRefExt.Data.hwID                := hwID;
-            _AxisRefExt.Data.hwIdTelegram111     := hwIdTelegram111;
-            _AxisRefExt.Data.hwIdTelegram750     := hwIdTelegram750;
-            _AxisRefExt.Data.MAP_HW_ID           := MAP_HW_ID;
+        //     _AxisRefExt.Data.hwID                := hwID;
+        //     _AxisRefExt.Data.hwIdTelegram111     := hwIdTelegram111;
+        //     _AxisRefExt.Data.hwIdTelegram750     := hwIdTelegram750;
+        //     _AxisRefExt.Data.MAP_HW_ID           := MAP_HW_ID;
 
 
-            Parametrization.Initialize(THIS);
-            HardwareDiagnosticsTask.Initialize(THIS);
+        //     Parametrization.Initialize(THIS);
+        //     HardwareDiagnosticsTask.Initialize(THIS);
 
-            SUPER.Execute(_AxisRefExt,Enable,EnablePositive,EnableNegative);
-            THIS.Execute(_AxisRefExt);
-        END_METHOD   
+        //     SUPER.Execute(_AxisRefExt,Enable,EnablePositive,EnableNegative);
+        //     THIS.Execute(_AxisRefExt);
+        // END_METHOD   
 
         METHOD PRIVATE Execute
             VAR_INPUT

--- a/src/components.festo.drives/ctrl/src/PROFIdrive/AxoReadWritePROFIdriveParameter.st
+++ b/src/components.festo.drives/ctrl/src/PROFIdrive/AxoReadWritePROFIdriveParameter.st
@@ -65,15 +65,15 @@ NAMESPACE AXOpen.Components.Festo.Drives
 
         END_METHOD
 
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent          :   IAxoContext; 
-            END_VAR            
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent          :   IAxoContext; 
+        //     END_VAR            
 
-            THIS.Initialize(parent);
-            THIS.Execute();
+        //     THIS.Initialize(parent);
+        //     THIS.Execute();
 
-        END_METHOD
+        // END_METHOD
 
         METHOD PUBLIC Execute
             

--- a/src/components.kuka.robotics/ctrl/src/AxoKrc4_v_5_x_x.st
+++ b/src/components.kuka.robotics/ctrl/src/AxoKrc4_v_5_x_x.st
@@ -148,37 +148,37 @@ NAMESPACE AXOpen.Components.Kuka.Robotics
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                hwID            :   WORD;   
-                hwId_512_DI_DO  :   WORD;   //  Hardware Id of the input data of the robot
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         hwID            :   WORD;   
+        //         hwId_512_DI_DO  :   WORD;   //  Hardware Id of the input data of the robot
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwId_512_DI_DO = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwId_512_DI_DO = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                RobotStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwId_512_DI_DO = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#701;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         RobotStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwId_512_DI_DO = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID            :=  hwID           ;
-            _hwId_512_DI_DO  :=  hwId_512_DI_DO;
+        //     _hwID            :=  hwID           ;
+        //     _hwId_512_DI_DO  :=  hwId_512_DI_DO;
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
+++ b/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
@@ -129,35 +129,35 @@ NAMESPACE AXOpen.Components.Mitsubishi.Robotics
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                hwID                :   WORD;
-                hwIdInOut_64_byte   :   WORD;
-            END_VAR
-            THIS.Initialize(parent);
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         hwID                :   WORD;
+        //         hwIdInOut_64_byte   :   WORD;
+        //     END_VAR
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwIdInOut_64_byte = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.Serve(THIS);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwIdInOut_64_byte = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                RobotStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdInOut_64_byte = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#701;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         RobotStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdInOut_64_byte = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID               :=  hwID;
-            _hwIdInOut_64_byte  :=  hwIdInOut_64_byte;
+        //     _hwID               :=  hwID;
+        //     _hwIdInOut_64_byte  :=  hwIdInOut_64_byte;
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.pneumatics/ctrl/src/AxoCylinder.st
+++ b/src/components.pneumatics/ctrl/src/AxoCylinder.st
@@ -51,6 +51,8 @@ NAMESPACE AXOpen.Components.Pneumatics
 
             _MoveToWorkIsBusy : BOOL;
             _MoveToHomeIsBusy : BOOL;
+
+            _context : IAxoContext;
         END_VAR
 
         ///<summary>
@@ -68,14 +70,17 @@ NAMESPACE AXOpen.Components.Pneumatics
                 moveWorkSignal : BOOL;
             END_VAR
 
-            IF (parent = NULL) THEN RETURN; END_IF;
+            IF (parent = NULL) THEN 
+                RETURN; 
+            END_IF;
 
-            IF THIS._context_ = NULL THEN
+            IF _context = NULL THEN
                 THIS.Initialize(parent);
                 _MoveToWorkTask.Initialize(THIS);
                 _MoveToHomeTask.Initialize(THIS);
                 _StopTask.Initialize(THIS);
-            end_if;
+                _context := THIS.GetContext();
+            END_IF;
 
             THIS.Open(); // inline representation save 1% of cpu by 40 pistons on 1516 Fw2.9
 

--- a/src/components.pneumatics/ctrl/test/CylinderTests.st
+++ b/src/components.pneumatics/ctrl/test/CylinderTests.st
@@ -36,7 +36,8 @@ NAMESPACE Cylinder.Tests
             context : TestContext;
             cylinder : AxoCylinder;
             cylinderParent : AXOpen.Core.AxoObject;
-            _rtc : AxoRtcMock;
+            _rtc             :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm             :   AXOpen.Core.Dummies.MockAxoRtm;
             _homeSensor : BOOL;
             _workSensor : BOOL;
             _moveHomeSignal : BOOL;
@@ -52,10 +53,14 @@ NAMESPACE Cylinder.Tests
 
         {TestSetup}
         METHOD PUBLIC TestSetup
-        // Will be called before MyTest_A AND before Test_B are executed
             context := contextBlank;
+            _rtm.SetElapsed(LTIME#2s);
+            context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            context.InjectRtc(_rtc);
             cylinder := cylinderBlank;
             cylinderParent := cylinderParentBlank;
+            cylinderParent.InitializeWithContext(context);
         END_METHOD
     
         {TestTearDown}
@@ -83,7 +88,7 @@ NAMESPACE Cylinder.Tests
             _rtc.SetNowUTC(dt);
             context.InjectRtc(_rtc);
             context.Open();   
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);                
             context.Close();                          
         END_METHOD
@@ -102,7 +107,7 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -115,12 +120,12 @@ NAMESPACE Cylinder.Tests
         END_METHOD
         
         {Test}
-        METHOD PUBLIC MoveWork         
+        METHOD PUBLIC MoveWork       
             THIS.Init();  
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -138,13 +143,13 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             context.Open();                                                              
             cylinder._StopTask.Invoke();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
 
@@ -162,13 +167,13 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             context.Open();                                                              
             cylinder._StopTask.Invoke();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -185,12 +190,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2023-01-12-15:49:12.123;
             END_VAR
-
             THIS.Init(dt);  
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -202,7 +206,7 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.SuspendMoveToWorkWhile(TRUE);
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -219,12 +223,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-15:49:12.123;
             END_VAR
-
             THIS.Init(dt);    
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -235,7 +238,7 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             cylinder.SuspendMoveToWorkWhile(TRUE);
             context.Close();                          
@@ -253,12 +256,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-13:49:12.123;
             END_VAR
-
             THIS.Init(dt);   
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -270,7 +272,7 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -287,12 +289,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-05:49:12.123;
             END_VAR
-
             THIS.Init(dt); 
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -303,7 +304,7 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             cylinder.SuspendMoveToHomeWhile(TRUE);
             context.Close();                          
@@ -321,14 +322,13 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-05:49:12.123;
             END_VAR
-
             THIS.Init(dt); 
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
             cylinder.SuspendMoveToWorkWhile(TRUE);
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -345,14 +345,13 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-05:41:12.123;
             END_VAR
-
             THIS.Init(dt); 
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -369,13 +368,12 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2023-01-12-15:49:12.123;
             END_VAR
-
             THIS.Init(dt);  
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -386,7 +384,7 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.AbortMoveToWorkWhen(TRUE);
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -403,12 +401,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-15:49:12.123;
             END_VAR
-
             THIS.Init(dt);    
 
             context.Open();                                                              
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -419,7 +416,7 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             cylinder.AbortMoveToWorkWhen(TRUE);
             context.Close();                          
@@ -437,12 +434,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-13:49:12.123;
             END_VAR
-
             THIS.Init(dt);   
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -454,7 +450,7 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.AbortMoveToHomeWhen(TRUE);
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -471,12 +467,11 @@ NAMESPACE Cylinder.Tests
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-05:49:12.123;
             END_VAR
-
             THIS.Init(dt); 
 
             context.Open();                                                              
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -487,7 +482,7 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
 
             context.Open();                                                              
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             cylinder.AbortMoveToHomeWhen(TRUE);
             context.Close();                          
@@ -512,7 +507,7 @@ NAMESPACE Cylinder.Tests
             context.Open();                                                              
             cylinder.AbortMoveToWorkWhen(TRUE);
             cylinder.MoveToWork();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -536,7 +531,7 @@ NAMESPACE Cylinder.Tests
             context.Open();                                                              
             cylinder.AbortMoveToHomeWhen(TRUE);
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
@@ -554,19 +549,19 @@ NAMESPACE Cylinder.Tests
         METHOD PUBLIC Messaging     
             VAR
                 dt : LDATE_AND_TIME := LDATE_AND_TIME#2021-01-11-05:41:12.123;
-            END_VAR   
+            END_VAR 
             THIS.Init(dt); 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
             cylinder.MoveToHome();
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
-            cylinderParent.Initialize(context);                                                        
+            cylinderParent.InitializeWithContext(context);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
 

--- a/src/components.rexroth.drives/ctrl/src/AxoIndraDrive.st
+++ b/src/components.rexroth.drives/ctrl/src/AxoIndraDrive.st
@@ -93,61 +93,61 @@ NAMESPACE AXOpen.Components.Rexroth.Drives
             THIS.Close(); 
         END_METHOD   
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent          :   IAxoContext; 
-                hwID                :   WORD;
-                hwIdParamCh_IDN     :   WORD;
-                hwIdInput_9_Words   :   WORD;
-                hwIdOutput_13_Words :   WORD;
-                Enable              :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
-                EnablePositive      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
-                EnableNegative      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent          :   IAxoContext; 
+        //         hwID                :   WORD;
+        //         hwIdParamCh_IDN     :   WORD;
+        //         hwIdInput_9_Words   :   WORD;
+        //         hwIdOutput_13_Words :   WORD;
+        //         Enable              :   BOOL;                       //  As long as ‘Enable’ is true, power is being enabled.
+        //         EnablePositive      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in positive direction
+        //         EnableNegative      :   BOOL;                       //  As long as ‘Enable’ is true, this permits motion in negative direction
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
                
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,hwIdParamCh_IDN = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705,hwIdInput_9_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#706,hwIdOutput_13_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,hwIdParamCh_IDN = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705,hwIdInput_9_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#706,hwIdOutput_13_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                DriveStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwID = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwIdParamCh_IDN = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#704;
-                RETURN;
-            ELSIF hwIdInput_9_Words = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#705;
-                RETURN;
-            ELSIF hwIdOutput_13_Words = WORD#0 THEN
-                DriveStatus.Error.Id := UINT#706;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         DriveStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwID = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwIdParamCh_IDN = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF hwIdInput_9_Words = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#705;
+        //         RETURN;
+        //     ELSIF hwIdOutput_13_Words = WORD#0 THEN
+        //         DriveStatus.Error.Id := UINT#706;
+        //         RETURN;
+        //     END_IF;
     
-            _AxisRefExt.Data.hwID                := hwID;
-            _AxisRefExt.Data.hwIdParamCh_IDN     := hwIdParamCh_IDN;
-            _AxisRefExt.Data.hwIdInput_9_Words   := hwIdInput_9_Words;
-            _AxisRefExt.Data.hwIdOutput_13_Words := hwIdOutput_13_Words;
+        //     _AxisRefExt.Data.hwID                := hwID;
+        //     _AxisRefExt.Data.hwIdParamCh_IDN     := hwIdParamCh_IDN;
+        //     _AxisRefExt.Data.hwIdInput_9_Words   := hwIdInput_9_Words;
+        //     _AxisRefExt.Data.hwIdOutput_13_Words := hwIdOutput_13_Words;
 
-            Messenger.ActivateOnCondition(ULINT#300, Enable AND NOT EnablePositive, eAxoMessageCategory#Warning);
-            Messenger.ActivateOnCondition(ULINT#301, Enable AND NOT EnableNegative, eAxoMessageCategory#Warning);
+        //     Messenger.ActivateOnCondition(ULINT#300, Enable AND NOT EnablePositive, eAxoMessageCategory#Warning);
+        //     Messenger.ActivateOnCondition(ULINT#301, Enable AND NOT EnableNegative, eAxoMessageCategory#Warning);
 
-            THIS.Open();
-            THIS.PreExecute(_AxisRefExt);
-            SUPER.Execute(_AxisRefExt,Enable,EnablePositive,EnableNegative);
-            THIS.PostExecute(_AxisRefExt);
-            THIS.Close(); 
-        END_METHOD
+        //     THIS.Open();
+        //     THIS.PreExecute(_AxisRefExt);
+        //     SUPER.Execute(_AxisRefExt,Enable,EnablePositive,EnableNegative);
+        //     THIS.PostExecute(_AxisRefExt);
+        //     THIS.Close(); 
+        // END_METHOD
 
         ///<summary>
         /// Ensures swapping the hardware input data structure into the AxisRef data structure  

--- a/src/components.rexroth.press/ctrl/src/AxoSmartFunctionKit_v_4_x_x.st
+++ b/src/components.rexroth.press/ctrl/src/AxoSmartFunctionKit_v_4_x_x.st
@@ -148,53 +148,53 @@ NAMESPACE AXOpen.Components.Rexroth.Press
             THIS.Execute();
         END_METHOD   
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run
-            VAR_INPUT
-                parent              :   IAxoContext; 
-                hwID                :   WORD;
-                hwIdParamCh_IDN     :   WORD;
-                hwIdInput_24_Words  :   WORD;
-                hwIdOutput_21_Words :   WORD;
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method or one of its overloads must be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run
+        //     VAR_INPUT
+        //         parent              :   IAxoContext; 
+        //         hwID                :   WORD;
+        //         hwIdParamCh_IDN     :   WORD;
+        //         hwIdInput_24_Words  :   WORD;
+        //         hwIdOutput_21_Words :   WORD;
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,hwIdParamCh_IDN = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,hwIdInput_24_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,hwIdOutput_21_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,hwIdParamCh_IDN = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,hwIdInput_24_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,hwIdOutput_21_Words = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                ComponentStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwID = WORD#0 THEN
-                ComponentStatus.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdParamCh_IDN = WORD#0 THEN
-                ComponentStatus.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwIdInput_24_Words = WORD#0 THEN
-                ComponentStatus.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwIdInput_24_Words = WORD#0 THEN
-                ComponentStatus.Error.Id := UINT#704;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         ComponentStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwID = WORD#0 THEN
+        //         ComponentStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdParamCh_IDN = WORD#0 THEN
+        //         ComponentStatus.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwIdInput_24_Words = WORD#0 THEN
+        //         ComponentStatus.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwIdInput_24_Words = WORD#0 THEN
+        //         ComponentStatus.Error.Id := UINT#704;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID                       := hwID;
-            _hwIdParamCh_IDN            := hwIdParamCh_IDN;     
-            _hwIdInput_24_Words         := hwIdInput_24_Words;  
-            _hwIdOutput_21_Words        := hwIdOutput_21_Words;             
+        //     _hwID                       := hwID;
+        //     _hwIdParamCh_IDN            := hwIdParamCh_IDN;     
+        //     _hwIdInput_24_Words         := hwIdInput_24_Words;  
+        //     _hwIdOutput_21_Words        := hwIdOutput_21_Words;             
     
-            THIS.Execute();
-        END_METHOD 
+        //     THIS.Execute();
+        // END_METHOD 
         
         METHOD PRIVATE Execute
             VAR 

--- a/src/components.siem.identification/ctrl/src/IOLink/AxoIOLink_RF200Device.st
+++ b/src/components.siem.identification/ctrl/src/IOLink/AxoIOLink_RF200Device.st
@@ -171,39 +171,39 @@ NAMESPACE AXOpen.Components.Siem.Identification
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent      :   IAxoContext;
-                HW_ID       :	WORD    :=  WORD#16#0;      //	Logic IO address of the IO-Link Master
-                portAddr    :	INT     :=  INT#0;          //  Start address of port
-                version     :	USINT   :=  USINT#11;       //	IO-Link version of the reader; 11: IO-Link V1.1, 10: IO-Link V1.0
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent      :   IAxoContext;
+        //         HW_ID       :	WORD    :=  WORD#16#0;      //	Logic IO address of the IO-Link Master
+        //         portAddr    :	INT     :=  INT#0;          //  Start address of port
+        //         version     :	USINT   :=  USINT#11;       //	IO-Link version of the reader; 11: IO-Link V1.1, 10: IO-Link V1.0
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                ReaderStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF HW_ID = WORD#0 THEN
-                ReaderStatus.Error.Id := UINT#701;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         ReaderStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF HW_ID = WORD#0 THEN
+        //         ReaderStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     END_IF;
 
-            _HW_ID      :=  HW_ID;
-            _portAddr   :=  portAddr;
-            _version    :=  version;
+        //     _HW_ID      :=  HW_ID;
+        //     _portAddr   :=  portAddr;
+        //     _version    :=  version;
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.siem.identification/ctrl/src/IdentProfile/Axo_IdentDevice.st
+++ b/src/components.siem.identification/ctrl/src/IdentProfile/Axo_IdentDevice.st
@@ -177,45 +177,45 @@ NAMESPACE AXOpen.Components.Siem.Identification
             THIS.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent          :   IAxoContext;
-                HW_ID               :   WORD    :=  WORD#16#0; 			//Hardware identifier
-                API 				:   DWORD   :=  DWORD#16#0000_5B00; //API number 
-                SLOT 				:   WORD    :=  WORD#16#02;  		//Slot number  
-                SUB_SLOT 			:   WORD    :=  WORD#16#01; 		//Subslot number 
-                CM_CHANNEL 			:   UINT    :=  UINT#1; 		    //channel of communication module	
-            END_VAR
-            THIS.Initialize(parent);
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent          :   IAxoContext;
+        //         HW_ID               :   WORD    :=  WORD#16#0; 			//Hardware identifier
+        //         API 				:   DWORD   :=  DWORD#16#0000_5B00; //API number 
+        //         SLOT 				:   WORD    :=  WORD#16#02;  		//Slot number  
+        //         SUB_SLOT 			:   WORD    :=  WORD#16#01; 		//Subslot number 
+        //         CM_CHANNEL 			:   UINT    :=  UINT#1; 		    //channel of communication module	
+        //     END_VAR
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
-            TaskMessenger.Serve(THIS);
-            IdentProfileMessenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
+        //     TaskMessenger.Serve(THIS);
+        //     IdentProfileMessenger.Serve(THIS);
 
 
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,HW_ID = WORD#0, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                ReaderStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF HW_ID = WORD#0 THEN
-                ReaderStatus.Error.Id := UINT#701;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         ReaderStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF HW_ID = WORD#0 THEN
+        //         ReaderStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     END_IF;
 
-            _identProfile_HwConnect.HW_ID       :=  HW_ID;
-            _identProfile_HwConnect.API         :=  API;
-            _identProfile_HwConnect.SLOT 	    :=  SLOT;
-            _identProfile_HwConnect.SUB_SLOT    :=  SUB_SLOT;
-            _identProfile_HwConnect.CM_CHANNEL  :=  CM_CHANNEL;
+        //     _identProfile_HwConnect.HW_ID       :=  HW_ID;
+        //     _identProfile_HwConnect.API         :=  API;
+        //     _identProfile_HwConnect.SLOT 	    :=  SLOT;
+        //     _identProfile_HwConnect.SUB_SLOT    :=  SUB_SLOT;
+        //     _identProfile_HwConnect.CM_CHANNEL  :=  CM_CHANNEL;
 
-            THIS.Execute();
-        END_METHOD
+        //     THIS.Execute();
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR 

--- a/src/components.ur.robotics/ctrl/src/AxoUrCb3/AxoUrCb3_v_3_x_x.st
+++ b/src/components.ur.robotics/ctrl/src/AxoUrCb3/AxoUrCb3_v_3_x_x.st
@@ -210,95 +210,95 @@ NAMESPACE AXOpen.Components.Ur.Robotics
             THIS.Execute(refPowerOnPulse);
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent                                                  : IAxoContext;
-                hwID                                                    : WORD;
-                hwIdAxoUrRobotics_T2O_State                             : WORD;
-                hwIdAxoUrRobotics_T2O_IO                                : WORD;
-                hwIdAxoUrRobotics_T2O_Joints                            : WORD;
-                hwIdAxoUrRobotics_T2O_TCP                               : WORD;
-                hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers     : WORD;
-                hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers     : WORD;
-                hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers   : WORD;
-                hwIdAxoUrRobotics_O2T_Robot_IO                          : WORD;
-                hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1       : WORD;
-                hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2       : WORD;
-                refPowerOnPulse                                         : REF_TO BOOL;
-            END_VAR
-            THIS.Initialize(parent);
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent                                                  : IAxoContext;
+        //         hwID                                                    : WORD;
+        //         hwIdAxoUrRobotics_T2O_State                             : WORD;
+        //         hwIdAxoUrRobotics_T2O_IO                                : WORD;
+        //         hwIdAxoUrRobotics_T2O_Joints                            : WORD;
+        //         hwIdAxoUrRobotics_T2O_TCP                               : WORD;
+        //         hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers     : WORD;
+        //         hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers     : WORD;
+        //         hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers   : WORD;
+        //         hwIdAxoUrRobotics_O2T_Robot_IO                          : WORD;
+        //         hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1       : WORD;
+        //         hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2       : WORD;
+        //         refPowerOnPulse                                         : REF_TO BOOL;
+        //     END_VAR
+        //     THIS.Initialize(parent);
 
-            Messenger.Serve(THIS);
+        //     Messenger.Serve(THIS);
 
-            Messenger.ActivateOnCondition(ULINT#700, parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701, hwIdAxoUrRobotics_T2O_State = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702, hwIdAxoUrRobotics_T2O_IO = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703, hwIdAxoUrRobotics_T2O_Joints = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704, hwIdAxoUrRobotics_T2O_TCP = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705, hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#706, hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#707, hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#708, hwIdAxoUrRobotics_O2T_Robot_IO = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#709, hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#710, hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#711, refPowerOnPulse = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#700, parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701, hwIdAxoUrRobotics_T2O_State = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702, hwIdAxoUrRobotics_T2O_IO = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703, hwIdAxoUrRobotics_T2O_Joints = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704, hwIdAxoUrRobotics_T2O_TCP = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705, hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#706, hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#707, hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#708, hwIdAxoUrRobotics_O2T_Robot_IO = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#709, hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#710, hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#711, refPowerOnPulse = NULL, eAxoMessageCategory#ProgrammingError);
 
-            IF parent = NULL THEN
-                RobotStatus.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_State = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#701;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_IO = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#702;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_Joints = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#703;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_TCP = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#704;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#705;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#706;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#707;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_O2T_Robot_IO = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#708;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#709;
-                RETURN;
-            ELSIF hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 = WORD#0 THEN
-                RobotStatus.Error.Id := UINT#710;
-                RETURN;
-            ELSIF refPowerOnPulse =  NULL THEN
-                RobotStatus.Error.Id := UINT#711;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         RobotStatus.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_State = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#701;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_IO = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_Joints = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_TCP = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#705;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#706;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#707;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_O2T_Robot_IO = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#708;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#709;
+        //         RETURN;
+        //     ELSIF hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 = WORD#0 THEN
+        //         RobotStatus.Error.Id := UINT#710;
+        //         RETURN;
+        //     ELSIF refPowerOnPulse =  NULL THEN
+        //         RobotStatus.Error.Id := UINT#711;
+        //         RETURN;
+        //     END_IF;
 
-            _hwID := hwID;
-            _hwIdAxoUrRobotics_T2O_State := hwIdAxoUrRobotics_T2O_State;
-            _hwIdAxoUrRobotics_T2O_IO := hwIdAxoUrRobotics_T2O_IO;
-            _hwIdAxoUrRobotics_T2O_Joints := hwIdAxoUrRobotics_T2O_Joints;
-            _hwIdAxoUrRobotics_T2O_TCP := hwIdAxoUrRobotics_T2O_TCP;
-            _hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers;
-            _hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers;
-            _hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers;
-            _hwIdAxoUrRobotics_O2T_Robot_IO := hwIdAxoUrRobotics_O2T_Robot_IO;
-            _hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 := hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1;
-            _hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 := hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2;
+        //     _hwID := hwID;
+        //     _hwIdAxoUrRobotics_T2O_State := hwIdAxoUrRobotics_T2O_State;
+        //     _hwIdAxoUrRobotics_T2O_IO := hwIdAxoUrRobotics_T2O_IO;
+        //     _hwIdAxoUrRobotics_T2O_Joints := hwIdAxoUrRobotics_T2O_Joints;
+        //     _hwIdAxoUrRobotics_T2O_TCP := hwIdAxoUrRobotics_T2O_TCP;
+        //     _hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Bit_Registers;
+        //     _hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Int_Registers;
+        //     _hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers := hwIdAxoUrRobotics_T2O_General_Purpose_Float_Registers;
+        //     _hwIdAxoUrRobotics_O2T_Robot_IO := hwIdAxoUrRobotics_O2T_Robot_IO;
+        //     _hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1 := hwIdAxoUrRobotics_O2T_General_Purpose_Registers_1;
+        //     _hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2 := hwIdAxoUrRobotics_O2T_General_Purpose_Registers_2;
 
-            THIS.Execute(refPowerOnPulse);
-        END_METHOD
+        //     THIS.Execute(refPowerOnPulse);
+        // END_METHOD
 
         METHOD PRIVATE Execute 
             VAR_INPUT

--- a/src/core/ctrl/src/AxoAlert/AxoAlert.st
+++ b/src/core/ctrl/src/AxoAlert/AxoAlert.st
@@ -15,6 +15,7 @@ NAMESPACE AXOpen.Core
             _createPlcCycleSpace :  BOOL;
             _PlcCycleSpaceCounter : UINT;
             _wasShow : BOOL;
+            _context    : IAxoContext;
         END_VAR    
 
         METHOD PUBLIC Show : IAxoAlertFormat
@@ -80,6 +81,10 @@ NAMESPACE AXOpen.Core
         /// Restore AlertDialog. In special case context can be null.
         ///</summary>
         METHOD PUBLIC OVERRIDE Restore : IAxoTaskState
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+                        
             Restore := THIS;
 
             _alertType := eDialogType#Undefined;
@@ -88,7 +93,7 @@ NAMESPACE AXOpen.Core
             _timeToBurn := UINT#5;
             _PlcCycleSpaceCounter:=  UINT#0;
 
-            IF _context_ = NULL THEN
+            IF _context = NULL THEN
                 Status := eAxoTaskState#Ready;  //needed in case when dialog observation was interrupt
                 ErrorDetails := '';
             ELSE

--- a/src/core/ctrl/src/AxoComponent/AxoComponent.st
+++ b/src/core/ctrl/src/AxoComponent/AxoComponent.st
@@ -2,14 +2,18 @@ NAMESPACE AXOpen.Core
 
     {S7.extern=ReadWrite}
     CLASS PUBLIC ABSTRACT AxoComponent EXTENDS AxoObject IMPLEMENTS IAxoComponent     
+        VAR
+            _context    :   IAxoContext;
+        END_VAR
         ///<summary>
 		/// Executes the logic for manual-maintenance control.   
         ///</summary>   
         METHOD PUBLIC FINAL ActivateManualControl 
-            IF THIS._context_ <> NULL THEN
-                 _manualControlContextCycle := _context_.OpenCycleCount();
+            IF THIS._context <> NULL THEN
+                 _manualControlContextCycle := _context.OpenCycleCount();
                 THIS.ManualControl();
             ELSE
+                _context := THIS.GetContext();
                 _manualControlContextCycle := ULINT#0;        // TODO: some message should inform about this issue
             END_IF;  
         END_METHOD
@@ -23,13 +27,14 @@ NAMESPACE AXOpen.Core
             VAR
                 _myContextCycleCount : ULINT;
             END_VAR
-            IF THIS._context_ <> NULL THEN
-                _myContextCycleCount := _context_.OpenCycleCount();
+            IF THIS._context <> NULL THEN
+                _myContextCycleCount := _context.OpenCycleCount();
                 //When component.Service() is called "before" invoking its task _serviceContextCycle is equal to GetContext().OpenCycleCount()
                 _isManuallyControllable := _manualControlContextCycle = _myContextCycleCount OR 
                 //When component.Service() is called "after" invoking its task (_serviceContextCycle + 1) is equal to GetContext().OpenCycleCount()
                                 (_manualControlContextCycle + ULINT#1) = _myContextCycleCount;        
             ELSE
+                _context := THIS.GetContext();
                 _isManuallyControllable := FALSE;              // TODO: some message should inform about this issue
                 _myContextCycleCount := ULINT#0;
             END_IF;  
@@ -63,13 +68,14 @@ NAMESPACE AXOpen.Core
             VAR
                 _myContextCycleCount : ULINT;
             END_VAR
-            IF THIS._context_ <> NULL THEN
-                _myContextCycleCount := _context_.OpenCycleCount();
+            IF THIS._context <> NULL THEN
+                _myContextCycleCount := _context.OpenCycleCount();
                 //When component.Service() is called "before" invoking its task _serviceContextCycle is equal to GetContext().OpenCycleCount()
                 _isManuallyControllable := _manualControlContextCycle = _myContextCycleCount OR 
                 //When component.Service() is called "after" invoking its task (_serviceContextCycle + 1) is equal to GetContext().OpenCycleCount()
                                 (_manualControlContextCycle + ULINT#1) = _myContextCycleCount;        
             ELSE
+                _context := THIS.GetContext();
                 _isManuallyControllable := FALSE;              // TODO: some message should inform about this issue
                 _myContextCycleCount := ULINT#0;
             END_IF;  
@@ -80,13 +86,14 @@ NAMESPACE AXOpen.Core
             VAR
                 _myContextCycleCount : ULINT;
             END_VAR
-            IF THIS._context_ <> NULL THEN
-                _myContextCycleCount := _context_.OpenCycleCount();
+            IF THIS._context <> NULL THEN
+                _myContextCycleCount := _context.OpenCycleCount();
                 //When component.Service() is called "before" invoking its task _serviceContextCycle is equal to GetContext().OpenCycleCount()
                 _isManuallyControllable := _manualControlContextCycle = _myContextCycleCount OR 
                 //When component.Service() is called "after" invoking its task (_serviceContextCycle + 1) is equal to GetContext().OpenCycleCount()
                                 (_manualControlContextCycle + ULINT#1) = _myContextCycleCount;        
             ELSE
+                _context := THIS.GetContext();
                 _isManuallyControllable := FALSE;              // TODO: some message should inform about this issue
                 _myContextCycleCount := ULINT#0;
             END_IF;  

--- a/src/core/ctrl/src/AxoComponent/AxoComponent.st
+++ b/src/core/ctrl/src/AxoComponent/AxoComponent.st
@@ -2,7 +2,7 @@ NAMESPACE AXOpen.Core
 
     {S7.extern=ReadWrite}
     CLASS PUBLIC ABSTRACT AxoComponent EXTENDS AxoObject IMPLEMENTS IAxoComponent     
-        VAR
+        VAR PRIVATE
             _context    :   IAxoContext;
         END_VAR
         ///<summary>

--- a/src/core/ctrl/src/AxoContext/AxoContext.st
+++ b/src/core/ctrl/src/AxoContext/AxoContext.st
@@ -70,6 +70,7 @@ NAMESPACE AXOpen.Core
             IF(_rtc <> NULL) THEN
                 GetRtc := _rtc;
             ELSE
+                // TODO provide some message 
                 GetRtc := NULL_RTC;    
             END_IF;    
         END_METHOD
@@ -98,6 +99,7 @@ NAMESPACE AXOpen.Core
             IF(_rtc <> NULL) THEN
                 GetRtm := _rtm;
             ELSE
+                // TODO provide some message 
                 GetRtm := NULL_RTM;    
             END_IF;    
         END_METHOD
@@ -111,6 +113,7 @@ NAMESPACE AXOpen.Core
             IF(_contextLogger <> NULL) THEN
                 GetLogger := _contextLogger;
             ELSE
+                // TODO provide some message 
                 GetLogger := NULL_LOGGER;    
             END_IF;    
         END_METHOD

--- a/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
@@ -27,6 +27,8 @@ NAMESPACE AXOpen.Core
             _closeCycleCounter : ULINT;  
             _refStep :  REF_TO AxoStep;       
             _microStep : UINT;   
+            _context        :   IAxoContext;
+
         END_VAR     
 
         ///<summary>
@@ -35,9 +37,13 @@ NAMESPACE AXOpen.Core
         /// sequencer.
         ///</summary>
         METHOD PUBLIC Open : BOOL
-            VAR
-                tContext : IAxoContext;
-            END_VAR
+            // VAR
+            //     tContext : IAxoContext;
+            // END_VAR
+            IF _context = NULL THEN 
+                _context := THIS.GetContext(); 
+            END_IF;
+
             Open := FALSE;
             
             CollectDataTask.Initialize(THIS);
@@ -50,33 +56,38 @@ NAMESPACE AXOpen.Core
             StepBackwardCommand.SetSuspendMultipleExecuteCallCheck(TRUE);
 
             IF SUPER.Execute() THEN
-                IF _context_ = NULL THEN RETURN; END_IF;         
-                _openCycleCounter := _context_.OpenCycleCount();
+                IF _context = NULL THEN 
+                    RETURN; 
+                END_IF;         
+                _openCycleCounter := _context.OpenCycleCount();
                 CASE _coordinatorState OF
                     AxoCoordinatorStates#Idle :
                         _configurationFlowOrder := ULINT#0;
                         _numberOfConfiguredSteps := ULINT#0;
                         _coordinatorState := AxoCoordinatorStates#Configuring;
 
-                        tContext := StepForwardCommand.GetContextUnsafe();
+                        // tContext := StepForwardCommand.GetContextUnsafe();
                         
-                        IF  tContext = NULL THEN
-                            StepForwardCommand.Initialize(_context_);
-                            StepIn.Initialize(_context_);
-                            StepBackwardCommand.Initialize(_context_);
-                        END_IF;
+                        // IF  tContext = NULL THEN
+                            // StepForwardCommand.Initialize(_context);
+                            // StepIn.Initialize(_context);
+                            // StepBackwardCommand.Initialize(_context);
+                        // END_IF;
 
                         // IF(StepForwardCommand.GetContext() = NULL) THEN // asi to robi problem
                         //     StepForwardCommand.Initialize(_context_);
                         //     StepIn.Initialize(_context_);
                         //     StepBackwardCommand.Initialize(_context_);
                         // END_IF;    
+                            StepForwardCommand.Initialize(THIS);
+                            StepIn.Initialize(THIS);
+                            StepBackwardCommand.Initialize(THIS);
 
                     AxoCoordinatorStates#Configuring :
                         THIS.OnBeforeSequenceStart();
                         CurrentOrder := ULINT#1;
                         _coordinatorState := AxoCoordinatorStates#Running;
-                        _context_.GetLogger().Log('Sequence in config state :', AXOpen.Logging.eLogLevel#Verbose, THIS);
+                        _context.GetLogger().Log('Sequence in config state :', AXOpen.Logging.eLogLevel#Verbose, THIS);
                 END_CASE;    
                 Open := TRUE;
             END_IF;            
@@ -87,9 +98,14 @@ NAMESPACE AXOpen.Core
                 step : IAxoStep;                
                 Enable : BOOL;
             END_VAR
-
+            IF _context = NULL THEN 
+                _context := THIS.GetContext(); 
+            END_IF;
             IF SUPER.Execute() THEN               
-                IF step.GetContext() = NULL THEN Execute := FALSE; RETURN; END_IF;     
+                IF step.GetContext() = NULL THEN // TODO - solve uninitialized step (as GetContext never returns NULL, this condition will not be TRUE never-ever)
+                    Execute := FALSE; 
+                    RETURN; 
+                END_IF;     
                 
                 _step := step;
                             
@@ -153,7 +169,7 @@ NAMESPACE AXOpen.Core
                 IF step.GetIsActive() AND (step.IsReady() OR step.IsDone() OR SteppingMode = eAxoSteppingMode#StepByStep) THEN
                     IF (SteppingMode = eAxoSteppingMode#Continous) THEN
                         step.Invoke();
-                        _context_.GetLogger().Log('Starts step :', AXOpen.Logging.eLogLevel#Verbose, step);
+                        _context.GetLogger().Log('Starts step :', AXOpen.Logging.eLogLevel#Verbose, step);
                     // Invoke the step in a case of step mode when StepIn Command is invoked
                     ELSIF (SteppingMode = eAxoSteppingMode#StepByStep) THEN
                         IF StepIn.Execute() THEN
@@ -196,10 +212,15 @@ NAMESPACE AXOpen.Core
         /// Moves the execution to the next step.                        
         ///</summary>
         METHOD PUBLIC MoveNext 
+            IF _context = NULL THEN 
+                _context := THIS.GetContext(); 
+            END_IF;
             IF SUPER.Execute() THEN
-                IF _step.GetContext() = NULL THEN RETURN; END_IF;       
+                IF _step.GetContext() = NULL THEN // TODO - solve uninitialized _step (as GetContext never returns NULL, this condition will not be TRUE never-ever)
+                    RETURN; 
+                END_IF;       
                 IF _coordinatorState = AxoCoordinatorStates#Running THEN
-                    _context_.GetLogger().Log('Step done :', AXOpen.Logging.eLogLevel#Verbose, _step);
+                    _context.GetLogger().Log('Step done :', AXOpen.Logging.eLogLevel#Verbose, _step);
                     _step.DoneWhen(_step.IsBusy());
                     _step.SetIsActive(FALSE);
                     CurrentOrder := CurrentOrder + ULINT#1;                                      
@@ -216,11 +237,16 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 RequestedStep : IAxoStep;
             END_VAR
+            IF _context = NULL THEN 
+                _context := THIS.GetContext(); 
+            END_IF;
             IF SUPER.Execute() THEN
-                IF RequestedStep.GetContext() = NULL THEN RETURN; END_IF;               
+                IF RequestedStep.GetContext() = NULL THEN // TODO - solve uninitialized RequestedStep (as GetContext never returns NULL, this condition will not be TRUE never-ever)
+                    RETURN; 
+                END_IF;               
                 IF RequestedStep.GetStepOrder() <> ULINT#0 AND                    
                     _coordinatorState = AxoCoordinatorStates#Running THEN
-                    _context_.GetLogger().Log('Step request to step :', AXOpen.Logging.eLogLevel#Verbose, RequestedStep);
+                    _context.GetLogger().Log('Step request to step :', AXOpen.Logging.eLogLevel#Verbose, RequestedStep);
                     _step.DoneWhen(_step.IsBusy());
                     _step.SetIsActive(FALSE);
                     CurrentOrder := RequestedStep.GetStepOrder();
@@ -236,7 +262,12 @@ NAMESPACE AXOpen.Core
         ///</summary>
         METHOD PUBLIC CompleteSequence   
             IF SUPER.Execute() THEN
-                IF _step.GetContext() = NULL THEN RETURN; END_IF;         
+                IF _context = NULL THEN 
+                    _context := THIS.GetContext(); 
+                END_IF;
+                IF _step.GetContext() = NULL THEN 
+                    RETURN; 
+                END_IF;         
                 IF _coordinatorState = AxoCoordinatorStates#Running THEN
                     _step.DoneWhen(TRUE);
                     _step.SetIsActive(FALSE);
@@ -246,7 +277,7 @@ NAMESPACE AXOpen.Core
                     // Finalize the StepIn Command in a case of step mode
                     StepIn.DoneWhen(SteppingMode = eAxoSteppingMode#StepByStep);
                     THIS.OnCompleteSequence();
-                    _context_.GetLogger().Log('Sequence completed :', AXOpen.Logging.eLogLevel#Verbose, THIS);
+                    _context.GetLogger().Log('Sequence completed :', AXOpen.Logging.eLogLevel#Verbose, THIS);
                 END_IF;
             END_IF;
         END_METHOD    
@@ -304,26 +335,6 @@ NAMESPACE AXOpen.Core
             END_IF;
         END_METHOD  
         
-        // METHOD PROTECTED InvalidContext1 : BOOL
-        //     IF _context_ = NULL THEN 
-        //         InvalidContext := TRUE;  // TODO: We will need to message this, when messaging ready.            
-        //     ELSE
-        //         InvalidContext := FALSE;
-        //     END_IF;
-        // END_METHOD
-        
-        // METHOD PROTECTED InvalidContext1 : BOOL
-        //     VAR_INPUT
-        //         step : IAxoStep;                
-        //     END_VAR
-        //     IF _context_ = NULL THEN 
-        //         InvalidContext := TRUE;  // TODO: We will need to message this, when messaging ready.            
-        //     ELSIF step.GetContext() = NULL THEN
-        //         InvalidContext := TRUE;  // TODO: We will need to message this, when messaging ready.            
-        //     ELSE
-        //         InvalidContext := FALSE;
-        //     END_IF;
-        // END_METHOD
        
         METHOD PROTECTED DisableAllSteppingComands 
             StepForwardCommand.IsDisabled := TRUE;

--- a/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencerContainer.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencerContainer.st
@@ -5,7 +5,7 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 context : IAxoContext;
             END_VAR
-            THIS.Initialize(context);
+            THIS.InitializeWithContext(context);
             IF THIS.Open() THEN
                 THIS.Main();
             END_IF;

--- a/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
@@ -18,6 +18,10 @@ NAMESPACE AXOpen.Core
             _noStepCallInPreviousPlcCycle : BOOL;
         END_VAR 
        
+        VAR PRIVATE
+            _context    :   IAxoContext;
+        END_VAR
+
         ///<summary>
         /// Gets duration of the current iteration of the step.
         ///</summary>
@@ -113,9 +117,12 @@ NAMESPACE AXOpen.Core
                 _currentlyOpenCycleCount : ULINT;
                 // Selector : REF_TO Selector;
             END_VAR    
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;
 
-            IF _context_ <> NULL THEN 
-                _currentlyOpenCycleCount := _context_.OpenCycleCount();
+            IF _context <> NULL THEN 
+                _currentlyOpenCycleCount := _context.OpenCycleCount();
                 _isCalledJustOnceInThisPlcCycle:= _openCycleCount = _currentlyOpenCycleCount - ULINT#1;
                 _multipleStepCallInThisPlcCycle := _openCycleCount >= _currentlyOpenCycleCount; // TODO: We will need to message this, when messaging ready.            
                 _noStepCallInPreviousPlcCycle := _openCycleCount < _currentlyOpenCycleCount - ULINT#1; // TODO: We will need to message this, when messaging ready.            
@@ -124,7 +131,7 @@ NAMESPACE AXOpen.Core
                 coordAsAxoObject ?= coord;
                IF(coordAsAxoObject <> NULL) THEN
                     THIS.Initialize(coordAsAxoObject); 
-                    _currentlyOpenCycleCount := _context_.OpenCycleCount();
+                    _currentlyOpenCycleCount := _context.OpenCycleCount();
                     _isCalledJustOnceInThisPlcCycle:= _openCycleCount = _currentlyOpenCycleCount - ULINT#1;
                     _multipleStepCallInThisPlcCycle := _openCycleCount >= _currentlyOpenCycleCount; // TODO: We will need to message this, when messaging ready.            
                     _noStepCallInPreviousPlcCycle := _openCycleCount < _currentlyOpenCycleCount - ULINT#1; // TODO: We will need to message this, when messaging ready.            
@@ -151,7 +158,12 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 Active : BOOL;
             END_VAR
-            IF(NOT THIS.IsActive AND Active) THEN _context_.GetLogger().Log('At step:', AXOpen.Logging.eLogLevel#Verbose, THIS); END_IF;
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;
+            IF(NOT THIS.IsActive AND Active) THEN 
+                _context.GetLogger().Log('At step:', AXOpen.Logging.eLogLevel#Verbose, THIS); 
+            END_IF;
             IsActive := Active;
         END_METHOD
 

--- a/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
@@ -117,6 +117,7 @@ NAMESPACE AXOpen.Core
                 _currentlyOpenCycleCount : ULINT;
                 // Selector : REF_TO Selector;
             END_VAR    
+            THIS.Initialize(coord);
             IF _context = NULL THEN
                 _context := THIS.GetContext();
             END_IF;

--- a/src/core/ctrl/src/AxoDialog/AxoDialogBase.st
+++ b/src/core/ctrl/src/AxoDialog/AxoDialogBase.st
@@ -4,14 +4,22 @@ NAMESPACE AXOpen.Core
         VAR PUBLIC
             _closeSignal : BOOL;
         END_VAR
+
+        VAR PRIVATE
+            _context    : IAxoContext;
+        END_VAR
        
         ///<summary>
         /// Restore dialog. In special case context can be null.
         ///</summary>
         METHOD PUBLIC OVERRIDE Restore : IAxoTaskState
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+            
             Restore := THIS;
 
-            IF _context_ = NULL THEN
+            IF _context = NULL THEN
                 Status := eAxoTaskState#Ready;  //needed in case when dialog observation was interrupt
                 ErrorDetails := '';
                 THIS.OnRestore();

--- a/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
+++ b/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
@@ -41,7 +41,7 @@ NAMESPACE AXOpen.Messaging.Static
 
         VAR PRIVATE
             ActiveContextCount : ULINT;
-            Context : IAxoContext;         
+            _context : IAxoContext;         
         END_VAR
        
         ///<summary>
@@ -52,13 +52,13 @@ NAMESPACE AXOpen.Messaging.Static
                 inContext : IAxoContext;
             END_VAR     
 
-            IF  _context_ = NULL THEN  
+            IF  _context = NULL THEN  
                 IF inContext = NULL THEN
                     RETURN;
                 END_IF;
 
-                THIS.Initialize(inContext);
-                Context := inContext; // Duplicity!!!
+                THIS.InitializeWithContext(inContext);
+                _context := inContext; 
             END_IF;
 
             IF THIS.IsActive AND NOT THIS.AcknowledgedBeforeFallen THEN
@@ -71,7 +71,7 @@ NAMESPACE AXOpen.Messaging.Static
 
             IF MessageCode = ULINT#0 THEN
                 IF IsActive THEN
-                    IF Context.OpenCycleCount() - ActiveContextCount > UINT#1 THEN
+                    IF _context.OpenCycleCount() - ActiveContextCount > UINT#1 THEN
                         THIS.Deactivate();
                     END_IF;
                 ELSIF AcknowledgedBeforeFallen THEN
@@ -107,14 +107,14 @@ NAMESPACE AXOpen.Messaging.Static
                 inObject : IAxoObject;
             END_VAR  
 
-            IF  _context_ = NULL THEN  
+            IF  _context = NULL THEN  
                 IF inObject.GetContext() = NULL THEN
                     RETURN;
                 END_IF;
 
                 THIS.Initialize(inObject);
-                THIS.Initialize(inObject.GetContext());                
-                Context := inObject.GetContext(); // Duplicity!!!
+                THIS.InitializeWithContext(inObject.GetContext());                
+                _context := inObject.GetContext(); 
             END_IF;
 
             IF THIS.IsActive AND NOT THIS.AcknowledgedBeforeFallen THEN
@@ -127,7 +127,7 @@ NAMESPACE AXOpen.Messaging.Static
 
             IF MessageCode = ULINT#0 THEN
                 IF IsActive THEN
-                    IF Context.OpenCycleCount() - ActiveContextCount > UINT#1 THEN
+                    IF _context.OpenCycleCount() - ActiveContextCount > UINT#1 THEN
                         THIS.Deactivate();
                     END_IF;
                 ELSIF AcknowledgedBeforeFallen THEN
@@ -162,20 +162,20 @@ NAMESPACE AXOpen.Messaging.Static
 
             Activate := THIS;
             
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
             
             IF MessageCode = ULINT#0 THEN
                 IF ActiveContextCount = ULINT#0 THEN                
-                    Risen := Context.GetRtc().NowUTC();
+                    Risen := _context.GetRtc().NowUTC();
                     Fallen := LDATE_AND_TIME#1970-01-01-00:00:00.000;
                     Acknowledged := LDATE_AND_TIME#1970-01-01-00:00:00.000;
                     WaitingForAcknowledge := FALSE;
-                    Context.GetLogger().Log('Risen', THIS.ToLogLevel(_category), THIS);
+                    _context.GetLogger().Log('Risen', THIS.ToLogLevel(_category), THIS);
                 END_IF;
 
-                ActiveContextCount := Context.OpenCycleCount();
+                ActiveContextCount := _context.OpenCycleCount();
 
                 Category := _category;
 
@@ -195,21 +195,21 @@ NAMESPACE AXOpen.Messaging.Static
 
             Activate := THIS;
             
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
             
             IF NOT IsActive AND NOT WaitingForAcknowledge AND MessageCode = ULINT#0 AND ActiveContextCount = ULINT#0 THEN                
-                Risen := Context.GetRtc().NowUTC();
+                Risen := _context.GetRtc().NowUTC();
                 Fallen := LDATE_AND_TIME#1970-01-01-00:00:00.000;
                 Acknowledged := LDATE_AND_TIME#1970-01-01-00:00:00.000;
                 WaitingForAcknowledge := FALSE;
-                Context.GetLogger().Log('Risen', THIS.ToLogLevel(_category), THIS);
+                _context.GetLogger().Log('Risen', THIS.ToLogLevel(_category), THIS);
                 MessageCode := _messageCode;
             END_IF;
 
             IF MessageCode = _messageCode THEN
-                ActiveContextCount := Context.OpenCycleCount();
+                ActiveContextCount := _context.OpenCycleCount();
                 Category := _category;
                 AcknowledgementRequired := Category >= eAxoMessageCategory#Error;
                 IsActive := TRUE;
@@ -269,7 +269,7 @@ NAMESPACE AXOpen.Messaging.Static
                 _messageCode : ULINT;
             END_VAR
 
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 
@@ -277,8 +277,8 @@ NAMESPACE AXOpen.Messaging.Static
                 IF  MessageCode = _messageCode THEN
                     IsActive := FALSE;
                     ActiveContextCount := ULINT#0;
-                    Fallen := Context.GetRtc().NowUTC();                
-                    Context.GetLogger().Log('Fallen', eLogLevel#Information, THIS);
+                    Fallen := _context.GetRtc().NowUTC();                
+                    _context.GetLogger().Log('Fallen', eLogLevel#Information, THIS);
                     IF AcknowledgementRequired AND NOT AcknowledgedBeforeFallen THEN
                         WaitingForAcknowledge := TRUE;
                     ELSE
@@ -290,7 +290,7 @@ NAMESPACE AXOpen.Messaging.Static
         END_METHOD   
 
         METHOD PRIVATE Deactivate
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 
@@ -298,8 +298,8 @@ NAMESPACE AXOpen.Messaging.Static
                 IF MessageCode = ULINT#0 THEN
                     IsActive := FALSE;
                     ActiveContextCount := ULINT#0;
-                    Fallen := Context.GetRtc().NowUTC();                
-                    Context.GetLogger().Log('Fallen', eLogLevel#Information, THIS);
+                    Fallen := _context.GetRtc().NowUTC();                
+                    _context.GetLogger().Log('Fallen', eLogLevel#Information, THIS);
                     IF AcknowledgementRequired AND NOT AcknowledgedBeforeFallen THEN
                         WaitingForAcknowledge := TRUE;
                     ELSE
@@ -313,7 +313,7 @@ NAMESPACE AXOpen.Messaging.Static
             VAR_INPUT
                 _messageCode : ULINT;
             END_VAR
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 
@@ -331,12 +331,12 @@ NAMESPACE AXOpen.Messaging.Static
                     MessageCode := ULINT#0;
                 END_IF;
                 AcknowledgeRequest := FALSE;
-                Acknowledged := Context.GetRtc().NowUTC();
+                Acknowledged := _context.GetRtc().NowUTC();
             END_IF;
         END_METHOD    
 
         METHOD PRIVATE Acknowledge
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 
@@ -353,14 +353,14 @@ NAMESPACE AXOpen.Messaging.Static
                 MessageCode := ULINT#0;
             END_IF;
             AcknowledgeRequest := FALSE;
-            Acknowledged := Context.GetRtc().NowUTC();
+            Acknowledged := _context.GetRtc().NowUTC();
         END_METHOD    
 
         ///<summary>
         /// Restores all members of this instance to their initial states.
         ///</summary>
         METHOD PUBLIC Restore
-            IF Context = NULL THEN
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 

--- a/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
+++ b/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
@@ -159,6 +159,9 @@ NAMESPACE AXOpen.Messaging.Static
             VAR_INPUT
                 _category : eAxoMessageCategory;
             END_VAR
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
 
             Activate := THIS;
             
@@ -192,6 +195,9 @@ NAMESPACE AXOpen.Messaging.Static
                 _messageCode : ULINT;
                 _category : eAxoMessageCategory;
             END_VAR
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
 
             Activate := THIS;
             
@@ -268,6 +274,9 @@ NAMESPACE AXOpen.Messaging.Static
             VAR_INPUT
                 _messageCode : ULINT;
             END_VAR
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
 
             IF _context = NULL THEN
                 RETURN;
@@ -290,6 +299,10 @@ NAMESPACE AXOpen.Messaging.Static
         END_METHOD   
 
         METHOD PRIVATE Deactivate
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context = NULL THEN
                 RETURN;
             END_IF;
@@ -314,6 +327,10 @@ NAMESPACE AXOpen.Messaging.Static
                 _messageCode : ULINT;
             END_VAR
             IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
+            IF _context = NULL THEN
                 RETURN;
             END_IF;
 
@@ -336,6 +353,10 @@ NAMESPACE AXOpen.Messaging.Static
         END_METHOD    
 
         METHOD PRIVATE Acknowledge
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context = NULL THEN
                 RETURN;
             END_IF;
@@ -360,6 +381,10 @@ NAMESPACE AXOpen.Messaging.Static
         /// Restores all members of this instance to their initial states.
         ///</summary>
         METHOD PUBLIC Restore
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context = NULL THEN
                 RETURN;
             END_IF;

--- a/src/core/ctrl/src/AxoMomentaryTask/AxoMomentaryTask.st
+++ b/src/core/ctrl/src/AxoMomentaryTask/AxoMomentaryTask.st
@@ -45,19 +45,25 @@ NAMESPACE AXOpen.Core
         END_METHOD
 
         METHOD PRIVATE IsRunCalledInThisPlcCycle : BOOL
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context <> NULL THEN
                 IsRunCalledInThisPlcCycle := _openCycleCount = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 IsRunCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasRunCalledInPreviousPlcCycle : BOOL
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context <> NULL THEN
                 WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 WasRunCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 

--- a/src/core/ctrl/src/AxoMomentaryTask/AxoMomentaryTask.st
+++ b/src/core/ctrl/src/AxoMomentaryTask/AxoMomentaryTask.st
@@ -33,7 +33,8 @@ NAMESPACE AXOpen.Core
         END_VAR    
         
         VAR PRIVATE
-            _openCycleCount : ULINT;
+            _openCycleCount :   ULINT;
+            _context        :   IAxoContext;
         END_VAR 
         
         ///<summary>
@@ -44,17 +45,19 @@ NAMESPACE AXOpen.Core
         END_METHOD
 
         METHOD PRIVATE IsRunCalledInThisPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                IsRunCalledInThisPlcCycle := _openCycleCount = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                IsRunCalledInThisPlcCycle := _openCycleCount = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 IsRunCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasRunCalledInPreviousPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 WasRunCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
@@ -62,8 +65,12 @@ NAMESPACE AXOpen.Core
         ///<summary>
         ///	This method needs to be called cyclically.
         ///</summary>    
-        METHOD PUBLIC Run : BOOL            
-             _openCycleCount := _context_.OpenCycleCount();
+        METHOD PUBLIC Run : BOOL         
+            IF (_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+
+             _openCycleCount := _context.OpenCycleCount();
 
             IF IsDisabled THEN
                 RemoteSwitchOn := FALSE;

--- a/src/core/ctrl/src/AxoObject/AxoObject.st
+++ b/src/core/ctrl/src/AxoObject/AxoObject.st
@@ -19,9 +19,11 @@ NAMESPACE AXOpen.Core
             MsgCnt   : LINT := LINT#0;    
         END_VAR    
 
-        VAR PROTECTED           
+        VAR PRIVATE           
             _parent         : IAxoObject;
-            _context_       : IAxoContext;
+            _context        : IAxoContext;
+            _isInitialized  : BOOL;
+            _errorState     : UINT;  
         END_VAR  
         
         VAR PRIVATE  
@@ -44,9 +46,10 @@ NAMESPACE AXOpen.Core
         /// Gets context in which this object was initialized.
         ///</summary>
         METHOD PUBLIC GetContext : IAxoContext
-            IF(_context_ <> NULL) THEN
-                GetContext := _context_;
+            IF(_context <> NULL) THEN
+                GetContext := _context;
             ELSE
+                // TODO provide some message 
                 GetContext := NULL_CONTEXT;                    
             END_IF;    
         END_METHOD
@@ -55,16 +58,17 @@ NAMESPACE AXOpen.Core
         /// Gets context in which this object was initialized.
         ///</summary>
         METHOD PUBLIC GetContextUnsafe : IAxoContext
-            GetContextUnsafe := _context_;
+            GetContextUnsafe := _context;
         END_METHOD
 
         ///<summary>
         /// Gets parent in which this object was initialized.
         ///</summary>
         METHOD PUBLIC GetParent : IAxoObject
-            IF(_context_ <> NULL) THEN
+            IF(_context <> NULL) THEN
                 GetParent := _parent;
             ELSE
+                // TODO provide some message 
                 GetParent := NULL_OBJECT;    
             END_IF;    
         END_METHOD
@@ -78,12 +82,38 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 inParent : IAxoObject;
             END_VAR                           
-                       
-            IF(inParent <> NULL) THEN
-                _context_    := inParent.GetContext();                 
-                _parent     := inParent;
-                RETURN;                 
-            END_IF;            
+                     
+            VAR
+                NULL_CONTEXT_OBJ    : IAxoObject;
+            END_VAR
+
+            IF _isInitialized THEN
+                RETURN;
+            END_IF;
+
+            IF(inParent = NULL) THEN
+                // TODO provide some message 
+                _errorState := UINT#20;
+                RETURN;
+            END_IF;
+
+            NULL_CONTEXT_OBJ ?= NULL_CONTEXT;
+            IF(inParent.GetContext() = NULL_CONTEXT_OBJ) THEN
+                // TODO provide some message 
+                _errorState := UINT#30;
+                RETURN;
+            END_IF;
+
+            IF(inParent = _parent) THEN
+                // TODO provide some message 
+                _errorState := UINT#40;
+                RETURN;
+            END_IF;
+
+            _context        := inParent.GetContext();                 
+            _parent         := inParent;
+            _isInitialized  := TRUE;
+            
         END_METHOD  
         
         ///<summary>
@@ -91,15 +121,24 @@ NAMESPACE AXOpen.Core
         /// This method should be called only once upon the program start.
         /// Any subsequent call are ignored.
         ///</summary>
-        METHOD PUBLIC Initialize
+        METHOD PUBLIC InitializeWithContext
             VAR_INPUT
                 inContext : IAxoContext;
             END_VAR   
          
-            
-            IF(inContext <> NULL) THEN
-                _context_    := inContext;                 
+            IF _isInitialized THEN
+                RETURN;
             END_IF;
+
+            IF(inContext = NULL) THEN
+                // TODO provide some message 
+                _errorState := UINT#10;
+                RETURN;
+            END_IF;
+            
+            _context        := inContext;                 
+            _isInitialized  := TRUE;
+
         END_METHOD   
         
         VAR
@@ -114,11 +153,11 @@ NAMESPACE AXOpen.Core
                 inCount : LINT;
             END_VAR         
 
-            IF(_context_ = NULL) THEN                 
+            IF(_context = NULL) THEN                 
                 RETURN; 
             END_IF;
 
-            IF(_lastMessageAggregationCycle <> _context_.OpenCycleCount()) THEN
+            IF(_lastMessageAggregationCycle <> _context.OpenCycleCount()) THEN
                 THIS.MsgCnt := LINT#0;
             END_IF;    
 
@@ -135,7 +174,7 @@ NAMESPACE AXOpen.Core
                 THIS._parent.AggregateMessage(inCount);
             END_IF;    
 
-            _lastMessageAggregationCycle := _context_.OpenCycleCount();  
+            _lastMessageAggregationCycle := _context.OpenCycleCount();  
         END_METHOD    
     END_CLASS    
 END_NAMESPACE    

--- a/src/core/ctrl/src/AxoObject/AxoObject.st
+++ b/src/core/ctrl/src/AxoObject/AxoObject.st
@@ -153,8 +153,9 @@ NAMESPACE AXOpen.Core
                 inCount : LINT;
             END_VAR         
 
-            IF(_context = NULL) THEN                 
-                RETURN; 
+            IF(_context = NULL) THEN          
+                _context := THIS.GetContext();       
+                // RETURN; 
             END_IF;
 
             IF(_lastMessageAggregationCycle <> _context.OpenCycleCount()) THEN

--- a/src/core/ctrl/src/AxoTask/AxoTask.st
+++ b/src/core/ctrl/src/AxoTask/AxoTask.st
@@ -137,11 +137,13 @@ NAMESPACE AXOpen.Core
                 IF Status <> eAxoTaskState#Error THEN
                     Status := eAxoTaskState#Disabled; 
                 END_IF;
-                IsReady := false; RETURN;
+                IsReady := false; 
+                RETURN;
             ELSE
                 IF  Status = eAxoTaskState#Disabled THEN
                     Status := eAxoTaskState#Ready; 
-                    IsReady := TRUE; RETURN;
+                    IsReady := TRUE; 
+                    RETURN;
                 END_IF;
             END_IF;
 
@@ -156,11 +158,13 @@ NAMESPACE AXOpen.Core
                 IF Status <> eAxoTaskState#Error THEN
                     Status := eAxoTaskState#Disabled; 
                 END_IF;
-                IsDone := false; RETURN;
+                IsDone := false; 
+                RETURN;
             ELSE
                 IF  Status = eAxoTaskState#Disabled THEN
                     Status := eAxoTaskState#Ready; 
-                    IsDone := false; RETURN;
+                    IsDone := false; 
+                    RETURN;
                 END_IF;
             END_IF;
 
@@ -175,11 +179,13 @@ NAMESPACE AXOpen.Core
                 IF Status <> eAxoTaskState#Error THEN
                     Status := eAxoTaskState#Disabled; 
                 END_IF;
-                IsBusy := false; RETURN;
+                IsBusy := false; 
+                RETURN;
             ELSE
                 IF  Status = eAxoTaskState#Disabled THEN
                     Status := eAxoTaskState#Ready; 
-                    IsBusy := false; RETURN;
+                    IsBusy := false; 
+                    RETURN;
                 END_IF;
             END_IF;
 
@@ -194,11 +200,13 @@ NAMESPACE AXOpen.Core
                 IF Status <> eAxoTaskState#Error THEN
                     Status := eAxoTaskState#Disabled; 
                 END_IF;
-                IsAborted := false; RETURN;
+                IsAborted := false; 
+                RETURN;
             ELSE
                 IF  Status = eAxoTaskState#Disabled THEN
                     Status := eAxoTaskState#Ready; 
-                    IsAborted := false; RETURN; 
+                    IsAborted := false; 
+                    RETURN; 
                 END_IF;
             END_IF;
             
@@ -212,14 +220,17 @@ NAMESPACE AXOpen.Core
             IF IsDisabled THEN 
                 IF Status <> eAxoTaskState#Error THEN
                     Status := eAxoTaskState#Disabled; 
-                    HasError := FALSE; RETURN; 
+                    HasError := FALSE; 
+                    RETURN; 
                 ELSE
-                    HasError := TRUE; RETURN; 
+                    HasError := TRUE; 
+                    RETURN; 
                 END_IF;
             ELSE
                 IF  Status = eAxoTaskState#Disabled THEN
                     Status := eAxoTaskState#Ready; 
-                    HasError := FALSE; RETURN; 
+                    HasError := FALSE; 
+                    RETURN; 
                 END_IF;
             END_IF;
 
@@ -291,37 +302,45 @@ NAMESPACE AXOpen.Core
         // END_METHOD 
 
         METHOD PRIVATE IsNewInvokeCall : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             IF _context <> NULL THEN
                 IsNewInvokeCall := _openCycleCountInvoke < _context.OpenCycleCount() - ULINT#1;
             ELSE
-                _context := THIS.GetContext();
                 IsNewInvokeCall := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE IsNewExecuteCall : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             IF _context <> NULL THEN
                 IsNewExecuteCall := _openCycleCountExecute < _context.OpenCycleCount() - ULINT#1;
             ELSE
-                _context := THIS.GetContext();
                 IsNewExecuteCall := FALSE;
             END_IF;     
         END_METHOD 
 
         METHOD PRIVATE IsExecuteCalledInThisPlcCycle : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             IF _context <> NULL THEN
                 IsExecuteCalledInThisPlcCycle := _openCycleCountExecute = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 IsExecuteCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasExecuteCalledInPreviousPlcCycle : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             IF _context <> NULL THEN
                 WasExecuteCalledInPreviousPlcCycle := _openCycleCountExecute + ULINT#1 = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 WasExecuteCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
@@ -401,11 +420,10 @@ NAMESPACE AXOpen.Core
         /// Restores this task.
         ///</summary>    
         METHOD PUBLIC Restore : IAxoTaskState
-            IF(_context = NULL) THEN
-                _context := THIS.GetContext();
-            END_IF;
-
             IF(Status <> eAxoTaskState#Ready AND Status <> eAxoTaskState#Disabled) THEN
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;      
                 _context.GetLogger().Log('Task restored', eLogLevel#Verbose, THIS);
                 _restoreCycleCount :=  _context.OpenCycleCount();
             END_IF;    
@@ -434,11 +452,10 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 Condition : BOOL;
             END_VAR
-            IF(_context = NULL) THEN
-                _context := THIS.GetContext();
-            END_IF;  
-
-            IF Condition AND Status = eAxoTaskState#Busy THEN   
+            IF Condition AND Status = eAxoTaskState#Busy THEN 
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;        
                 _context.GetLogger().Log('Task done.', eLogLevel#Verbose, THIS);
                 Status := eAxoTaskState#Done;
                 THIS.OnDone();
@@ -459,8 +476,13 @@ NAMESPACE AXOpen.Core
                 _context := THIS.GetContext();
             END_IF;
 
-            IF(_context = NULL) THEN RETURN; END_IF;
-            IF( RemoteInvoke) THEN THIS.Invoke(); RemoteInvoke := FALSE; END_IF;
+            IF(_context = NULL) THEN 
+                RETURN; 
+            END_IF;
+            IF( RemoteInvoke) THEN 
+                THIS.Invoke(); 
+                RemoteInvoke := FALSE; 
+            END_IF;
             IF _RemoteRestoreEnabled THEN
                 IF( RemoteRestore) THEN THIS.Restore(); RemoteRestore := FALSE; END_IF;
             ELSE
@@ -573,12 +595,10 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 HasErrorState : BOOL;
             END_VAR
-
-            IF(_context = NULL) THEN
-                _context := THIS.GetContext();
-            END_IF;
-
             IF(HasErrorState) THEN
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;      
                 Status := eAxoTaskState#Error;  
                 _context.GetLogger().Log('Task failed', eLogLevel#Error, THIS);             
                 THIS.OnError();  
@@ -595,11 +615,11 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 HasErrorState : BOOL;
                 ErrorDescription : STRING[254];
-            END_VAR  
-            IF(_context = NULL) THEN
-                _context := THIS.GetContext();
-            END_IF;          
-            IF(HasErrorState) THEN                
+            END_VAR          
+            IF(HasErrorState) THEN      
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;                
                 ErrorDetails :=  ErrorDescription; 
                 _context.GetLogger().Log(ErrorDetails, eLogLevel#Error, THIS);  
             END_IF;    
@@ -627,11 +647,10 @@ NAMESPACE AXOpen.Core
         /// Aborts the execution of the task if running and sets its state to aborted.
         ///</summary>
         METHOD PUBLIC Abort 
-            IF(_context = NULL) THEN
-                _context := THIS.GetContext();
-            END_IF;
-
             IF THIS.Status = eAxoTaskState#Busy THEN
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;      
                 THIS.Status := eAxoTaskState#Aborted;
                 THIS.OnAbort();
                 _abortCycleCount :=  _context.OpenCycleCount();
@@ -643,6 +662,9 @@ NAMESPACE AXOpen.Core
         ///</summary>
         METHOD PUBLIC Resume 
             IF THIS.Status = eAxoTaskState#Aborted THEN
+                IF(_context = NULL) THEN
+                    _context := THIS.GetContext();
+                END_IF;      
                 THIS.Status := eAxoTaskState#Busy;
                 THIS.OnResume();
                 _resumeCycleCount :=  _context.OpenCycleCount();
@@ -762,6 +784,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has been aborted in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC AbortTriggered : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             AbortTriggered := _abortCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
 
@@ -769,6 +794,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has been resumed in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC ResumeTriggered : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             ResumeTriggered := _resumeCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
 
@@ -776,6 +804,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has reached the `Done` state in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC DoneReached : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             DoneReached := _doneCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
@@ -783,6 +814,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has reached the `Error` state in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC ErrorOccured : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             ErrorOccured := _errorCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
@@ -790,6 +824,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has been restored in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC RestoreTriggered : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             RestoreTriggered := _restoreCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
@@ -797,6 +834,9 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has been started in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC StartTriggered : BOOL
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;      
             StartTriggered := _startCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     END_CLASS    

--- a/src/core/ctrl/src/AxoTask/AxoTask.st
+++ b/src/core/ctrl/src/AxoTask/AxoTask.st
@@ -105,6 +105,7 @@ NAMESPACE AXOpen.Core
             _abortCycleCount    :  ULINT;
             _resumeCycleCount   :  ULINT;
 
+            _context            :  IAxoContext;
         END_VAR 
 
         ///<summary>
@@ -290,49 +291,37 @@ NAMESPACE AXOpen.Core
         // END_METHOD 
 
         METHOD PRIVATE IsNewInvokeCall : BOOL
-            IF _context_ <> NULL THEN
-                IsNewInvokeCall := _openCycleCountInvoke < _context_.OpenCycleCount() - ULINT#1;
+            IF _context <> NULL THEN
+                IsNewInvokeCall := _openCycleCountInvoke < _context.OpenCycleCount() - ULINT#1;
             ELSE
+                _context := THIS.GetContext();
                 IsNewInvokeCall := FALSE;
             END_IF;     
         END_METHOD 
-
-        // METHOD PRIVATE IsInvokeCalledInThisPlcCycle1 : BOOL
-        //     IF _context_ <> NULL THEN
-        //         IsInvokeCalledInThisPlcCycle := _openCycleCountInvoke = _context_.OpenCycleCount();
-        //     ELSE
-        //         IsInvokeCalledInThisPlcCycle := FALSE;
-        //     END_IF;     
-        // END_METHOD 
-        
-        // METHOD PRIVATE WasInvokeCalledInPreviousPlcCycle1 : BOOL
-        //     IF _context_ <> NULL THEN
-        //         WasInvokeCalledInPreviousPlcCycle := _openCycleCountInvoke +ULINT#1 = _context_.OpenCycleCount();
-        //     ELSE
-        //         WasInvokeCalledInPreviousPlcCycle := FALSE;
-        //     END_IF;     
-        // END_METHOD 
         
         METHOD PRIVATE IsNewExecuteCall : BOOL
-            IF _context_ <> NULL THEN
-                IsNewExecuteCall := _openCycleCountExecute < _context_.OpenCycleCount() - ULINT#1;
+            IF _context <> NULL THEN
+                IsNewExecuteCall := _openCycleCountExecute < _context.OpenCycleCount() - ULINT#1;
             ELSE
+                _context := THIS.GetContext();
                 IsNewExecuteCall := FALSE;
             END_IF;     
         END_METHOD 
 
         METHOD PRIVATE IsExecuteCalledInThisPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                IsExecuteCalledInThisPlcCycle := _openCycleCountExecute = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                IsExecuteCalledInThisPlcCycle := _openCycleCountExecute = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 IsExecuteCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasExecuteCalledInPreviousPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                WasExecuteCalledInPreviousPlcCycle := _openCycleCountExecute + ULINT#1 = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                WasExecuteCalledInPreviousPlcCycle := _openCycleCountExecute + ULINT#1 = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 WasExecuteCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
@@ -363,7 +352,10 @@ NAMESPACE AXOpen.Core
                 _isNullContext : BOOL;
             END_VAR;
             
-            _isNullContext := _context_ = NULL;
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+            _isNullContext := _context = NULL;
 
 
             IF _isNullContext THEN
@@ -388,15 +380,17 @@ NAMESPACE AXOpen.Core
                 Status := eAxoTaskState#Ready; 
             END_IF;
 
-            _openCycleCountInvoke := _context_.OpenCycleCount();
+            _openCycleCountInvoke := _context.OpenCycleCount();
 
             // task should not be Invoked, if the execute method was not called in this or previous PLC cycle
             IF Status = eAxoTaskState#Ready THEN
                 IF (THIS.IsExecuteCalledInThisPlcCycle() OR THIS.WasExecuteCalledInPreviousPlcCycle()) THEN
                     Status := eAxoTaskState#Kicking;      
-                    _context_.GetLogger().Log('Task invoked', eLogLevel#Verbose, THIS);
+                    _context.GetLogger().Log('Task invoked', eLogLevel#Verbose, THIS);
                   ELSE                                         
-                    IF(NOT _suspendExecuteCallAnalisis) THEN _CyclicExecuteIsNotCalled.Activate(eAxoMessageCategory#ProgrammingError); END_IF;                     
+                    IF(NOT _suspendExecuteCallAnalisis) THEN 
+                        _CyclicExecuteIsNotCalled.Activate(eAxoMessageCategory#ProgrammingError); 
+                    END_IF;                     
                  END_IF;     
             END_IF;     
 
@@ -407,9 +401,13 @@ NAMESPACE AXOpen.Core
         /// Restores this task.
         ///</summary>    
         METHOD PUBLIC Restore : IAxoTaskState
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+
             IF(Status <> eAxoTaskState#Ready AND Status <> eAxoTaskState#Disabled) THEN
-                _context_.GetLogger().Log('Task restored', eLogLevel#Verbose, THIS);
-                _restoreCycleCount :=  _context_.OpenCycleCount();
+                _context.GetLogger().Log('Task restored', eLogLevel#Verbose, THIS);
+                _restoreCycleCount :=  _context.OpenCycleCount();
             END_IF;    
             Status := eAxoTaskState#Ready; 
             ErrorDetails := '';   
@@ -436,12 +434,15 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 Condition : BOOL;
             END_VAR
-              
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;  
+
             IF Condition AND Status = eAxoTaskState#Busy THEN   
-                _context_.GetLogger().Log('Task done.', eLogLevel#Verbose, THIS);
+                _context.GetLogger().Log('Task done.', eLogLevel#Verbose, THIS);
                 Status := eAxoTaskState#Done;
                 THIS.OnDone();
-                _doneCycleCount :=  _context_.OpenCycleCount();
+                _doneCycleCount :=  _context.OpenCycleCount();
             END_IF;    
         END_METHOD
 
@@ -454,8 +455,11 @@ NAMESPACE AXOpen.Core
                 _stateKicking : BOOL;
                 _openCycleCount : ULINT;
             END_VAR
-            
-            IF(_context_ = NULL) THEN RETURN; END_IF;
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+
+            IF(_context = NULL) THEN RETURN; END_IF;
             IF( RemoteInvoke) THEN THIS.Invoke(); RemoteInvoke := FALSE; END_IF;
             IF _RemoteRestoreEnabled THEN
                 IF( RemoteRestore) THEN THIS.Restore(); RemoteRestore := FALSE; END_IF;
@@ -471,7 +475,7 @@ NAMESPACE AXOpen.Core
             
             _MultipleExecuteIsCalled.Serve(THIS);
 
-            _openCycleCount :=  _context_.OpenCycleCount();
+            _openCycleCount :=  _context.OpenCycleCount();
 
             IF NOT _SuspendMultipleExecuteCallCheck THEN
                 IF _openCycleCountExecute = _openCycleCount THEN
@@ -504,16 +508,16 @@ NAMESPACE AXOpen.Core
                 Status := eAxoTaskState#Busy; 
 
                 // This null check is due to implementation of RTC in unit tests
-                IF(_context_.GetRtc() <> NULL) THEN
-                    StartTimeStamp := _context_.GetRtc().NowUTC();
+                IF(_context.GetRtc() <> NULL) THEN
+                    StartTimeStamp := _context.GetRtc().NowUTC();
                 END_IF;  
                   
                 // Don't touch this, it is used for remote execs.
-                StartSignature := _openCycleCountExecute;//_context_.OpenCycleCount();    
-                _context_.GetLogger().Log('Task started.', eLogLevel#Verbose, THIS);                       
+                StartSignature := _openCycleCountExecute;//_context.OpenCycleCount();    
+                _context.GetLogger().Log('Task started.', eLogLevel#Verbose, THIS);                       
                 THIS.OnStart();
                 _isFirstExecutionCycle := TRUE; 
-                _startCycleCount :=  _context_.OpenCycleCount();
+                _startCycleCount :=  _context.OpenCycleCount();
             END_IF;    
 
             IF(Status = eAxoTaskState#Error) THEN
@@ -540,7 +544,7 @@ NAMESPACE AXOpen.Core
 
             _RtmInvalid.Serve(THIS);
             
-            IF(NOT _suspendExecuteCallAnalisis) THEN _RtmInvalid.ActivateOnCondition(_context_.GetRtm() = NULL , eAxoMessageCategory#ProgrammingError); END_IF;                     
+            IF(NOT _suspendExecuteCallAnalisis) THEN _RtmInvalid.ActivateOnCondition(_context.GetRtm() = NULL , eAxoMessageCategory#ProgrammingError); END_IF;                     
 
         END_METHOD    
 
@@ -558,7 +562,7 @@ NAMESPACE AXOpen.Core
         //     END_VAR               
         //     _castIIAxoStep ?= _sender;
         //     IF(_castIIAxoStep <> NULL) THEN RETURN; END_IF;            
-        //     _context_.GetLogger().Log(_message, _level, THIS);       
+        //     _context.GetLogger().Log(_message, _level, THIS);       
         // END_METHOD
 
         ///<summary>
@@ -570,12 +574,16 @@ NAMESPACE AXOpen.Core
                 HasErrorState : BOOL;
             END_VAR
 
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+
             IF(HasErrorState) THEN
                 Status := eAxoTaskState#Error;  
-                _context_.GetLogger().Log('Task failed', eLogLevel#Error, THIS);             
+                _context.GetLogger().Log('Task failed', eLogLevel#Error, THIS);             
                 THIS.OnError();  
                 THIS.WhileError();   
-                _errorCycleCount :=  _context_.OpenCycleCount();
+                _errorCycleCount :=  _context.OpenCycleCount();
             END_IF;    
         END_METHOD    
     
@@ -587,10 +595,13 @@ NAMESPACE AXOpen.Core
             VAR_INPUT
                 HasErrorState : BOOL;
                 ErrorDescription : STRING[254];
-            END_VAR            
+            END_VAR  
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;          
             IF(HasErrorState) THEN                
                 ErrorDetails :=  ErrorDescription; 
-                _context_.GetLogger().Log(ErrorDetails, eLogLevel#Error, THIS);  
+                _context.GetLogger().Log(ErrorDetails, eLogLevel#Error, THIS);  
             END_IF;    
             THIS.ThrowWhen(HasErrorState);        
         END_METHOD    
@@ -616,10 +627,14 @@ NAMESPACE AXOpen.Core
         /// Aborts the execution of the task if running and sets its state to aborted.
         ///</summary>
         METHOD PUBLIC Abort 
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+
             IF THIS.Status = eAxoTaskState#Busy THEN
                 THIS.Status := eAxoTaskState#Aborted;
                 THIS.OnAbort();
-                _abortCycleCount :=  _context_.OpenCycleCount();
+                _abortCycleCount :=  _context.OpenCycleCount();
             END_IF;
         END_METHOD
     
@@ -630,7 +645,7 @@ NAMESPACE AXOpen.Core
             IF THIS.Status = eAxoTaskState#Aborted THEN
                 THIS.Status := eAxoTaskState#Busy;
                 THIS.OnResume();
-                _resumeCycleCount :=  _context_.OpenCycleCount();
+                _resumeCycleCount :=  _context.OpenCycleCount();
             END_IF;
         END_METHOD
     
@@ -747,42 +762,42 @@ NAMESPACE AXOpen.Core
         /// Returns `TRUE` when the task has been aborted in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC AbortTriggered : BOOL
-            AbortTriggered := _abortCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            AbortTriggered := _abortCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
 
         ///<summary>
         /// Returns `TRUE` when the task has been resumed in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC ResumeTriggered : BOOL
-            ResumeTriggered := _resumeCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            ResumeTriggered := _resumeCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
 
         ///<summary>
         /// Returns `TRUE` when the task has reached the `Done` state in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC DoneReached : BOOL
-            DoneReached := _doneCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            DoneReached := _doneCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
         ///<summary>
         /// Returns `TRUE` when the task has reached the `Error` state in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC ErrorOccured : BOOL
-            ErrorOccured := _errorCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            ErrorOccured := _errorCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
         ///<summary>
         /// Returns `TRUE` when the task has been restored in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC RestoreTriggered : BOOL
-            RestoreTriggered := _restoreCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            RestoreTriggered := _restoreCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     
         ///<summary>
         /// Returns `TRUE` when the task has been started in this or previous PLC cycle.
         ///</summary>
         METHOD PUBLIC StartTriggered : BOOL
-            StartTriggered := _startCycleCount >= _context_.OpenCycleCount() - ULINT#1;
+            StartTriggered := _startCycleCount >= _context.OpenCycleCount() - ULINT#1;
         END_METHOD
     END_CLASS    
 END_NAMESPACE

--- a/src/core/ctrl/src/AxoToggleTask/AxoToggleTask.st
+++ b/src/core/ctrl/src/AxoToggleTask/AxoToggleTask.st
@@ -33,7 +33,8 @@ NAMESPACE AXOpen.Core
         END_VAR    
         
         VAR PRIVATE
-            _openCycleCount : ULINT;
+            _openCycleCount :   ULINT;
+            _context        :   IAxoContext;
         END_VAR 
         
         ///<summary>
@@ -44,17 +45,19 @@ NAMESPACE AXOpen.Core
         END_METHOD
 
         METHOD PRIVATE IsRunCalledInThisPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                IsRunCalledInThisPlcCycle := _openCycleCount = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                IsRunCalledInThisPlcCycle := _openCycleCount = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 IsRunCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasRunCalledInPreviousPlcCycle : BOOL
-            IF _context_ <> NULL THEN
-                WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context_.OpenCycleCount();
+            IF _context <> NULL THEN
+                WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context.OpenCycleCount();
             ELSE
+                _context := THIS.GetContext();
                 WasRunCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
@@ -62,13 +65,15 @@ NAMESPACE AXOpen.Core
         ///<summary>
         ///	This method needs to be called cyclically.
         ///</summary>    
-        METHOD PUBLIC Run : BOOL            
-             _openCycleCount := _context_.OpenCycleCount();
+        METHOD PUBLIC Run : BOOL   
+            IF(_context = NULL) THEN
+                _context := THIS.GetContext();
+            END_IF;
+             _openCycleCount := _context.OpenCycleCount();
 
             IF IsDisabled THEN
                 RemoteToggle := FALSE;
             END_IF;
-
 
             //Triggering toggle remotely
             IF(RemoteToggle) THEN

--- a/src/core/ctrl/src/AxoToggleTask/AxoToggleTask.st
+++ b/src/core/ctrl/src/AxoToggleTask/AxoToggleTask.st
@@ -45,19 +45,25 @@ NAMESPACE AXOpen.Core
         END_METHOD
 
         METHOD PRIVATE IsRunCalledInThisPlcCycle : BOOL
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context <> NULL THEN
                 IsRunCalledInThisPlcCycle := _openCycleCount = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 IsRunCalledInThisPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
         
         METHOD PRIVATE WasRunCalledInPreviousPlcCycle : BOOL
+            IF _context = NULL THEN
+                _context := THIS.GetContext();
+            END_IF;     
+
             IF _context <> NULL THEN
                 WasRunCalledInPreviousPlcCycle := _openCycleCount + ULINT#1 = _context.OpenCycleCount();
             ELSE
-                _context := THIS.GetContext();
                 WasRunCalledInPreviousPlcCycle := FALSE;
             END_IF;     
         END_METHOD 
@@ -69,6 +75,7 @@ NAMESPACE AXOpen.Core
             IF(_context = NULL) THEN
                 _context := THIS.GetContext();
             END_IF;
+
              _openCycleCount := _context.OpenCycleCount();
 
             IF IsDisabled THEN

--- a/src/core/ctrl/src/Mocks/MockAxoRtc.st
+++ b/src/core/ctrl/src/Mocks/MockAxoRtc.st
@@ -1,0 +1,26 @@
+
+USING AXOpen.Messaging;
+USING AXOpen.Logging;
+USING AXOpen.Core;
+USING AXOpen.Rtm;
+USING AXOpen.Rtc;
+
+NAMESPACE AXOpen.Core.Dummies
+    {S7.extern=ReadWrite}
+    CLASS PUBLIC MockAxoRtc IMPLEMENTS IAxoRtc        
+        VAR PRIVATE
+            _nowUTC : LDATE_AND_TIME;
+        END_VAR
+
+        METHOD PUBLIC NowUTC : LDATE_AND_TIME
+            NowUTC := _nowUTC;
+        END_METHOD
+
+        METHOD PUBLIC SetNowUTC 
+            VAR_INPUT
+                Set : LDATE_AND_TIME;
+            END_VAR
+            _nowUTC := Set;
+        END_METHOD
+    END_CLASS          
+END_NAMESPACE

--- a/src/core/ctrl/src/Mocks/MockAxoRtm.st
+++ b/src/core/ctrl/src/Mocks/MockAxoRtm.st
@@ -1,0 +1,26 @@
+
+USING AXOpen.Messaging;
+USING AXOpen.Logging;
+USING AXOpen.Core;
+USING AXOpen.Rtm;
+USING AXOpen.Rtc;
+
+NAMESPACE AXOpen.Core.Dummies
+    {S7.extern=ReadWrite}
+    CLASS PUBLIC MockAxoRtm IMPLEMENTS IAxoRtm
+        VAR PRIVATE
+            _elapsed : LTIME;
+        END_VAR
+
+        METHOD PUBLIC Elapsed : LTIME
+            Elapsed := _elapsed;
+        END_METHOD
+
+        METHOD PUBLIC SetElapsed
+            VAR_INPUT
+                Set : LTIME;
+            END_VAR
+            _elapsed := Set;
+        END_METHOD
+    END_CLASS          
+END_NAMESPACE

--- a/src/core/ctrl/src/abstractions/NULLs.st
+++ b/src/core/ctrl/src/abstractions/NULLs.st
@@ -67,6 +67,10 @@ NAMESPACE AXOpen.Core
 
             ;
         END_METHOD
+    
+        METHOD PUBLIC GetParent : IAxoObject
+            GetParent := THIS;
+        END_METHOD
     END_CLASS    
 
     ///<summary>

--- a/src/core/ctrl/test/AxoCoordination/AxoSequencerContainerTests.st
+++ b/src/core/ctrl/test/AxoCoordination/AxoSequencerContainerTests.st
@@ -480,6 +480,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             // _context.Open();
             // _sequencer.Initialize(_rootObject);
             // _sequencer.Invoke();
+            // Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
             // _sequencer.Open();
             // _sequencer._step_1.Execute(_sequencer);
             // _sequencer._step_2.Execute(_sequencer);

--- a/src/core/ctrl/test/AxoCoordination/AxoSequencerContainerTests.st
+++ b/src/core/ctrl/test/AxoCoordination/AxoSequencerContainerTests.st
@@ -1,6 +1,10 @@
 USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests  
     TYPE PUBLIC
@@ -18,11 +22,19 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
     END_TYPE
 
     {S7.extern=ReadWrite}
-   CLASS TestContext EXTENDS AXOpen.Core.Dummies.MockAxoContext                    
+   CLASS TestContext EXTENDS MockAxoContext                    
             METHOD PROTECTED OVERRIDE Main
                 ;
             END_METHOD               
     END_CLASS     
+
+
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
 
     {S7.extern=ReadWrite}
     CLASS MySequencer EXTENDS AxoSequencerContainer
@@ -158,10 +170,11 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
     {S7.extern=ReadWrite}
     CLASS SequencerContainerTests
         VAR PROTECTED        
-            _context   : TestContext;
-            _sequencer : MySequencer;
+            _context    : TestContext;
+            _rootObject    : TestObject;
+            _sequencer  : MySequencer;
             _stepState  :   eAxoTaskState;
-            _counter : ULINT;
+            _counter    : ULINT;
         END_VAR    
 
         METHOD EqualeAxoTaskState : BOOL
@@ -201,8 +214,9 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         END_METHOD
                 
         METHOD PRIVATE InitializeSequence
+            _rootObject.InitializeWithContext(_context);
             _context.Open();
-            _sequencer.Initialize(_context);
+            _sequencer.Initialize(_rootObject);
         END_METHOD
        
         METHOD PRIVATE InvokeSequence
@@ -213,9 +227,10 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         METHOD PRIVATE PrepareSequence
             _context.Open();
             _sequencer._stepLogic := eStepLogic#JustExecuteCall;
-            _sequencer.Initialize(_context);
+            _rootObject.InitializeWithContext(_context);
+            _sequencer.Initialize(_rootObject);
             _sequencer.Invoke();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
         END_METHOD
 
@@ -233,23 +248,29 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             _sequencer._CompleteSequence := CompleteSequence;
 
             _sequencer._stepLogic := eStepLogic#ExecuteSequence;
-            _sequencer.Initialize(_context);
+            _sequencer.Initialize(_rootObject);
             _sequencer.Invoke();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
 
             _context.Close();
         END_METHOD
 
         VAR PROTECTED       
-            _contextClean    :   TestContext;
-            _sequencerClean  :   MySequencer;
-            _stepStateClean  :   eAxoTaskState;
-            _counterClean    :   ULINT;
+            _contextClean   :   TestContext;
+            _rtc            :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm            :   AXOpen.Core.Dummies.MockAxoRtm;
+            _sequencerClean :   MySequencer;
+            _stepStateClean :   eAxoTaskState;
+            _counterClean   :   ULINT;
         END_VAR    
 
         {TestSetup}
         METHOD PUBLIC TestSetup
             _context    :=  _contextClean;
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
             _sequencer  :=  _sequencerClean;
             _stepState  :=  _stepStateClean;
             _counter    :=  _counterClean;
@@ -286,7 +307,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             THIS.InitializeSequence();
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
             _sequencer.Invoke();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
         END_METHOD
 
@@ -295,9 +316,9 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             THIS.InitializeSequence();
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
             _sequencer.Invoke();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
         END_METHOD
 
@@ -305,7 +326,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         METHOD PUBLIC order_of_steps_should_be_assigned_after_first_sequence_cycle
             THIS.InvokeSequence();
             _sequencer._stepLogic := eStepLogic#JustExecuteCall;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
              Assert.Equal(ULINT#1,_sequencer._step_1.Order);
              Assert.Equal(ULINT#2,_sequencer._step_2.Order);
              Assert.Equal(ULINT#3,_sequencer._step_3.Order);
@@ -315,7 +336,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         METHOD PUBLIC no_step_should_be_executed_when_configuring
             THIS.InvokeSequence();
             _sequencer._stepLogic := eStepLogic#None;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             // Configuring steps no step should execute
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer));
@@ -455,6 +476,14 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
 
         {Test}
         METHOD PUBLIC RequestStep_should_not_affect_the_sequence_when_the_coordinator_is_in_configuring
+            // _rootObject.InitializeWithContext(_context);
+            // _context.Open();
+            // _sequencer.Initialize(_rootObject);
+            // _sequencer.Invoke();
+            // _sequencer.Open();
+            // _sequencer._step_1.Execute(_sequencer);
+            // _sequencer._step_2.Execute(_sequencer);
+            // _sequencer._step_3.Execute(_sequencer);
             THIS.InvokeSequence();
 
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
@@ -618,7 +647,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //First sequence run, no step is executed
             THIS.InvokeSequence();
             _sequencer._stepLogic := eStepLogic#MAIN_123;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#0, _sequencer._orderCounter);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
@@ -629,7 +658,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //Sequence should stay in the Idle state as the CompleteSequence() was called on running sequence
             _context.Open();
             _sequencer._stepLogic := eStepLogic#MAIN_123;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#6, _sequencer._orderCounter - StepOrderLastValue);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
@@ -638,7 +667,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //No steps are going to be executed, as the orders of the steps need to be assign again
             _context.Open();
             _sequencer._stepLogic := eStepLogic#MAIN_123;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#0, _sequencer._orderCounter - StepOrderLastValue);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
@@ -648,7 +677,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //Sequence should stay in the Idle state as the CompleteSequence() was called on running sequence
             _context.Open();
             _sequencer._stepLogic := eStepLogic#MAIN_122;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#3, _sequencer._orderCounter - StepOrderLastValue);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
@@ -661,7 +690,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //First sequence run, no step is executed
             THIS.InvokeSequence();
             _sequencer._stepLogic := eStepLogic#MAIN_12x;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             Assert.Equal(FALSE, _sequencer._step_1.IsActive);
             Assert.Equal(FALSE, _sequencer._step_2.IsActive);
             Assert.Equal(FALSE, _sequencer._step_3.IsActive); 
@@ -690,7 +719,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //First sequence run, no step is executed
             THIS.InvokeSequence();
             _sequencer._stepLogic := eStepLogic#MAIN_123;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#0, _sequencer._orderCounter);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
@@ -700,7 +729,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //Step body should be executed for step_1 and step_2.
             _context.Open();
             _sequencer._stepLogic := eStepLogic#MAIN_12x;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#3, _sequencer._orderCounter - StepOrderLastValue);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
@@ -712,7 +741,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
             //Step_3 is in the order of the execution, but it is not going to be executed, as it was not called in the previous PLC cycle.
             _context.Open();
             _sequencer._stepLogic := eStepLogic#MAIN_123;
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#0, _sequencer._orderCounter - StepOrderLastValue);
             Assert.Equal(TRUE, THIS.EqualAxoCoordinatorStates(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
@@ -1779,7 +1808,7 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         METHOD PUBLIC no_logic_should_be_executed_when_sequencer_is_not_running
             _sequencer._stepLogic := eStepLogic#LogicOutsideSteps;
             _context.Open();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#0, _sequencer._counter);
         END_METHOD
@@ -1788,1813 +1817,11 @@ NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests
         METHOD PUBLIC logic_should_be_executed_when_sequencer_is_running
             _sequencer._stepLogic := eStepLogic#LogicOutsideSteps;
             THIS.InvokeSequence();
-            _sequencer.Run(_context);
+            _sequencer.Run(_rootObject);
             _context.Close();
             Assert.Equal(ULINT#1, _sequencer._counter);
         END_METHOD
  
     END_CLASS  
 END_NAMESPACE
-
-
-//------------------------------------------------------------------------------------------------------
-//------------------------------------------------------------------------------------------------------
-//------------------------------------------------------------------------------------------------------
-
-// USING AxUnit;
-// USING AXOpen.Core;
-// USING AXOpen.Rtc;
-
-// NAMESPACE AXOpen.Core.AxoSequencerContainer_Tests  
-//     TYPE PUBLIC
-//         eStepLogic : INT 
-//         (          
-//             None := 0,
-//             JustExecuteCall := 1, 
-//             MAIN_12 := 2,
-//             MAIN_12x := 3,
-//             MAIN_123 := 4,
-//             MAIN_122 := 5,
-//             ExecuteSequence := 6,
-//             LogicOutsideSteps := 7
-//         ) := None;
-//     END_TYPE
-
-//     CLASS TestContext IMPLEMENTS IAxoContext         
-//         VAR PROTECTED                        
-//             _openCounter : ULINT;
-//             _closeCounter : ULINT;
-//             _identityCounter : ULINT;
-//          END_VAR       
-//         METHOD PUBLIC Open : ULINT
-//             _openCounter := _openCounter + ULINT#1;
-//         END_METHOD    
-
-//         METHOD PUBLIC Close : ULINT
-//             _closeCounter := _closeCounter + ULINT#1;
-//         END_METHOD
-
-//         METHOD PUBLIC OpenCycleCount : ULINT
-//             OpenCycleCount := _openCounter;
-//         END_METHOD
-                
-//         METHOD PUBLIC ClosedCycleCount : ULINT
-//             ClosedCycleCount := _closeCounter;
-//         END_METHOD
-
-//         METHOD PUBLIC CreateIdentity : ULINT            
-//             _identityCounter := _identityCounter + ULINT#1;
-//             CreateIdentity := _identityCounter;
-//         END_METHOD        
-
-//         METHOD PUBLIC GetRtc : IAxoRtc ; END_METHOD
-
-//         METHOD PUBLIC InjectRtc VAR_INPUT Rtc : IAxoRtc; END_VAR ; END_METHOD
-        
-//         VAR PRIVATE
-//             NULL_LOGGER : _NULL_LOGGER;
-//         END_VAR    
-//         METHOD PUBLIC GetLogger : AXOpen.Messaging.IAxoLogger GetLogger := NULL_LOGGER; END_METHOD
-//         METHOD PUBLIC InjectLogger VAR_INPUT _logger : AXOpen.Messaging.IAxoLogger; END_VAR ; END_METHOD    
-//     END_CLASS  
-
-//     CLASS MySequencer EXTENDS AxoSequencerContainer
-//         VAR PUBLIC
-//             _step_1    : AxoStep;
-//             _step_2    : AxoStep;
-//             _step_3    : AxoStep;        
-//             _stepLogic : eStepLogic;
-//             _orderCounter : ULINT;
-//             _CompleteStep : BOOL;
-//             _CompleteSequence : BOOL;
-//             _counter : ULINT;
-//         END_VAR
-//         VAR PRIVATE
-//             OnBeforeSequenceStartCounter : ULINT;
-//             OnCompleteSequenceCounter : ULINT;
-//         END_VAR
-//         METHOD PROTECTED OVERRIDE OnBeforeSequenceStart
-//             OnBeforeSequenceStartCounter := OnBeforeSequenceStartCounter + ULINT#1;
-//         END_METHOD
-        
-//         METHOD PROTECTED OVERRIDE OnCompleteSequence
-//             OnCompleteSequenceCounter := OnCompleteSequenceCounter + ULINT#1;
-//         END_METHOD 
-        
-//         METHOD PUBLIC GetOnBeforeSequenceStartCounter : ULINT
-//             GetOnBeforeSequenceStartCounter := OnBeforeSequenceStartCounter;
-//         END_METHOD
-        
-//         METHOD PUBLIC GetOnCompleteSequenceCounter : ULINT
-//             GetOnCompleteSequenceCounter := OnCompleteSequenceCounter;
-//         END_METHOD
-    
-//         METHOD PROTECTED OVERRIDE Main
-//             _step_1.Initialize(THIS);
-//             _step_2.Initialize(THIS);
-//             _step_3.Initialize(THIS); 
-
-//             CASE _stepLogic OF
-//                 eStepLogic#JustExecuteCall: 
-//                     _step_1.Execute(THIS);
-//                     _step_2.Execute(THIS);
-//                     _step_3.Execute(THIS); 
-
-//                 eStepLogic#MAIN_12: 
-//                     THIS.MAIN_12();
-
-//                 eStepLogic#MAIN_12x: 
-//                     THIS.MAIN_12x();
-
-//                 eStepLogic#MAIN_123: 
-//                     THIS.MAIN_123();
-
-//                 eStepLogic#MAIN_122: 
-//                     THIS.MAIN_122();
-
-//                 eStepLogic#ExecuteSequence: 
-//                     THIS.ExecuteSequence(_CompleteStep , _CompleteSequence);
-
-//                 eStepLogic#LogicOutsideSteps: 
-//                     THIS.LogicOutsideSteps();
-
-//                 END_CASE;
-//         END_METHOD
-
-//         METHOD MAIN_12x 
-//             IF(_step_1.Execute(THIS)) THEN  
-//                 _orderCounter := _orderCounter + _step_1.GetStepOrder();
-//                 THIS.MoveNext();
-//             END_IF;    
-           
-//             IF(_step_2.Execute(THIS)) THEN
-//                 _orderCounter := _orderCounter + _step_2.GetStepOrder();
-//                 THIS.MoveNext();
-//             END_IF; 
-//         END_METHOD
-
-//         METHOD MAIN_12 
-//             THIS.MAIN_12x();
-//             THIS.CompleteSequence();
-//         END_METHOD
-
-//         METHOD MAIN_123 
-//             THIS.MAIN_12x();
-//             IF(_step_3.Execute(THIS)) THEN
-//                 _orderCounter := _orderCounter + _step_3.GetStepOrder();
-//                 THIS.MoveNext();
-//             END_IF; 
-//             THIS.CompleteSequence();
-//         END_METHOD
-
-//         METHOD MAIN_122 
-//             THIS.MAIN_12x();
-
-//             IF(_step_2.Execute(THIS)) THEN
-//                 _orderCounter := _orderCounter + ULINT#1000;
-//                 THIS.MoveNext();
-//             END_IF; 
-//             THIS.CompleteSequence();
-//         END_METHOD
-
-//         METHOD ExecuteSequence 
-//             VAR_INPUT
-//                 CompleteStep : BOOL;
-//                 CompleteSequence : BOOL;
-//             END_VAR
-
-//             IF _step_1.Execute(THIS) THEN
-//                 IF CompleteStep THEN
-//                     THIS.MoveNext();
-//                 END_IF;
-//             END_IF;
-//             IF _step_2.Execute(THIS) THEN
-//                 IF CompleteStep THEN
-//                     THIS.MoveNext();
-//                 END_IF;
-//             END_IF;
-//             IF _step_3.Execute(THIS) THEN
-//                 IF CompleteSequence THEN
-//                     THIS.CompleteSequence();
-//                 END_IF;
-//             END_IF;
-//         END_METHOD
-
-//         METHOD LogicOutsideSteps 
-//             THIS.MAIN_123();
-//             _counter := _counter + ULINT#1;
-//         END_METHOD
-//     END_CLASS
-
-
-//     {TestFixture}
-//     CLASS SequencerContainerTests
-//         VAR PROTECTED        
-//             _context   : TestContext;
-//             _sequencer : MySequencer;
-//             _stepState  :   eAxoTaskState;
-//             _counter : ULINT;
-//         END_VAR    
-
-//         METHOD Equal : BOOL
-//             VAR_INPUT
-//                  expected:  eAxoTaskState;
-//                  actual:  eAxoTaskState;
-//             END_VAR
-//             Equal := expected = actual;
-//         END_METHOD         
-        
-//         METHOD Equal : BOOL
-//             VAR_INPUT
-//                 expected:  AxoCoordinatorStates;
-//                 actual:  AxoCoordinatorStates;
-//             END_VAR
-//             Equal := expected = actual;
-//         END_METHOD 
-
-//         METHOD Equal : BOOL
-//             VAR_INPUT
-//                  expected:  eAxoSteppingMode;
-//                  actual:  eAxoSteppingMode;
-//             END_VAR
-//             Equal := expected = actual;
-//         END_METHOD         
-        
-//         METHOD Equal : BOOL
-//             VAR_INPUT
-//                  expected:  eAxoSequenceMode;
-//                  actual:  eAxoSequenceMode;
-//             END_VAR
-//             Equal := expected = actual;
-//         END_METHOD         
-        
-//         METHOD PUBLIC GetSequencerState : AxoCoordinatorStates
-//             GetSequencerState := _sequencer.GetCoordinatorState();
-//         END_METHOD
-                
-//         METHOD PRIVATE InitializeSequence
-//             _context.Open();
-//             _sequencer.Initialize(_context);
-//         END_METHOD
-       
-//         METHOD PRIVATE InvokeSequence
-//             THIS.InitializeSequence();
-//             _sequencer.Invoke();
-//         END_METHOD
-       
-//         METHOD PRIVATE PrepareSequence
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#JustExecuteCall;
-//             _sequencer.Initialize(_context);
-//             _sequencer.Invoke();
-//             _sequencer.Run(_context);
-//             _context.Close();
-//         END_METHOD
-
-//         METHOD PRIVATE ExecuteSequence
-//             VAR_INPUT
-//                 CompleteStep : BOOL;
-//                 CompleteSequence : BOOL;
-//             END_VAR
-
-//             THIS.PrepareSequence();
-
-//             _context.Open();
- 
-//             _sequencer._CompleteStep := CompleteStep;
-//             _sequencer._CompleteSequence := CompleteSequence;
-
-//             _sequencer._stepLogic := eStepLogic#ExecuteSequence;
-//             _sequencer.Initialize(_context);
-//             _sequencer.Invoke();
-//             _sequencer.Run(_context);
-
-//             _context.Close();
-//         END_METHOD
-       
-//         {Test}
-//         METHOD PUBLIC should_be_in_idle
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC should_be_in_idle_after_initialization
-//             THIS.InitializeSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC Invoke_and_Run_Call_when_idle_should_transit_to_configuring
-//             THIS.InitializeSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _sequencer.Invoke();
-//             _sequencer.Run(_context);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC Run_Call_when_configuring_should_transit_to_running
-//             THIS.InitializeSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _sequencer.Invoke();
-//             _sequencer.Run(_context);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             _sequencer.Run(_context);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC order_of_steps_should_be_assigned_after_first_sequence_cycle
-//             THIS.InvokeSequence();
-//             _sequencer._stepLogic := eStepLogic#JustExecuteCall;
-//             _sequencer.Run(_context);
-//              Assert.Equal(ULINT#1,_sequencer._step_1.Order);
-//              Assert.Equal(ULINT#2,_sequencer._step_2.Order);
-//              Assert.Equal(ULINT#3,_sequencer._step_3.Order);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC no_step_should_be_executed_when_configuring
-//             THIS.InvokeSequence();
-//             _sequencer._stepLogic := eStepLogic#None;
-//             _sequencer.Run(_context);
-//             // Configuring steps no step should execute
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE,_sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE,_sequencer._step_3.Execute(_sequencer));           
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC Execute_should_return_true_when_the_step_is_executing
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(TRUE , _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC IsActive_should_be_true_when_the_step_is_in_the_order_of_the_execution
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             Assert.Equal(TRUE , _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_3.IsActive);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC Currently_executed_step_should_be_Busy
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             Assert.Equal(TRUE , _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC All_steps_except_the_currently_executed_one_should_be_Disabled
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDisabled);
-//             Assert.Equal(TRUE , _sequencer._step_2.IsDisabled);
-//             Assert.Equal(TRUE , _sequencer._step_3.IsDisabled);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC MoveNext_should_set_currently_executed_step_to_Done
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE, _sequencer._step_1.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC MoveNext_should_reset_the_Busy_state_of_the_currently_executed_step
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(TRUE, _sequencer._step_1.IsBusy());
-//             _sequencer.MoveNext();
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC MoveNext_should_increment_the_Current_Order
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer.MoveNext();
-//             Assert.Equal(ULINT#2, _sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC MoveNext_should_trigger_the_execution_of_the_following_step
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(TRUE, _sequencer._step_1.Execute(_sequencer));
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(TRUE, _sequencer._step_2.Execute(_sequencer));
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE, _sequencer._step_3.Execute(_sequencer));  
-//             _context.Close();
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC RequestStep_should_not_affect_the_sequence_when_the_coordinator_is_in_idle
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _sequencer.RequestStep(_sequencer._step_3); 
-//             _sequencer.Open();
-//             // Configuring steps no step should execute
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC RequestStep_should_not_affect_the_sequence_when_the_coordinator_is_in_configuring
-//             THIS.InvokeSequence();
-
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _sequencer.Open();
-//             // Configuring steps no step should execute
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             _sequencer.RequestStep(_sequencer._step_3); 
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(TRUE , _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));          
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RequestStep_should_set_currently_executed_step_to_Done
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             Assert.Equal(TRUE, _sequencer._step_1.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RequestStep_should_reset_the_Busy_state_of_the_currently_executed_step
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(TRUE, _sequencer._step_1.IsBusy());
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RequestStep_should_change_the_Current_Order_to_the_order_of_the_required_step
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             Assert.Equal(_sequencer._step_3.GetStepOrder(), _sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC RequestStep_should_start_the_execution_of_the_required_step_when_the_coordinator_is_running
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(TRUE , _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             _context.Close();
-
-//             _context.Open();
-//            _sequencer.Open();
-//             // RequestStep should finish execution of the _stepOne and start the execution of the _stepThree
-//             _sequencer.RequestStep(_sequencer._step_3); 
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(TRUE , _sequencer._step_3.Execute(_sequencer));          
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // RequestStep should finish execution of the _stepThree and start the execution of the _stepTwo
-//             _sequencer.RequestStep(_sequencer._step_2); 
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(TRUE,  _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));          
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC Step_order_assignement_should_be_performed_even_when_the_steps_are_disabled
-//             THIS.InvokeSequence();
-//             _sequencer.Open();
-//             Assert.Equal(ULINT#0,_sequencer._step_1.GetStepOrder());
-//             Assert.Equal(ULINT#0,_sequencer._step_2.GetStepOrder());
-//             Assert.Equal(ULINT#0,_sequencer._step_3.GetStepOrder());
-//             // Configuring steps no step should execute no mather if Enabled or Disabled
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer,FALSE));
-//             Assert.Equal(FALSE,_sequencer._step_2.Execute(_sequencer,FALSE));
-//             Assert.Equal(FALSE,_sequencer._step_3.Execute(_sequencer,FALSE));  
-
-//             Assert.Equal(ULINT#1,_sequencer._step_1.GetStepOrder());
-//             Assert.Equal(ULINT#2,_sequencer._step_2.GetStepOrder());
-//             Assert.Equal(ULINT#3,_sequencer._step_3.GetStepOrder());
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC Disabled_step_should_be_skipped_even_when_it_is_in_the_order_of_the_execution
-//             THIS.PrepareSequence();
-
-//             // Steps are configured, so the first Enabled step should execute
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(ULINT#1,_sequencer.CurrentOrder);
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer,FALSE));
-//             Assert.Equal(ULINT#2,_sequencer.CurrentOrder);
-//             Assert.Equal(TRUE,_sequencer._step_2.Execute(_sequencer,TRUE));
-//             Assert.Equal(FALSE,_sequencer._step_3.Execute(_sequencer,TRUE));  
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC RequestStep_should_not_start_the_disabled_step_but_the_next_one_enabled
-//             THIS.PrepareSequence();
-
-//            // Steps are configured, so the first Enabled step (in this case _stepTwo) should be executed
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer,FALSE));
-//             Assert.Equal(TRUE ,_sequencer._step_2.Execute(_sequencer,TRUE));
-//             Assert.Equal(FALSE,_sequencer._step_3.Execute(_sequencer,TRUE));  
-//             _context.Close();
-
-//             // After MoveNext() method is called, _stepThree should start to be executed, as it is Enabled
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer,FALSE));
-//             Assert.Equal(TRUE ,_sequencer._step_2.Execute(_sequencer,TRUE));
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE ,_sequencer._step_3.Execute(_sequencer,TRUE));  
-//             _context.Close();
-
-//             // RequestStep to _stepOne should finish the execution of the _stepThree and prepare for the execution of the _stepOne
-//             // As _stepOne is disabled, its next proceeding step enabled (in our cas _stepTwo) starts to be executed
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.RequestStep(_sequencer._step_1);
-//             Assert.Equal(ULINT#1,_sequencer.CurrentOrder);
-//             Assert.Equal(FALSE,_sequencer._step_1.Execute(_sequencer,FALSE));
-//             Assert.Equal(ULINT#2,_sequencer.CurrentOrder);
-//             Assert.Equal(TRUE,_sequencer._step_2.Execute(_sequencer,TRUE));
-//             Assert.Equal(FALSE,_sequencer._step_3.Execute(_sequencer,TRUE));  
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC step_called_more_then_once_inside_the_running_sequence_should_not_be_executed
-//             VAR 
-//                 StepOrderLastValue : ULINT;
-//             END_VAR
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             //First sequence run, no step is executed
-//             THIS.InvokeSequence();
-//             _sequencer._stepLogic := eStepLogic#MAIN_123;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             StepOrderLastValue :=  _sequencer._orderCounter;
-//             //Second sequence run, steps are going already to be executed.
-//             //Steps are called in the order: step_1, step_2, step_3.
-//             //Step body should be executed for step_1, step_2 and step_3
-//             //Sequence should stay in the Idle state as the CompleteSequence() was called on running sequence
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#MAIN_123;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#6, _sequencer._orderCounter - StepOrderLastValue);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             StepOrderLastValue := _sequencer._orderCounter;
-//             //First sequence run after CompleteSequence() call on running sequence
-//             //No steps are going to be executed, as the orders of the steps need to be assign again
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#MAIN_123;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter - StepOrderLastValue);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             StepOrderLastValue := _sequencer._orderCounter;
-//             //Steps are called in the order: step_1,step_2, step_2.
-//             //Step body should be executed only for step_1 and for first call of the step_2 
-//             //Sequence should stay in the Idle state as the CompleteSequence() was called on running sequence
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#MAIN_122;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#3, _sequencer._orderCounter - StepOrderLastValue);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC step_called_more_then_once_inside_the_configuring_sequence_should_set_the_sequence_to_idle //TODO error state
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             //First sequence run, no step is executed
-//             THIS.InvokeSequence();
-//             _sequencer._stepLogic := eStepLogic#MAIN_12x;
-//             _sequencer.Run(_context);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_3.IsActive); 
-//             Assert.Equal(ULINT#1, _sequencer._step_1.Order);
-//             Assert.Equal(ULINT#2, _sequencer._step_2.Order);
-//             Assert.Equal(ULINT#0, _sequencer._step_3.Order); 
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             _sequencer._step_2.Execute(_sequencer);
-//             _context.Close();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             Assert.Equal(FALSE, _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_3.IsActive); 
-//             Assert.Equal(ULINT#1, _sequencer._step_1.Order);
-//             Assert.Equal(ULINT#0, _sequencer._step_2.Order);
-//             Assert.Equal(ULINT#0, _sequencer._step_3.Order); 
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC step_that_was_not_called_in_the_previous_PLC_cycle_should_not_be_executed_even_if_it_is_on_the_order_of_the_execution
-//             VAR 
-//                 StepOrderLastValue : ULINT;
-//             END_VAR
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             //First sequence run, no step is executed
-//             THIS.InvokeSequence();
-//             _sequencer._stepLogic := eStepLogic#MAIN_123;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             StepOrderLastValue := _sequencer._orderCounter;
-//             //Second sequence run, steps are going already to be executed.
-//             //Steps are called in the order: step_1, step_2.
-//             //Step body should be executed for step_1 and step_2.
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#MAIN_12x;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#3, _sequencer._orderCounter - StepOrderLastValue);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-//             StepOrderLastValue := _sequencer._orderCounter;
-//             // Assert.Equal(TRUE,_sequencer.IsInOrderOfExecution(_step_3));
-//             Assert.Equal(_sequencer.CurrentOrder, _sequencer._step_3.Order);
-//             //Steps are called in the order: step_1,step_2, step_3.
-//             //Step_1 and step_2 has been already executed. 
-//             //Step_3 is in the order of the execution, but it is not going to be executed, as it was not called in the previous PLC cycle.
-//             _context.Open();
-//             _sequencer._stepLogic := eStepLogic#MAIN_123;
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#0, _sequencer._orderCounter - StepOrderLastValue);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD    
-        
-//         {Test}        
-//         METHOD PUBLIC CompleteSequence_should_set_currently_executed_step_to_Done
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(TRUE, _sequencer._step_3.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC CompleteSequence_should_reset_the_Busy_state_of_the_currently_executed_step
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(TRUE, _sequencer._step_3.IsBusy());
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC CompleteSequence_should_set_the_Current_Order_to_1
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC CompleteSequence_should_set_the_coordinator_state_to_Idle
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC CompleteSequence_should_set_the_first_step_in_the_sequence_as_active_after_two_PLC_cycle
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(TRUE, _sequencer._step_3.IsBusy());
-//             _sequencer.CompleteSequence();
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configuring again
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             Assert.Equal(FALSE, _sequencer._step_1.IsActive);              
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configuredand executed again
-//             Assert.Equal(TRUE , _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             Assert.Equal(TRUE , _sequencer._step_1.IsActive);              
-//             _context.Close();
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC currently_executed_step_should_indicate_its_state_as_busy
-//             THIS.PrepareSequence();
-            
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring, _sequencer.GetCoordinatorState()));
-//             Assert.Equal(TRUE, THIS.Equal(eAxoTaskState#Disabled, _sequencer._step_1.GetState()));
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(TRUE ,  _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(TRUE , THIS.Equal(eAxoTaskState#Busy, _sequencer._step_1.GetState()));
-//             Assert.Equal(TRUE , _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_1.HasError());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC when_sequence_is_configuring_all_steps_should_be_disabled
-//             THIS.InvokeSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _sequencer.Open();
-//             // Configuring steps no step should execute
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));           
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             Assert.Equal(TRUE , _sequencer._step_1.GetState() = eAxoTaskState#Disabled);
-//             Assert.Equal(TRUE , _sequencer._step_2.GetState() = eAxoTaskState#Disabled);
-//             Assert.Equal(TRUE , _sequencer._step_3.GetState() = eAxoTaskState#Disabled);
-//             _context.Close();
-//             Assert.Equal(TRUE , THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC step_exited_with_move_next_method_should_indicate_its_state_as_done
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(TRUE ,  _sequencer._step_1.Execute(_sequencer));
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE , THIS.Equal(eAxoTaskState#Done, _sequencer._step_1.GetState()));
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_1.HasError());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC step_exited_with_move_next_method_should_indicate_its_state_as_done_even_in_another_PLC_cycle
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             // Steps are configured first step should execute
-//             Assert.Equal(TRUE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(TRUE, _sequencer._step_1.IsBusy());
-//             _sequencer.MoveNext();
-//             Assert.Equal(TRUE, _sequencer._step_1.IsDone());
-//             Assert.Equal(TRUE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(TRUE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             _context.Close();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsDone());
-//             Assert.Equal(TRUE , _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(TRUE , _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-//             _sequencer.MoveNext();
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_2.IsDone());
-//             Assert.Equal(TRUE , _sequencer._step_3.Execute(_sequencer));  
-//             Assert.Equal(TRUE , _sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             _context.Close();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(TRUE , _sequencer._step_3.Execute(_sequencer)); 
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_2.IsDone());
-//             Assert.Equal(TRUE , _sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC sequence_should_be_in_configuring_state_after_complete_sequence_and_all_steps_should_be_restored
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.CompleteSequence();
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-
-//             // Configuring steps no step should execute
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));           
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             Assert.Equal(TRUE , _sequencer._step_1.GetState() = eAxoTaskState#Disabled);
-//             Assert.Equal(TRUE , _sequencer._step_2.GetState() = eAxoTaskState#Disabled);
-//             Assert.Equal(TRUE , _sequencer._step_3.GetState() = eAxoTaskState#Disabled);
-//             _context.Close();
-//             Assert.Equal(TRUE , THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC multiple_calls_of_the_method_IsCalledJustOnceInThisPlcCycle_should_return_same_value
-//             THIS.PrepareSequence();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             Assert.Equal(TRUE , _sequencer._step_1.IsCalledJustOnceInThisPlcCycle());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsCalledJustOnceInThisPlcCycle());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsCalledJustOnceInThisPlcCycle());
-//             Assert.Equal(FALSE, _sequencer._step_3.IsCalledJustOnceInThisPlcCycle());
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC OpenCycleCount_should_be_one_greather_than_ClosedCycleCount_before_calling_context_Close
-//             _context.Open();
-//             Assert.Equal(_context.OpenCycleCount() ,_context.ClosedCycleCount() + ULINT#1);
-//             _context.Close();
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC OpenCycleCount_should_the_same_as_ClosedCycleCount_after_calling_context_Close
-//             _context.Open();
-//             _context.Close();
-//             Assert.Equal(_context.OpenCycleCount() ,_context.ClosedCycleCount());
-//         END_METHOD
-
-//         {Test}
-//         METHOD PUBLIC should_return_the_continous_stepping_mode
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#Continous));
-//         END_METHOD
-        
-//         {Test}
-//         METHOD PUBLIC should_return_the_step_by_step_stepping_mode
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//         END_METHOD
-        
-//         {Test}
-//         METHOD PUBLIC should_return_the_cyclic_mode
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SequenceMode, eAxoSequenceMode#Cyclic));
-//         END_METHOD
-        
-//         {Test}
-//         METHOD PUBLIC should_return_the_runonce_mode
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SequenceMode, eAxoSequenceMode#RunOnce));
-//         END_METHOD
-        
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_set_currently_executed_step_to_Done
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             Assert.Equal(FALSE, _sequencer._step_3.IsDone());
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(TRUE, _sequencer._step_3.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_reset_the_Busy_state_of_the_currently_executed_step
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             Assert.Equal(TRUE, _sequencer._step_3.IsBusy());
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(FALSE, _sequencer._step_3.IsBusy());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_set_the_Current_Order_to_1
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_set_the_coordinator_state_to_Idle
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_set_the_CurrentOrder_to_1
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             _context.Close();
-
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_should_stops_the_execution_of_the_active_step_in_the_next_PLC_cycles
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             Assert.Equal(FALSE, _sequencer._step_1.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_2.Execute(_sequencer));
-//             Assert.Equal(FALSE, _sequencer._step_3.Execute(_sequencer));  
-//             _context.Close();
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC RunOnce_mode_CompleteSequence_coordinator_state_should_stay_in_Idle_in_the_next_PLC_cycles
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);  
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _context.Close();
-
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);  
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Idle , _sequencer.GetCoordinatorState()));
-//             _context.Close();
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC should_return_number_of_steps_in_our_case_three
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(ULINT#3, _sequencer.GetNumberOfConfiguredSteps());
-//         END_METHOD
-        
-//         {Test}        
-//         METHOD PUBLIC all_stepping_commands_should_be_disabled_when_StepByStep_mode_is_not_running
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(TRUE,_sequencer.StepForwardCommand.IsDisabled);
-//             Assert.Equal(TRUE,_sequencer.StepIn.IsDisabled);
-//             Assert.Equal(TRUE,_sequencer.StepBackwardCommand.IsDisabled);
-//         END_METHOD
-        
-//         {Test}        
-//         METHOD PUBLIC all_stepping_commands_should_be_disabled_when_Sequencer_is_not_running_mode
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.PrepareSequence();
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Configuring , _sequencer.GetCoordinatorState()));
-//             Assert.Equal(TRUE,_sequencer.StepForwardCommand.IsDisabled);
-//             Assert.Equal(TRUE,_sequencer.StepIn.IsDisabled);
-//             Assert.Equal(TRUE,_sequencer.StepBackwardCommand.IsDisabled);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_and_StepIn_commands_should_not_be_disabled_when_Sequencer_is_running_mode
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.ExecuteSequence(TRUE,TRUE);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDisabled);
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsDisabled);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_command_should_not_be_disabled_when_Sequencer_is_running_mode_and_CurrentOrder_is_greather_then_one
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.ExecuteSequence(TRUE,TRUE);
-//             _sequencer.RequestStep(_sequencer._step_2);
-//             THIS.ExecuteSequence(TRUE,TRUE);
-//             Assert.Equal(TRUE, THIS.Equal(AxoCoordinatorStates#Running , _sequencer.GetCoordinatorState()));
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsDisabled);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepInCommand_should_invoke_the_current_step
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             Assert.Equal(TRUE,_sequencer._step_1.IsActive);
-//             Assert.Equal(TRUE,_sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsDone());
-
-//             // Act
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             // Assert
-//             Assert.Equal(TRUE , _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsReady());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             Assert.Equal(TRUE , _sequencer.StepIn.IsBusy());
-//             Assert.Equal(FALSE, _sequencer.StepIn.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepInCommand_should_invoke_the_current_step_if_Current_step_is_Done_StepIn_should_be_also_Done
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             Assert.Equal(TRUE , _sequencer._step_1.IsActive);
-//             Assert.Equal(TRUE , _sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer.StepIn.IsBusy());
-//             Assert.Equal(FALSE, _sequencer.StepIn.IsDone());
-
-//             // Act
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(TRUE,FALSE);
-
-//             // Assert
-//             Assert.Equal(FALSE, _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsDone());
-//             Assert.Equal(FALSE, _sequencer.StepIn.IsBusy());
-//             Assert.Equal(TRUE , _sequencer.StepIn.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC when_step_by_step_mode_is_switched_on_during_any_step_execution_this_step_should_continue_its_execution
-//             // Arrange
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             Assert.Equal(TRUE , _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsReady());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsDone());
- 
-//             Assert.Equal(FALSE, _sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-
-//             // Act
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-//             THIS.ExecuteSequence(TRUE,FALSE);
-
-//             // Assert
-//             Assert.Equal(FALSE, _sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE, _sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE, _sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE , _sequencer._step_1.IsDone());
- 
-//             Assert.Equal(TRUE , _sequencer._step_2.IsActive);
-//             Assert.Equal(TRUE , _sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE, _sequencer._step_2.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDone());
-            
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsReady());
-//             Assert.Equal(TRUE ,_sequencer.StepIn.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsDone());
-
-//             Assert.Equal(TRUE ,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(TRUE ,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsDone());
-
-//             Assert.Equal(FALSE,_sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-
-//             _previousOrder := _sequencer.CurrentOrder;
-            
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDone());
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(TRUE ,_sequencer.StepForwardCommand.IsDone());
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(FALSE,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsDone());
-
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsActive);
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-
-//             Assert.Equal(_previousOrder + ULINT#1  ,_sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_should_restore_the_currently_executing_step
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(TRUE ,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsDone());
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             _context.Close();
-
-//             // Assert
-//             Assert.Equal(FALSE,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_should_prepare_following_step_to_be_ready_to_execute
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(FALSE,_sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsActive);
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_command_should_be_in_done_state_after_succesfull_execution
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDone());
-            
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-
-//             //Assert
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDone());
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(TRUE ,_sequencer.StepForwardCommand.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_command_should_increment_Current_order_if_its_value_is_lower_then_number_of_steps
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _previousOrder := _sequencer.CurrentOrder;
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             _context.Close();
-            
-//             //Assert
-//             Assert.Equal(_previousOrder + ULINT#1,_sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_command_should_not_increment_Current_order_if_its_value_is_equal_to_number_of_steps
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _previousOrder := _sequencer.CurrentOrder;
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepForwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-//             _context.Close();
-            
-//             //Assert
-//             Assert.Equal(_previousOrder,_sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepForward_command_should_be_disabled_when_CurrentOrder_is_equal_to_last_step_order
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(ULINT#3,_sequencer.CurrentOrder);
-//             Assert.Equal(TRUE ,_sequencer.StepForwardCommand.IsDisabled);
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepForwardCommand.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsDone());
-            
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsReady());
-//             Assert.Equal(TRUE ,_sequencer.StepIn.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepIn.IsDone());
-
-//             Assert.Equal(TRUE ,_sequencer._step_3.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_3.IsReady());
-//             Assert.Equal(TRUE ,_sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsDone());
-
-//             Assert.Equal(FALSE,_sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-
-//             _previousOrder := _sequencer.CurrentOrder;
-            
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepBackwardCommand.Invoke();
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsDone());
-//             _sequencer._step_1.Execute(_sequencer);
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(TRUE ,_sequencer.StepBackwardCommand.IsDone());
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(FALSE,_sequencer._step_3.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_3.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsDone());
-
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsActive);
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-
-//             Assert.Equal(_previousOrder - ULINT#1  ,_sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_should_restore_the_currently_executing_step
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer._step_3.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_3.IsReady());
-//             Assert.Equal(TRUE ,_sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsDone());
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepBackwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(FALSE,_sequencer._step_3.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_3.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_3.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_should_prepare_previous_step_to_be_ready_to_execute
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(FALSE,_sequencer._step_2.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-            
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepBackwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsActive);
-//             Assert.Equal(TRUE ,_sequencer._step_2.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_2.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_command_should_be_in_done_state_after_succesfull_execution
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(TRUE ,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsDone());
-
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepBackwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(TRUE ,_sequencer.StepBackwardCommand.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_command_should_decrement_Current_order_if_its_value_is_higher_then_one
-//             VAR
-//                 _previousOrder : ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.RequestStep(_sequencer._step_3);
-//             _sequencer.StepIn.Invoke();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             _previousOrder := _sequencer.CurrentOrder;
-            
-//             // Act
-//             _context.Open();
-//             _sequencer.Open();
-//             _sequencer.StepBackwardCommand.Invoke();
-//             _sequencer._step_1.Execute(_sequencer);
-//             _sequencer._step_2.Execute(_sequencer);
-//             _sequencer._step_3.Execute(_sequencer);
-
-//             // Assert
-//             Assert.Equal(_previousOrder - ULINT#1  ,_sequencer.CurrentOrder);
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepBackward_command_should_be_disabled_when_CurrentOrder_is_equal_to_last_step_order
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-
-//             Assert.Equal(ULINT#1,_sequencer.CurrentOrder);
-//             Assert.Equal(TRUE ,_sequencer.StepBackwardCommand.IsDisabled);
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsReady());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsBusy());
-//             Assert.Equal(FALSE,_sequencer.StepBackwardCommand.IsDone());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_be_triggered_when_sequence_starts
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_not_be_triggered_when_sequence_has_been_already_started
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_be_triggered_when_sequence_starts_even_in_step_by_step_mode
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_not_be_triggered_when_sequence_has_been_already_started_even_in_step_by_step_mode
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_be_triggered_when_sequence_starts_even_in_run_once_mode
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_not_be_triggered_when_sequence_has_been_already_started_even_in_run_once_mode
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_be_triggered_when_sequence_starts_even_in_run_once_mode_and_step_by_step_mode
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnBeforeSequenceStart_should_not_be_triggered_when_sequence_has_been_already_started_even_in_run_once_mode_and_step_by_step_mode
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             THIS._counter :=  _sequencer.GetOnBeforeSequenceStartCounter();
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             Assert.Equal(THIS._counter,_sequencer.GetOnBeforeSequenceStartCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_be_triggered_when_CompleteSequence_is_called
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_not_be_triggered_when_CompleteSequence_was_already_called
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.CompleteSequence();
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_be_triggered_when_CompleteSequence_is_called_even_in_step_by_step_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_not_be_triggered_when_CompleteSequence_was_already_called_even_in_step_by_step_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             _sequencer.CompleteSequence();
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_be_triggered_when_CompleteSequence_is_called_even_in_run_once_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_not_be_triggered_when_CompleteSequence_was_already_called_even_in_run_once_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.CompleteSequence();
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_be_triggered_when_CompleteSequence_is_called_even_in_run_once_mode_and_step_by_step_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter + ULINT#1,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC OnCompleteSequence_should_not_be_triggered_when_CompleteSequence_was_already_called_even_in_run_once_mode_and_step_by_step_mode
-//             THIS.ExecuteSequence(TRUE,FALSE);
-//             _sequencer.SequenceMode := eAxoSequenceMode#RunOnce;
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             _sequencer.CompleteSequence();
-//             THIS._counter :=  _sequencer.GetOnCompleteSequenceCounter();
-//             _sequencer.CompleteSequence();
-//             Assert.Equal(THIS._counter,_sequencer.GetOnCompleteSequenceCounter());
-//         END_METHOD
-
-//         {Test}        
-//         METHOD PUBLIC StepInCommand_should_restore_and_invoke_the_current_step_when_it_was_in_error_state
-//             VAR 
-//                 count :ULINT;
-//             END_VAR
-//             // Arrange
-//             _sequencer.SteppingMode := eAxoSteppingMode#StepByStep;
-//             Assert.Equal(TRUE ,THIS.Equal(_sequencer.SteppingMode, eAxoSteppingMode#StepByStep));
-
-//             THIS.ExecuteSequence(FALSE,FALSE);
-//             _sequencer.StepIn.Invoke();
-
-//             THIS.PrepareSequence();
-//             _context.Open();
-//             _sequencer.Open();
-
-//             IF _sequencer._step_1.Execute(_sequencer) THEN
-//                 count := count + ULINT#1;
-//                 _sequencer._step_1.ThrowWhen(TRUE);
-//             END_IF;
-//             _sequencer._step_2.Execute(_sequencer); 
-//             _sequencer._step_3.Execute(_sequencer); 
-//             _context.Close();
-
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             Assert.Equal(TRUE,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(FALSE,_sequencer._step_1.IsBusy());
-//             Assert.Equal(TRUE,_sequencer._step_1.HasError());
-//             Assert.Equal(ULINT#1, count);
-
-//             // Act
-//             _sequencer.StepIn.Invoke();
-
-//             THIS.PrepareSequence();
-//             _context.Open();
-//             _sequencer.Open();
-
-//             IF _sequencer._step_1.Execute(_sequencer) THEN
-//                 count := count + ULINT#1;
-//             END_IF;
-//             _sequencer._step_2.Execute(_sequencer); 
-//             _sequencer._step_3.Execute(_sequencer); 
-//             _context.Close();
-
-//             // Assert
-//             Assert.Equal(ULINT#1, _sequencer.CurrentOrder);
-//             Assert.Equal(TRUE,_sequencer._step_1.IsActive);
-//             Assert.Equal(FALSE,_sequencer._step_1.IsReady());
-//             Assert.Equal(TRUE,_sequencer._step_1.IsBusy());
-//             Assert.Equal(FALSE,_sequencer._step_1.HasError());
-//             Assert.Equal(ULINT#2, count);
-//         END_METHOD
-        
-//         {Test}        
-//         METHOD PUBLIC no_logic_should_be_executed_when_sequencer_is_not_running
-//             _sequencer._stepLogic := eStepLogic#LogicOutsideSteps;
-//             _context.Open();
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#0, _sequencer._counter);
-//         END_METHOD
- 
-//         {Test}        
-//         METHOD PUBLIC logic_should_be_executed_when_sequencer_is_running
-//             _sequencer._stepLogic := eStepLogic#LogicOutsideSteps;
-//             THIS.InvokeSequence();
-//             _sequencer.Run(_context);
-//             _context.Close();
-//             Assert.Equal(ULINT#1, _sequencer._counter);
-//         END_METHOD
- 
-//     END_CLASS  
-// END_NAMESPACE
 

--- a/src/core/ctrl/test/AxoCoordination/AxoSequencerTests.st
+++ b/src/core/ctrl/test/AxoCoordination/AxoSequencerTests.st
@@ -1,6 +1,10 @@
 USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Core.AxoSequencer_Tests  
     
@@ -10,6 +14,13 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
                 ;
             END_METHOD               
     END_CLASS     
+
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
 
     {S7.extern=ReadWrite}
     CLASS MySequencer EXTENDS AxoSequencer
@@ -39,6 +50,7 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
     CLASS SequencerTests
         VAR PROTECTED        
             _context   : TestContext;
+            _rootObject : TestObject;
             _sequencer : MySequencer;
             _step_1    : AxoStep;
             _step_2    : AxoStep;
@@ -85,15 +97,16 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
         END_METHOD
                 
         METHOD PRIVATE InitializeSequence
+            _rootObject.InitializeWithContext(_context);
             _context.Open();
-            _sequencer.Initialize(_context);
+            _sequencer.Initialize(_rootObject);
         END_METHOD
        
         METHOD PRIVATE InvokeSequence
             THIS.InitializeSequence();
-            _step_1.Initialize(_context);
-            _step_2.Initialize(_context);
-            _step_3.Initialize(_context);        
+            _step_1.Initialize(_rootObject);
+            _step_2.Initialize(_rootObject);
+            _step_3.Initialize(_rootObject);        
             _sequencer.Invoke();
         END_METHOD
        
@@ -138,6 +151,8 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
        
         VAR PROTECTED        
             _contextClean       :   TestContext;
+            _rtc                :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm                :   AXOpen.Core.Dummies.MockAxoRtm;
             _sequencerClean     :   MySequencer;
             _step_1Clean        :   AxoStep;
             _step_2Clean        :   AxoStep;
@@ -150,6 +165,10 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
         {TestSetup}
         METHOD PUBLIC TestSetup
             _context        :=  _contextClean;
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
             _sequencer      :=  _sequencerClean;
             _step_1         :=  _step_1Clean;
             _step_2         :=  _step_2Clean;
@@ -512,10 +531,10 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
         END_METHOD
 
         METHOD MAIN_12x 
-            _step_1.Initialize(_context);
-            _step_2.Initialize(_context);
-            _step_3.Initialize(_context);
-            _sequencer.Initialize(_context);
+            _step_1.Initialize(_rootObject);
+            _step_2.Initialize(_rootObject);
+            _step_3.Initialize(_rootObject);
+            _sequencer.Initialize(_rootObject);
             _sequencer.Invoke();
 
             _sequencer.Open();
@@ -1721,10 +1740,10 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
                 count :ULINT;
             END_VAR
             _context.Open();
-            _sequencer.Initialize(_context);
-            _step_1.Initialize(_context);
-            _step_2.Initialize(_context);
-            _step_3.Initialize(_context);        
+            _sequencer.Initialize(_rootObject);
+            _step_1.Initialize(_rootObject);
+            _step_2.Initialize(_rootObject);
+            _step_3.Initialize(_rootObject);        
 
             IF _sequencer.Open() THEN
                 _step_1.Execute(_sequencer);
@@ -1742,10 +1761,10 @@ NAMESPACE AXOpen.Core.AxoSequencer_Tests
                 count :ULINT;
             END_VAR
             _context.Open();
-            _sequencer.Initialize(_context);
-            _step_1.Initialize(_context);
-            _step_2.Initialize(_context);
-            _step_3.Initialize(_context);        
+            _sequencer.Initialize(_rootObject);
+            _step_1.Initialize(_rootObject);
+            _step_2.Initialize(_rootObject);
+            _step_3.Initialize(_rootObject);        
 
             _sequencer.Invoke();
 
@@ -1925,14 +1944,14 @@ END_NAMESPACE
                 
 //         METHOD PRIVATE InitializeSequence
 //             _context.Open();
-//             _sequencer.Initialize(_context);
+//             _sequencer.Initialize(_rootObject);
 //         END_METHOD
        
 //         METHOD PRIVATE InvokeSequence
 //             THIS.InitializeSequence();
-//             _step_1.Initialize(_context);
-//             _step_2.Initialize(_context);
-//             _step_3.Initialize(_context);        
+//             _step_1.Initialize(_rootObject);
+//             _step_2.Initialize(_rootObject);
+//             _step_3.Initialize(_rootObject);        
 //             _sequencer.Invoke();
 //         END_METHOD
        
@@ -2313,10 +2332,10 @@ END_NAMESPACE
 //         END_METHOD
 
 //         METHOD MAIN_12x 
-//             _step_1.Initialize(_context);
-//             _step_2.Initialize(_context);
-//             _step_3.Initialize(_context);
-//             _sequencer.Initialize(_context);
+//             _step_1.Initialize(_rootObject);
+//             _step_2.Initialize(_rootObject);
+//             _step_3.Initialize(_rootObject);
+//             _sequencer.Initialize(_rootObject);
 //             _sequencer.Invoke();
 
 //             _sequencer.Open();
@@ -3521,10 +3540,10 @@ END_NAMESPACE
 //                 count :ULINT;
 //             END_VAR
 //             _context.Open();
-//             _sequencer.Initialize(_context);
-//             _step_1.Initialize(_context);
-//             _step_2.Initialize(_context);
-//             _step_3.Initialize(_context);        
+//             _sequencer.Initialize(_rootObject);
+//             _step_1.Initialize(_rootObject);
+//             _step_2.Initialize(_rootObject);
+//             _step_3.Initialize(_rootObject);        
 
 //             IF _sequencer.Open() THEN
 //                 _step_1.Execute(_sequencer);
@@ -3542,10 +3561,10 @@ END_NAMESPACE
 //                 count :ULINT;
 //             END_VAR
 //             _context.Open();
-//             _sequencer.Initialize(_context);
-//             _step_1.Initialize(_context);
-//             _step_2.Initialize(_context);
-//             _step_3.Initialize(_context);        
+//             _sequencer.Initialize(_rootObject);
+//             _step_1.Initialize(_rootObject);
+//             _step_2.Initialize(_rootObject);
+//             _step_3.Initialize(_rootObject);        
 
 //             _sequencer.Invoke();
 

--- a/src/core/ctrl/test/AxoCoordination/AxoStepTests.st
+++ b/src/core/ctrl/test/AxoCoordination/AxoStepTests.st
@@ -1,7 +1,10 @@
-USING AXOpen.Logging;
+USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
-USING AxUnit;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AxOpenCoreAssert
     FUNCTION Equal
@@ -24,21 +27,32 @@ NAMESPACE AXOpen.Core.AxoStep_Tests
             END_METHOD               
     END_CLASS         
 
+
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
+
+
     {TestFixture}
     {S7.extern=ReadWrite}
     CLASS StepTests
         VAR PROTECTED
             _context    : TestContext;
+            _rootObject : TestObject;
             _stepOne    : AxoStep;
             _stepTwo    : AxoStep;
             _stepThree  : AxoStep;
             _sequencer  : AxoSequencer;
         END_VAR  
         METHOD PRIVATE Initialize
-            _sequencer.Initialize(_context);
-            _stepOne.Initialize(_context);
-            _stepTwo.Initialize(_context);
-            _stepThree.Initialize(_context);
+            _rootObject.InitializeWithContext(_context);
+            _sequencer.Initialize(_rootObject);
+            _stepOne.Initialize(_rootObject);
+            _stepTwo.Initialize(_rootObject);
+            _stepThree.Initialize(_rootObject);
         END_METHOD
         METHOD Equal : BOOL
             VAR_INPUT
@@ -50,6 +64,8 @@ NAMESPACE AXOpen.Core.AxoStep_Tests
 
         VAR PRIVATE
             _contextClean   : TestContext;
+            _rtc            :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm            :   AXOpen.Core.Dummies.MockAxoRtm;
             _stepOneClean   : AxoStep;
             _stepTwoClean   : AxoStep;
             _stepThreeClean : AxoStep;
@@ -59,6 +75,10 @@ NAMESPACE AXOpen.Core.AxoStep_Tests
         {TestSetup}
         METHOD PUBLIC TestSetup
             _context    :=  _contextClean;
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
             _stepOne    :=  _stepOneClean;
             _stepTwo    :=  _stepTwoClean;
             _stepThree  :=  _stepThreeClean;

--- a/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
+++ b/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
@@ -325,15 +325,15 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _suti._object._messenger.Activate();
             _suti._object._messenger.Serve(_suti._object);
             _suti.Close();
-            Assert.Equal(FALSE, _suti._object._messenger.IsActive);
-
-            //--Assert
-            //2nd
-            _suti.Open();
-            _suti._object._messenger.Activate();
-            _suti._object._messenger.Serve(_suti._object);
-            _suti.Close();
             Assert.Equal(TRUE, _suti._object._messenger.IsActive);
+
+            // //--Assert
+            // //2nd
+            // _suti.Open();
+            // _suti._object._messenger.Activate();
+            // _suti._object._messenger.Serve(_suti._object);
+            // _suti.Close();
+            // Assert.Equal(TRUE, _suti._object._messenger.IsActive);
         END_METHOD
 
         {Test}
@@ -371,15 +371,15 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _suti._object._messenger.ActivateOnCondition(TRUE);
             _suti._object._messenger.Serve(_suti._object);
             _suti.Close();
-            Assert.Equal(FALSE, _suti._object._messenger.IsActive);
-
-            //--Assert
-            //2nd
-            _suti.Open();
-            _suti._object._messenger.ActivateOnCondition(TRUE);
-            _suti._object._messenger.Serve(_suti._object);
-            _suti.Close();
             Assert.Equal(TRUE, _suti._object._messenger.IsActive);
+
+            // //--Assert
+            // //2nd
+            // _suti.Open();
+            // _suti._object._messenger.ActivateOnCondition(TRUE);
+            // _suti._object._messenger.Serve(_suti._object);
+            // _suti.Close();
+            // Assert.Equal(TRUE, _suti._object._messenger.IsActive);
         END_METHOD
 
         {Test}

--- a/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
+++ b/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
@@ -2,6 +2,7 @@ USING AXOpen.Core;
 USING AXOpen.Core;
 USING AxUnit;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
 USING AXOpen.Core;
 USING AXOpen.Logging;
 USING AXOpen.Messaging;
@@ -19,11 +20,12 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _object : TestObject;     
             _nested : NestedObject_L1;            
         END_VAR      
+
         VAR PRIVATE            
             NULL_RTC : _NULL_RTC;
-           
             _rtc : IAxoRtc;
-         END_VAR       
+            _NowUTC : LDATE_AND_TIME;
+        END_VAR       
 
         METHOD PUBLIC Open : ULINT
             _openCounter := _openCounter + ULINT#1;
@@ -61,6 +63,17 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc := Rtc;
         END_METHOD
         
+        METHOD INTERNAL SetNowUTC : LDATE_AND_TIME
+            VAR_INPUT
+                Set :  LDATE_AND_TIME;
+            END_VAR;
+            _NowUTC := Set;
+        END_METHOD
+
+        METHOD PUBLIC NowUTC : LDATE_AND_TIME    
+            NowUTC := _NowUTC;
+        END_METHOD       
+
         VAR PRIVATE
             NULL_LOGGER : _NULL_LOGGER;
         END_VAR    
@@ -69,11 +82,34 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
 
         VAR PRIVATE
             NULL_RTM : _NULL_RTM;
+            _rtm : IAxoRtm;
+            _elapsed : LTIME;
         END_VAR    
-        METHOD PUBLIC GetRtm : AXOpen.Rtm.IAxoRtm GetRtm := NULL_RTM; END_METHOD
-        METHOD PUBLIC InjectRtm VAR_INPUT inRtm : AXOpen.Rtm.IAxoRtm; END_VAR ; END_METHOD    
-    END_CLASS  
+        METHOD PUBLIC GetRtm : AXOpen.Rtm.IAxoRtm 
+            IF(_rtm <> NULL) THEN
+                GetRtm := _rtm;
+            ELSE
+                GetRtm := NULL_RTM;    
+            END_IF;   
+        END_METHOD
+        METHOD PUBLIC InjectRtm 
+            VAR_INPUT 
+                inRtm : AXOpen.Rtm.IAxoRtm; 
+            END_VAR 
+            _rtm := inRtm;
+        END_METHOD    
+        METHOD INTERNAL Elapsed : LTIME
+            Elapsed := _elapsed;
+        END_METHOD
 
+        METHOD PUBLIC SetElapsed : LTIME    
+            VAR_INPUT
+                Set :  LTIME;
+            END_VAR;
+            _elapsed := Set;
+        END_METHOD       
+    END_CLASS  
+   
     {S7.extern=ReadWrite}
     CLASS TestContextE EXTENDS Dummies.MockAxoContext
   
@@ -147,18 +183,32 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         VAR PRIVATE
             _suti : TestContextI;
             _sute : TestContextE;
+            // _rtc : AXOpen.Core.Dummies.MockAxoRtc;
             _rtc : AxoRtcMock;
+            _rtm : AXOpen.Core.Dummies.MockAxoRtm;
         END_VAR
 
         VAR
             _sutiClean : TestContextI;
-            _suteClean : TestContextE;            
+            _suteClean : TestContextE;      
+            _rootIObject : TestObject;
+            _rootEObject : TestObject;
+    
         END_VAR    
     
         {TestSetup}
         METHOD PUBLIC TestSetup
             _suti := _sutiClean;
+            _rtm.SetElapsed(LTIME#2s);
+            // _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            // _suti.InjectRtc(_rtc);
+            _suti.InjectRtm(_rtm);
+            _rootIObject.InitializeWithContext(_suti);
+
             _sute := _suteClean;     
+            // _sute.InjectRtc(_rtc);
+            _sute.InjectRtm(_rtm);
+            _rootEObject.InitializeWithContext(_suti);
         END_METHOD
 
         {TestTearDown}
@@ -214,7 +264,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         METHOD PUBLIC isactive_should_be_true_after_activate_call
             //--Act
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate();
             _suti.Close();
@@ -235,7 +285,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             FOR i := 0 TO 2 DO
                 _suti.Open();
-                _suti._nested.Initialize(_suti);
+                _suti._nested.InitializeWithContext(_suti);
                 _suti._nested._nestedObject_L2.Initialize(_suti._nested);
                 _suti._nested._nestedObject_L2._nestedObject_L3.Initialize(_suti._nested._nestedObject_L2);            
     
@@ -271,7 +321,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st PLC cycle
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Activate();
             _suti._object._messenger.Serve(_suti._object);
             _suti.Close();
@@ -290,7 +340,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         METHOD PUBLIC isactive_should_be_false_after_ActivateOnCondition_false_call
             //--Act
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(FALSE);
             _suti.Close();
@@ -303,7 +353,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         METHOD PUBLIC isactive_should_be_true_after_ActivateOnCondition_true_call
             //--Act
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE);
             _suti.Close();
@@ -317,7 +367,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st PLC cycle
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.ActivateOnCondition(TRUE);
             _suti._object._messenger.Serve(_suti._object);
             _suti.Close();
@@ -350,7 +400,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -388,7 +438,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -428,7 +478,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -455,7 +505,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -482,7 +532,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -509,7 +559,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -536,7 +586,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -563,7 +613,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -590,7 +640,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -617,7 +667,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -644,7 +694,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.Activate(expMessage.Category);
             _suti.Close();
@@ -667,7 +717,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -694,7 +744,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -721,7 +771,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -748,7 +798,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -775,7 +825,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -802,7 +852,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -829,7 +879,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -856,7 +906,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -883,7 +933,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -910,7 +960,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -937,7 +987,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -964,7 +1014,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -991,7 +1041,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -1018,7 +1068,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).DoNotRequireAcknowledgement();
             _suti.Close();
@@ -1045,7 +1095,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -1072,7 +1122,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).DoNotRequireAcknowledgement();
             _suti.Close();
@@ -1099,7 +1149,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -1126,7 +1176,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).DoNotRequireAcknowledgement();
             _suti.Close();
@@ -1153,7 +1203,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -1180,7 +1230,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).DoNotRequireAcknowledgement();
             _suti.Close();
@@ -1207,7 +1257,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category);
             _suti.Close();
@@ -1234,7 +1284,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).DoNotRequireAcknowledgement();
             _suti.Close();
@@ -1256,7 +1306,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             //--Act
             //1st-PLC cycle: Rising of the message
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE).RequireAcknowledgement();
             _suti.Close();
@@ -1288,7 +1338,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -1330,7 +1380,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -1376,7 +1426,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -1415,7 +1465,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             _rtc.SetNowUTC(expMessage.Risen);
             _suti.InjectRtc(_rtc);
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(TRUE,expMessage.Category).RequireAcknowledgement();
             _suti.Close();
@@ -1453,9 +1503,9 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
             END_VAR
             //--Arrange
             _suti.Open();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.ActivateOnCondition(FALSE,expMessage.Category).RequireAcknowledgement();
-            _suti._object.Initialize(_suti);
+            _suti._object.InitializeWithContext(_suti);
             _suti._object._messenger.Serve(_suti._object);
             _suti._object._messenger.ActivateOnCondition(FALSE,expMessage.Category).RequireAcknowledgement();
             _suti.Close(); 

--- a/src/core/ctrl/test/AxoMomentaryTask/AxoMomentaryTaskTests.st
+++ b/src/core/ctrl/test/AxoMomentaryTask/AxoMomentaryTaskTests.st
@@ -1,15 +1,26 @@
 USING AxUnit;
-USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Core.AxoMomentaryTask_Tests
-     {S7.extern=ReadWrite}
-     CLASS TestContext EXTENDS AXOpen.Core.Dummies.MockAxoContext                    
+    {S7.extern=ReadWrite}
+   CLASS TestContext EXTENDS MockAxoContext                    
             METHOD PROTECTED OVERRIDE Main
                 ;
             END_METHOD               
-    END_CLASS         
+    END_CLASS     
+
+
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
 
     {S7.extern=ReadWrite}
     CLASS MyTask Extends AxoMomentaryTask
@@ -68,12 +79,14 @@ NAMESPACE AXOpen.Core.AxoMomentaryTask_Tests
     CLASS AxoMomentaryTaskUnitTests 
         VAR PROTECTED
            _context : TestContext;
+           _rootObject : MockAxoObject;
            myTask : MyTask;
             initValue : ULINT;
         END_VAR    
 
         METHOD PRIVATE Initialize
-            myTask.Initialize(_context);
+            _rootObject.InitializeWithContext(_context);
+            myTask.Initialize(_rootObject);
         END_METHOD
         
         VAR

--- a/src/core/ctrl/test/AxoRemoteTask/AxoRemoteTaskTests.st
+++ b/src/core/ctrl/test/AxoRemoteTask/AxoRemoteTaskTests.st
@@ -1,22 +1,34 @@
 USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
-
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 NAMESPACE AXOpen.Core
     NAMESPACE AxoRemoteTasksTests        
     
-     {S7.extern=ReadWrite}
-     CLASS TestContext EXTENDS AXOpen.Core.Dummies.MockAxoContext                    
+    {S7.extern=ReadWrite}
+   CLASS TestContext EXTENDS MockAxoContext                    
             METHOD PROTECTED OVERRIDE Main
                 ;
             END_METHOD               
-    END_CLASS         
+    END_CLASS     
+
+
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS    
    
     {TestFixture}
     {S7.extern=ReadWrite}
     CLASS IxRemoteTaskTests 
         VAR PROTECTED
            _context : TestContext;
+           _rootObject : MockAxoObject;
            myTask : AxoRemoteTask;
            expState:  eAxoTaskState;
            actState:  eAxoTaskState;
@@ -24,7 +36,8 @@ NAMESPACE AXOpen.Core
         END_VAR    
 
         METHOD PRIVATE Initialize
-            myTask.Initialize(_context);           
+            _rootObject.InitializeWithContext(_context);
+            myTask.Initialize(_rootObject);           
         END_METHOD     
 
         METHOD Equal : BOOL
@@ -37,15 +50,24 @@ NAMESPACE AXOpen.Core
 
         VAR
             _contextClean   :   TestContext;
+            _rtm            :   AXOpen.Core.Dummies.MockAxoRtm;
+            _rtc            :   AXOpen.Core.Dummies.MockAxoRtc;
             myTaskClean     :   AxoRemoteTask;
             expStateClean   :   eAxoTaskState;
             actStateClean   :   eAxoTaskState;
             initValueClean  :   ULINT;           
          END_VAR    
     
+
+
+         
         {TestSetup}
         METHOD PUBLIC TestSetup
             _context := _contextClean;
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
             myTask := myTaskClean;
             expState    :=  expStateClean;
             actState    :=  actStateClean;

--- a/src/core/ctrl/test/AxoTask/AxoTaskTests.st
+++ b/src/core/ctrl/test/AxoTask/AxoTaskTests.st
@@ -1,15 +1,24 @@
 USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Core.AxoTask_Tests
      {S7.extern=ReadWrite}
-     CLASS TestContext EXTENDS AXOpen.Core.Dummies.MockAxoContext                    
+     CLASS TestContext EXTENDS MockAxoContext                    
             METHOD PROTECTED OVERRIDE Main
                 ;
             END_METHOD               
     END_CLASS         
-
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
     {S7.extern=ReadWrite}
     CLASS MyTask Extends AxoTask
         VAR
@@ -82,19 +91,26 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
     {S7.extern=ReadWrite}
     CLASS AxoTaskUnitTests 
         VAR PROTECTED
-           _context     :   TestContext;
-           myTask       :   MyTask;
-           expState     :   eAxoTaskState;
-           actState     :   eAxoTaskState;
-           initValue    :   ULINT;
+           _context         :   TestContext;
+           _rootObject      :   MockAxoObject;
+           myTask           :   MyTask;
+           expState         :   eAxoTaskState;
+           actState         :   eAxoTaskState;
+           initValue        :   ULINT;
+           reqStringValue   : STRING[254];
         END_VAR    
 
         METHOD PRIVATE Initialize
-            myTask.Initialize(_context);
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
+            _rootObject.InitializeWithContext(_context);
+            myTask.Initialize(_rootObject);
         END_METHOD
 
         METHOD PRIVATE InitializeInvokeExecute
-            myTask.Initialize(_context);
+            THIS.Initialize();
             _context.Open();
             myTask.Invoke();
             myTask.Execute();
@@ -102,7 +118,7 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
         END_METHOD
 
         METHOD PRIVATE InitializeInvokeExecuteAbort
-            myTask.Initialize(_context);
+            THIS.Initialize();
             _context.Open();
             myTask.Invoke();
             myTask.Execute();
@@ -111,7 +127,7 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
         END_METHOD
 
         METHOD PRIVATE InitializeInvokeExecuteThrowWhen
-            myTask.Initialize(_context);
+            THIS.Initialize();
             _context.Open();
             myTask.Invoke();
             myTask.Execute();
@@ -120,7 +136,7 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
         END_METHOD
         
         METHOD PRIVATE InitializeInvokeExecuteDoneWhen
-            myTask.Initialize(_context);
+            THIS.Initialize();
             _context.Open();
             myTask.Invoke();
             myTask.Execute();
@@ -136,8 +152,18 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
             Equal := expected = actual;
         END_METHOD 
 
+        METHOD AreEqual : BOOL
+            VAR_INPUT
+                 expected:  STRING[254];
+                 actual:  STRING[254];
+            END_VAR
+            AreEqual := expected = actual;
+        END_METHOD    
+
         VAR PRIVATE
             _contextClean    :   TestContext;
+            _rtc             :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm             :   AXOpen.Core.Dummies.MockAxoRtm;
             myTaskClean      :   MyTask;
             expStateClean    :   eAxoTaskState;
             actStateClean    :   eAxoTaskState;
@@ -1294,5 +1320,171 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
             myTask.Execute();
             Assert.Equal(FALSE, myTask.ResumeTriggered());           
         END_METHOD
+
+        // {Test}
+        // METHOD PUBLIC invoke_call_without_execute_call_should_return_an_error
+        //     // Arrange
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     _context.Close();
+
+        //      // Act
+        //     _context.Open();
+        //     myTask.Invoke();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask.HasError());           
+        // END_METHOD     
+
+        // {Test}
+        // METHOD PUBLIC invoke_call_without_execute_call_should_return_CyclicExecuteIsNotCalled_as_an_error_detail
+        //     // Arrange
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     _context.Close();
+
+        //      // Act
+        //     _context.Open();
+        //     myTask.Invoke();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, THIS.AreEqual('CyclicExecuteIsNotCalled', myTask.ErrorDetails));           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC invoke_call_without_execute_call_should_change_messenger_state_to_IsActive
+        //     // Arrange
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     _context.Close();
+
+        //      // Act
+        //     _context.Open();
+        //     myTask.Invoke();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask._messenger.IsActive);           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC invoke_call_without_execute_call_should_change_messenger_code_to_1
+        //     // Arrange
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     _context.Close();
+
+        //      // Act
+        //     _context.Open();
+        //     myTask.Invoke();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(ULINT#1, myTask._messenger.MessageCode);           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC multiple_execute_call_should_return_an_error
+        //     // Arrange/Act
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask.HasError());           
+        // END_METHOD     
+
+        // {Test}
+        // METHOD PUBLIC multiple_execute_call_should_return_MultipleExecuteIsCalled_as_an_error_detail
+        //     // Arrange/Act
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, THIS.AreEqual('MultipleExecuteIsCalled', myTask.ErrorDetails));           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC multiple_execute_call_should_change_messenger_state_to_IsActive
+        //     // Arrange/Act
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask._messenger.IsActive);           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC multiple_execute_call_should_change_messenger_code_to_2
+        //     // Arrange/Act
+        //     THIS.Initialize();
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(ULINT#2, myTask._messenger.MessageCode);           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC execute_call_without_valid_rtm_should_return_an_error
+        //     // Arrange/Act
+        //     myTask.Initialize(_rootObject);
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask.HasError());           
+        // END_METHOD     
+
+        // {Test}
+        // METHOD PUBLIC execute_call_without_valid_rtm_should_return_RtmInvalid_as_an_error_detail
+        //     // Arrange/Act
+        //     myTask.Initialize(_rootObject);
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, THIS.AreEqual('RtmInvalid', myTask.ErrorDetails));           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC execute_call_without_valid_rtm_should_change_messenger_state_to_IsActive
+        //     // Arrange/Act
+        //     myTask.Initialize(_rootObject);
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(TRUE, myTask._messenger.IsActive);           
+        // END_METHOD     
+        
+        // {Test}
+        // METHOD PUBLIC execute_call_without_valid_rtm_should_change_messenger_code_to_3
+        //     // Arrange/Act
+        //     myTask.Initialize(_rootObject);
+        //     _context.Open();
+        //     myTask.Execute();          
+        //     _context.Close();
+
+        //    //Assert 
+        //     Assert.Equal(ULINT#3, myTask._messenger.MessageCode);           
+        // END_METHOD     
+        
+        
     END_CLASS
 END_NAMESPACE

--- a/src/core/ctrl/test/AxoToggleTask/AxoToggleTaskTests.st
+++ b/src/core/ctrl/test/AxoToggleTask/AxoToggleTaskTests.st
@@ -1,16 +1,24 @@
 USING AxUnit;
-USING AxUnit;
 USING AXOpen.Core;
 USING AXOpen.Rtc;
+USING AXOpen.Rtm;
+USING AXOpen.Core.Dummies;
+USING AXOpen.Messaging;
+USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Core.AxoToggleTask_Tests
      {S7.extern=ReadWrite}
-     CLASS TestContext EXTENDS AXOpen.Core.Dummies.MockAxoContext                    
+     CLASS TestContext EXTENDS MockAxoContext                    
             METHOD PROTECTED OVERRIDE Main
                 ;
             END_METHOD               
     END_CLASS         
-
+    {S7.extern=ReadWrite}
+    CLASS TestObject EXTENDS MockAxoObject     
+        VAR PUBLIC 
+            _messenger : AxoMessenger;
+        END_VAR
+    END_CLASS
     {S7.extern=ReadWrite}
     CLASS MyTask Extends AxoToggleTask
         VAR
@@ -67,12 +75,14 @@ NAMESPACE AXOpen.Core.AxoToggleTask_Tests
     CLASS AxoToggleTaskUnitTests 
         VAR PROTECTED
            _context : TestContext;
+           _rootObject : MockAxoObject;
            myTask : MyTask;
             initValue : ULINT;
         END_VAR    
 
         METHOD PRIVATE Initialize
-            myTask.Initialize(_context);
+            _rootObject.InitializeWithContext(_context);
+            myTask.Initialize(_rootObject);
         END_METHOD
 
         METHOD PRIVATE SwitchOn

--- a/src/data/ctrl/src/AxoDataExchange.st
+++ b/src/data/ctrl/src/AxoDataExchange.st
@@ -24,18 +24,18 @@ NAMESPACE AXOpen.Data
             Operation.Execute();
         END_METHOD
 
-        ///<summary>
-        /// Runs intialization and cyclical handling of this AxoDataExchange.
-        /// </summary> 
-        /// <param name="context">Root context of this object</param>
-        METHOD PUBLIC Run 
-            VAR_INPUT            
-                context : IAxoContext;
-            END_VAR    
-            THIS.Initialize(context);
-            Operation.Initialize(THIS);
-            Operation.Execute();
-        END_METHOD
+        // ///<summary>
+        // /// Runs intialization and cyclical handling of this AxoDataExchange.
+        // /// </summary> 
+        // /// <param name="context">Root context of this object</param>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT            
+        //         context : IAxoContext;
+        //     END_VAR    
+        //     THIS.Initialize(context);
+        //     Operation.Initialize(THIS);
+        //     Operation.Execute();
+        // END_METHOD
 
         ///<summary>
         /// Creates new entry into the remote repository from data entity of this AxoDataExchange.

--- a/src/data/ctrl/src/AxoDataFragmentExchange.st
+++ b/src/data/ctrl/src/AxoDataFragmentExchange.st
@@ -80,18 +80,18 @@ NAMESPACE AXOpen.Data
             Operation.Restore(); 
         END_METHOD 
         
-        ///<summary>
-        /// Runs intialization and cyclical handling of this AxoDataExchange.
-        /// </summary> 
-        /// <param name="context">Root context of this object</param>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                context : IAxoContext;
-            END_VAR
-            THIS.Initialize(context);
-            Operation.Initialize(THIS);
-            Operation.Execute();
-        END_METHOD
+        // ///<summary>
+        // /// Runs intialization and cyclical handling of this AxoDataExchange.
+        // /// </summary> 
+        // /// <param name="context">Root context of this object</param>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         context : IAxoContext;
+        //     END_VAR
+        //     THIS.Initialize(context);
+        //     Operation.Initialize(THIS);
+        //     Operation.Execute();
+        // END_METHOD
 
         ///<summary>
         /// Runs intialization and cyclical handling of this AxoDataExchange.        

--- a/src/data/ctrl/src/AxoDataPersistentExchange.st
+++ b/src/data/ctrl/src/AxoDataPersistentExchange.st
@@ -20,6 +20,10 @@ NAMESPACE AXOpen.Data
             
         END_VAR
 
+        VAR PRIVATE
+            _context : IAxoContext;
+        END_VAR
+
         ///<summary>
         /// This method determines if the current call is concurrent or not.
         ///  It takes an AXOpen.Core.IAxoObject as input and returns a BOOL. 
@@ -78,38 +82,14 @@ NAMESPACE AXOpen.Data
                 parent : IAxoObject;
             END_VAR    
 
-            if _context_ = NULL then 
+            IF parent = NULL THEN
+                RETURN;
+            END_IF;
+
+            IF _context = NULL THEN
                 THIS.Initialize(parent);
                 Operation.Initialize(THIS);
-            end_if;
-
-            Operation.Execute();
-            
-            IF NOT _IsFirstReadAllDone THEN 
-                IF Operation.IsInitialized AND (Operation.Identity <> ULINT#0) THEN // MUST BE INITIALIZED AND WITH IDENTITY
-                    IF Operation.IsReady() THEN // read all after startup
-                        Operation.Invoke('', ePersistentOperation#ReadAll);
-                        LastOperation := ePersistentOperation#ReadAll;
-
-                    ELSIF Operation.IsDone() AND (LastOperation = ePersistentOperation#ReadAll) THEN 
-                         _IsFirstReadAllDone := TRUE;
-                    END_IF;
-                END_IF;
-            END_IF;
-        END_METHOD
-
-        ///<summary>
-        /// Runs intialization and cyclical handling of this AxoDataPersistentExchange.
-        /// </summary> 
-        /// <param name="context">Root context of this object</param>
-        METHOD PUBLIC Run 
-            VAR_INPUT            
-                context : IAxoContext;
-            END_VAR    
-            
-            IF _context_ = NULL THEN 
-                THIS.Initialize(context);
-                Operation.Initialize(THIS);
+                _context := THIS.GetContext();
             END_IF;
 
             Operation.Execute();
@@ -126,6 +106,35 @@ NAMESPACE AXOpen.Data
                 END_IF;
             END_IF;
         END_METHOD
+
+        // ///<summary>
+        // /// Runs intialization and cyclical handling of this AxoDataPersistentExchange.
+        // /// </summary> 
+        // /// <param name="context">Root context of this object</param>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT            
+        //         context : IAxoContext;
+        //     END_VAR    
+            
+        //     IF _context_ = NULL THEN 
+        //         THIS.Initialize(context);
+        //         Operation.Initialize(THIS);
+        //     END_IF;
+
+        //     Operation.Execute();
+            
+        //     IF NOT _IsFirstReadAllDone THEN 
+        //         IF Operation.IsInitialized AND (Operation.Identity <> ULINT#0) THEN // MUST BE INITIALIZED AND WITH IDENTITY
+        //             IF Operation.IsReady() THEN // read all after startup
+        //                 Operation.Invoke('', ePersistentOperation#ReadAll);
+        //                 LastOperation := ePersistentOperation#ReadAll;
+
+        //             ELSIF Operation.IsDone() AND (LastOperation = ePersistentOperation#ReadAll) THEN 
+        //                  _IsFirstReadAllDone := TRUE;
+        //             END_IF;
+        //         END_IF;
+        //     END_IF;
+        // END_METHOD
 
         ///<summary>
         /// Executes the restore Operation for the AxoDataPersistentExchange component.

--- a/src/data/ctrl/src/IAxoDataExchange.st
+++ b/src/data/ctrl/src/IAxoDataExchange.st
@@ -44,12 +44,12 @@ NAMESPACE AXOpen.Data
         METHOD Restore        
         END_METHOD 
         
-        METHOD Run 
-            VAR_INPUT
-                context : IAxoContext;
-            END_VAR
+        // METHOD Run 
+        //     VAR_INPUT
+        //         context : IAxoContext;
+        //     END_VAR
             
-        END_METHOD
+        // END_METHOD
 
         METHOD Run 
             VAR_INPUT

--- a/src/data/ctrl/test/AxoDataExchangeTaskTests.st
+++ b/src/data/ctrl/test/AxoDataExchangeTaskTests.st
@@ -16,6 +16,7 @@ NAMESPACE AXOpen.Data
         CLASS AxoDataExchangeTask_Tests
             VAR PROTECTED
                 _context : TestContext;
+                _rootObject : AxoObject;
                 _dataExchangeTask : AxoDataCrudTask;
             END_VAR    
 
@@ -24,7 +25,8 @@ NAMESPACE AXOpen.Data
                 VAR
                     expected : STRING[254];
                 END_VAR    
-                _dataExchangeTask.Initialize(_context);
+                _rootObject.InitializeWithContext(_context);
+                _dataExchangeTask.Initialize(_rootObject);
                 _context.Open();
                 expected := 'CreateRecordIdentifier';
                 _dataExchangeTask.Invoke(expected);

--- a/src/data/ctrl/test/AxoDataPersistentExchangeTaskTests.st
+++ b/src/data/ctrl/test/AxoDataPersistentExchangeTaskTests.st
@@ -16,6 +16,7 @@ NAMESPACE AXOpen.Data
         CLASS AxoDataPersistentExchangeTask_Tests
             VAR PROTECTED
                 _context : TestContext;
+                _rootObject : AxoObject;
                 _dataExchangeTask : AxoDataPersistentCurdTask;
             END_VAR    
 
@@ -24,7 +25,8 @@ NAMESPACE AXOpen.Data
                 VAR
                     expected : STRING[254];
                 END_VAR    
-                _dataExchangeTask.Initialize(_context);
+                _rootObject.InitializeWithContext(_context);
+                _dataExchangeTask.Initialize(_rootObject);
                 _context.Open();
                 expected := 'UpdateIdentifier';
                 _dataExchangeTask.Invoke(expected);

--- a/src/data/ctrl/test/AxoDataPersistentExchangeTests.st
+++ b/src/data/ctrl/test/AxoDataPersistentExchangeTests.st
@@ -11,31 +11,15 @@ NAMESPACE AXOpen.Data
             END_METHOD                 
         END_CLASS
 
-        {S7.extern=ReadWrite}
-        CLASS AxoRtcMock IMPLEMENTS IAxoRtc
-            VAR PRIVATE 
-                _NowUTC : LDATE_AND_TIME;
-            END_VAR
-    
-            METHOD INTERNAL SetNowUTC : LDATE_AND_TIME
-                VAR_INPUT
-                    Set :  LDATE_AND_TIME;
-                END_VAR;
-                _NowUTC := Set;
-            END_METHOD
-    
-            METHOD PUBLIC NowUTC : LDATE_AND_TIME
-                NowUTC := _NowUTC;
-            END_METHOD    
-        END_CLASS
-
 
         {TestFixture}
         {S7.extern=ReadWrite}
         CLASS AxoDataExchange_Tests
             VAR PROTECTED
                 _context : TestContext;
-                _rtc : AxoRtcMock;
+                _rootObject : AxoObject;
+                _rtc : AXOpen.Core.Dummies.MockAxoRtc;
+                _rtm : AXOpen.Core.Dummies.MockAxoRtm;
 
                 _dataExchange : AxoDataPersistentExchange;
 
@@ -55,6 +39,12 @@ NAMESPACE AXOpen.Data
             METHOD PUBLIC TestSetup
             // Will be called before MyTest_A AND before Test_B are executed
                 _context := _contextBlank;
+                _rtm.SetElapsed(LTIME#2s);
+                _context.InjectRtm(_rtm);
+                _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+                _context.InjectRtc(_rtc);
+                _rootObject.InitializeWithContext(_context);
+                _dataExchange.Initialize(_rootObject);
                 _dataExchange := _dataExchangeBlank;
                 caller_1 := caller_1Blank;
                 caller_2 := caller_2Blank;
@@ -87,7 +77,7 @@ NAMESPACE AXOpen.Data
                 END_VAR
                 FOR iteration := 0 TO cycleCount DO
                     _context.Open();
-                    _dataExchange.Run(_context);
+                    _dataExchange.Run(_rootObject);
                     _context.Close();
                 END_FOR;
             END_METHOD
@@ -106,7 +96,7 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
+                caller_1.Initialize(_rootObject);
                 caller_1.Identity :=  _context.CreateIdentity();
                 IdentifierCaller_1 := '1';
                 _dataExchange.Operation.IsInitialized := true; //simulate intit from .net side
@@ -116,7 +106,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -127,7 +117,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -138,7 +128,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -161,7 +151,7 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
+                caller_1.Initialize(_rootObject);
                 caller_1.Identity :=  _context.CreateIdentity();
                 IdentifierCaller_1 := '1';
                 _dataExchange.Operation.IsInitialized := true; //simulate intit from .net side
@@ -171,7 +161,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE READ BLOCKED ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -186,7 +176,7 @@ NAMESPACE AXOpen.Data
                 _dataExchange.SetFirstReadDone(); // firs read done simulation
 
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // kicking
@@ -197,7 +187,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // BUSY => INVOKED
@@ -221,7 +211,7 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
+                caller_1.Initialize(_rootObject);
                 caller_1.Identity := ulint#0;
                 IdentifierCaller_1 := '1';
                 _dataExchange.Operation.IsInitialized := true; //simulate intit from .net side
@@ -232,7 +222,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -243,7 +233,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -254,7 +244,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); 
@@ -277,7 +267,7 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
+                caller_1.Initialize(_rootObject);
                 caller_1.Identity :=  _context.CreateIdentity();
                 IdentifierCaller_1 := '1';
                 _dataExchange.Operation.IsInitialized := true; //simulate intit from .net side
@@ -288,7 +278,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // kicking
@@ -299,7 +289,7 @@ NAMESPACE AXOpen.Data
 
                 //------------------------ INVOKE READ  ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // BUSY => INVOKED
@@ -325,8 +315,8 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
-                caller_2.Initialize(_context);
+                caller_1.Initialize(_rootObject);
+                caller_2.Initialize(_rootObject);
                 caller_1.Identity := _context.CreateIdentity();
                 caller_2.Identity := _context.CreateIdentity();
                 IdentifierCaller_1 := '1';
@@ -339,7 +329,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE READ CONCURRENT ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
                 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsBusy());
@@ -357,7 +347,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ INVOKE SUCCESEED - caller 1. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsBusy());
@@ -374,7 +364,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ DONE - caller 1. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); // SET DONE STATUS
+                _dataExchange.Run(_rootObject); // SET DONE STATUS
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsDone());
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
@@ -388,27 +378,27 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ +1 cycle gap between calls ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 //caller 1 finished not colled any more...
                 ResultCaller_2 := _dataExchange.InvokeUpdate(caller_2, IdentifierCaller_2); // still WAITING
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
                 _context.Close();
                 //------------------------ +2 cycle gap between calls -----------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_2 := _dataExchange.InvokeUpdate(caller_2, IdentifierCaller_2); // still WAITING
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
                 _context.Close();
                 //------------------------ Kicking  for caller 2 ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_2 := _dataExchange.InvokeUpdate(caller_2, IdentifierCaller_2); // Kicking for caller 2
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
 
                 _context.Close();
                 //------------------------ INVOKE SUCCESEED -  caller 2. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_1 := _dataExchange.InvokeUpdate(caller_1, IdentifierCaller_1); // will wait 
                 ResultCaller_2 := _dataExchange.InvokeUpdate(caller_2, IdentifierCaller_2); // invoke success
 
@@ -420,7 +410,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ DONE - caller 2. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_1 := _dataExchange.InvokeUpdate(caller_1, IdentifierCaller_1); // will wait 
                 ResultCaller_2 := _dataExchange.IsUpdateDone(caller_2); 
 
@@ -447,8 +437,8 @@ NAMESPACE AXOpen.Data
                 startTime := LDATE_AND_TIME#2023-11-11-11:11:11.111;
                 _rtc.SetNowUTC(startTime);
                 _context.InjectRtc(_rtc);
-                caller_1.Initialize(_context);
-                caller_2.Initialize(_context);
+                caller_1.Initialize(_rootObject);
+                caller_2.Initialize(_rootObject);
                 caller_1.Identity := _context.CreateIdentity();
                 caller_2.Identity := _context.CreateIdentity();
                 IdentifierCaller_1 := '1';
@@ -461,7 +451,7 @@ NAMESPACE AXOpen.Data
                 
                  //------------------------ INVOKE  CONCURRENT ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
                 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsReady());
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsBusy());
@@ -479,7 +469,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ INVOKE SUCCESEED - caller 1. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context);
+                _dataExchange.Run(_rootObject);
 
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsBusy());
@@ -496,7 +486,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ DONE - caller 1. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); // SET DONE STATUS
+                _dataExchange.Run(_rootObject); // SET DONE STATUS
 
                 AxUnit.Assert.Equal(TRUE, _dataExchange.Operation.IsDone());
                 AxUnit.Assert.Equal(FALSE, _dataExchange.Operation.IsReady());
@@ -510,27 +500,27 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ +1 cycle gap between calls ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 //caller 1 finished not colled any more...
                 ResultCaller_2 := _dataExchange.InvokeRead(caller_2, IdentifierCaller_2); // still WAITING
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
                 _context.Close();
                 //------------------------ +2 cycle gap between calls -----------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_2 := _dataExchange.InvokeRead(caller_2, IdentifierCaller_2); // still WAITING
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
                 _context.Close();
                 //------------------------ Kicking read for caller 2 ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_2 := _dataExchange.InvokeRead(caller_2, IdentifierCaller_2); // Kicking for caller 2
                 AxUnit.Assert.Equal(FALSE, ResultCaller_2);
 
                 _context.Close();
                 //------------------------ INVOKE SUCCESEED -  caller 2. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // will wait 
                 ResultCaller_2 := _dataExchange.InvokeRead(caller_2, IdentifierCaller_2); // invoke success
 
@@ -542,7 +532,7 @@ NAMESPACE AXOpen.Data
                 _context.Close();
                 //------------------------ DONE - caller 2. ------------------------
                 _context.Open();
-                _dataExchange.Run(_context); 
+                _dataExchange.Run(_rootObject); 
                 ResultCaller_1 := _dataExchange.InvokeRead(caller_1, IdentifierCaller_1); // will wait 
                 ResultCaller_2 := _dataExchange.IsReadDone(caller_2); 
 

--- a/src/inspectors/app/ix-blazor/AXOpen.Inspectors.blazor/Pages/Documentation.razor
+++ b/src/inspectors/app/ix-blazor/AXOpen.Inspectors.blazor/Pages/Documentation.razor
@@ -8,11 +8,12 @@
 @* <RenderableContentControl Context="@Entry.Plc.documentation" Presentation="Command-Control" PollingInterval="100"/> *@
 
 <RenderableContentControl Context="@Entry.Plc.documentation._startInspection" Presentation="Command-Control" PollingInterval="100" />
+<RenderableContentControl Context="@Entry.Plc.documentation._automat._continue" Presentation="Command-Control" PollingInterval="100" />
 <RenderableContentControl Context="@Entry.Plc.documentation._automat._comprehensiveResult" Presentation="Command-Control" PollingInterval="100" />
 
-<RenderableContentControl Context="@Entry.Plc.documentation._automat._analogueInspector" Presentation="Command-Control" PollingInterval="100"/>
-<RenderableContentControl Context="@Entry.Plc.documentation._automat._digitalInspector" Presentation="Command-Control" PollingInterval="100" />
-<RenderableContentControl Context="@Entry.Plc.documentation._automat._dataInspector" Presentation="Command-Control" PollingInterval="100" />
+<RenderableContentControl Context="@Entry.Plc.documentation._automat._analogueInspectorData" Presentation="Command-Control" PollingInterval="100"/>
+<RenderableContentControl Context="@Entry.Plc.documentation._automat._digitalInspectorData" Presentation="Command-Control" PollingInterval="100" />
+<RenderableContentControl Context="@Entry.Plc.documentation._automat._dataInspectorData" Presentation="Command-Control" PollingInterval="100" />
 
 <div class="container">
  <!-- TOP LEVEL TASKS -->
@@ -35,7 +36,7 @@
     <div class="row">
        @if (Entry.Plc.documentation._automat.Status.Cyclic == (ushort)eAxoTaskState.Busy)
         {
-        <AxoSequencerView Component="Entry.Plc.documentation._automat" HasTaskControlButton="false" PollingInterval="20" ></AxoSequencerView>
+        <AxoSequencerView Component="Entry.Plc.documentation._automat" HasTaskControlButton="true" IsControllable="true" PollingInterval="20" ></AxoSequencerView>
         }
         
     </div>
@@ -46,15 +47,15 @@
 <RenderableContentControl Context="@Entry.Plc.documentation._automat._inspectionData" Presentation="Command-Control" PollingInterval="100" />
 
 
-<AxoDialogLocator DialogLocatorPath="custation001" ObservedObjects="new[] {Entry.Plc.documentation._automat}" />
+<AxoDialogLocator ObservedObjects="new[] {Entry.Plc.documentation._automat}" />
+
+<AxoObjectDiagnosticsView ObservedObjects="new[] {Entry.Plc.documentation._automat}"/>
+
+
+
 
 @code
 {
-    protected override void OnInitialized()
-    {
-        base.OnInitialized();
-    }
-
     public override void ConfigurePolling()
     {
         this.StartPolling(Entry.Plc.documentation._automat.Status);

--- a/src/inspectors/app/ix-blazor/AXOpen.Inspectors.blazor/Program.cs
+++ b/src/inspectors/app/ix-blazor/AXOpen.Inspectors.blazor/Program.cs
@@ -96,6 +96,7 @@ public static class Roles
             new Role(can_run_automat_mode),
             new Role(can_run_service_mode),
             new Role(can_skip_steps_in_sequence),
+            new Role(can_attempt_repair)
         };
 
         return roles;
@@ -107,6 +108,7 @@ public static class Roles
     public const string process_settings_access = nameof(process_settings_access);
     public const string process_traceability_access = nameof(process_traceability_access);
     public const string can_skip_steps_in_sequence = nameof(can_skip_steps_in_sequence);
+    public const string can_attempt_repair = nameof(can_attempt_repair);
 }
 
 

--- a/src/inspectors/app/src/Documentation/DocumentationContext.st
+++ b/src/inspectors/app/src/Documentation/DocumentationContext.st
@@ -1,26 +1,23 @@
+USING AXOpen.Core;
 {S7.extern=ReadWrite}
 CLASS DocumentationContext EXTENDS AXOpen.Core.AxoContext
     VAR PUBLIC
-
         _startInspection : BOOL := FALSE;
-         _automat: AutomatSequence;
-        _inspectors : Inspectors;
-      
+        _automat: AutomatSequence;
+        _inspectors : Inspectors;      
+        _rootObject : AxoObject;
     END_VAR
 
 
-    METHOD PROTECTED OVERRIDE Main
-        _inspectors.Initialize(THIS);
-        
-        _automat.Initialize(THIS);
-        _automat.Run(THIS);
+    METHOD PROTECTED OVERRIDE Main           
+        _rootObject.InitializeWithContext(THIS); 
+        _automat.Initialize(_rootObject);
+        _automat.Run(_rootObject);
         _automat.Execute();
 
         IF _startInspection THEN
             _automat.Invoke();
-        END_IF;
-      
-     
+        END_IF;           
     END_METHOD
 
 END_CLASS
@@ -31,17 +28,11 @@ END_CLASS
 CLASS PUBLIC AutomatSequence
     EXTENDS AXOpen.Core.AxoSequencerContainer
     VAR PUBLIC
+        _continue : BOOL := FALSE;
+
         Steps : ARRAY[0..50] OF AxoStep;
-        _digitalInspector: AXOpen.Inspectors.AxoDigitalInspector;
-        _analogueInspector: AXOpen.Inspectors.AxoAnalogueInspector;
-        _dataInspector: AXOpen.Inspectors.AxoDataInspector;
-
-
-        _digitalInspectorDialog       : AXOpen.Inspectors.AxoInspectorDialog;
-        _analogueInspectorDialog      : AXOpen.Inspectors.AxoInspectorDialog;
-        _dataInspectorDialog          : AXOpen.Inspectors.AxoInspectorDialog;
-
-
+        _inspector: AXOpen.Inspectors.AxoInspector;
+                
         _inspectionResult: BOOL;
         _inspectionValue: LREAL;
         _inspectionData: STRING;
@@ -50,15 +41,11 @@ CLASS PUBLIC AutomatSequence
         _analogueInspectorData : AXOpen.Inspectors.AxoAnalogueInspectorData;
         _dataInspectorData: AXOpen.Inspectors.AxoDataInspectorData;
 
-
         _comprehensiveResult: AXOpen.Inspectors.AxoComprehensiveResult;
-    END_VAR
-    VAR PRIVATE
-        
     END_VAR
 
     METHOD OVERRIDE Main
-        
+
         THIS.SequenceMode := eAxoSequenceMode#Cyclic;
 
         IF (Steps[0].Execute(THIS, TRUE, 'Move vertical cyclinder down.')) THEN
@@ -85,7 +72,7 @@ CLASS PUBLIC AutomatSequence
     
 
         IF (Steps[20].Execute(THIS, TRUE, 'RETRY STEP 90')) THEN
-            
+         
             IF(Steps[20].Duration > T#2000ms) THEN
                 THIS.MoveNext(); 
             END_IF;	
@@ -95,24 +82,50 @@ CLASS PUBLIC AutomatSequence
 
         // <PreservingOverallResultExample>
         IF (Steps[30].Execute(THIS, TRUE, 'Example Digital inspection')) THEN
-
+            _inspector.Inspect(THIS,REF(_digitalInspectorData),_inspectionResult);
             // <ExampleInspectionWithCoordinatorExample>
-            _digitalInspector.WithCoordinator(THIS).Inspect(THIS,REF(_digitalInspectorData),_inspectionResult).UpdateComprehensiveResult(_comprehensiveResult).OnFail().CarryOn();
+            // _inspector.WithCoordinator(THIS)
+            //             .Inspect(THIS,REF(_digitalInspectorData),_inspectionResult)
+            //             .UpdateComprehensiveResult(_comprehensiveResult)
+            //             .OnFail()
+            //             .CarryOn();
+             ;
             // </ExampleInspectionWithCoordinatorExample>
+        END_IF;
+
+        IF (Steps[31].Execute(THIS, TRUE, 'debug')) THEN         
+            IF _continue THEN
+                _continue := FALSE;
+                THIS.MoveNext(); 
             END_IF;
+        END_IF;
 
         IF (Steps[35].Execute(THIS, TRUE, 'Example Analog inspection')) THEN         
 
-            // _analogueInspector.WithCoordinator(THIS).Inspect(THIS,_inspectionValue).UpdateComprehensiveResult(_comprehensiveResult).OnFail().CarryOn();
-            _analogueInspector.WithCoordinator(THIS).Inspect(THIS,REF(_analogueInspectorData), _inspectionValue).UpdateComprehensiveResult(_comprehensiveResult).OnFail().CarryOn();
+            _inspector.WithCoordinator(THIS)
+                        .Inspect(THIS,REF(_analogueInspectorData), _inspectionValue)
+                        .UpdateComprehensiveResult(_comprehensiveResult)
+                        .OnFail()
+                        .CarryOn();
 
         END_IF;
        // </PreservingOverallResultExample>
 
+        IF (Steps[36].Execute(THIS, TRUE, 'debug')) THEN         
+             IF _continue THEN
+                 _continue := FALSE;
+                 THIS.MoveNext(); 
+             END_IF;
+         END_IF;
+
         IF (Steps[40].Execute(THIS, TRUE, 'Example Data inspection')) THEN
         
         // <HandlingFailureExample>
-        _dataInspector.WithCoordinator(THIS).Inspect(THIS,REF(_dataInspectorData),_inspectionData).UpdateComprehensiveResult(_comprehensiveResult).OnFail().Dialog(Steps[20], Steps[45]);
+        _inspector.WithCoordinator(THIS)
+                    .Inspect(THIS,REF(_dataInspectorData),_inspectionData)
+                    .UpdateComprehensiveResult(_comprehensiveResult)
+                    .OnFail()
+                    .Dialog(Steps[20], Steps[45]);
         // </HandlingFailureExample>
         END_IF;
 
@@ -123,7 +136,6 @@ CLASS PUBLIC AutomatSequence
             END_IF;	
 
         END_IF;
-
 
         THIS.Close(Steps[50]);
     END_METHOD

--- a/src/inspectors/app/src/Sandbox/SandboxContext.st
+++ b/src/inspectors/app/src/Sandbox/SandboxContext.st
@@ -2,16 +2,12 @@ USING AXOpen.Core;
 {S7.extern=ReadWrite}
 CLASS SandboxContext EXTENDS AXOpen.Core.AxoContext
     VAR PUBLIC
-
         _startInspection : BOOL := FALSE;
-
-        _inspectors : Inspectors;
-      
+        _inspectors : Inspectors;      
     END_VAR
 
-
     METHOD PROTECTED OVERRIDE Main
-        _inspectors.Initialize(THIS);
+        _inspectors.InitializeWithContext(THIS);
 
         IF _startInspection THEN
             _inspectors.Run();
@@ -24,8 +20,11 @@ END_CLASS
 {S7.extern=ReadWrite}
 CLASS Inspectors EXTENDS AXOpen.Core.AxoObject
     VAR PUBLIC
+        {#ix-set:AttributeName = "<#Digital Inspector Example#>"}
         _digitalInspector: AXOpen.Inspectors.AxoDigitalInspector;
+        {#ix-set:AttributeName = "<#Analog Inspector Example#>"}
         _analogueInspector: AXOpen.Inspectors.AxoAnalogueInspector;
+        {#ix-set:AttributeName = "<#Data Inspector Example#>"}
         _dataInspector: AXOpen.Inspectors.AxoDataInspector;
 
         _inspectionResult: BOOL;

--- a/src/inspectors/app/src/program.st
+++ b/src/inspectors/app/src/program.st
@@ -13,6 +13,7 @@ PROGRAM MyProgram
     VAR_TEMP
 
     END_VAR
+
     sandbox.InjectRtc(S71500Rtc);
     sandbox.InjectRtm(S71500Rtm);
     sandbox.Run();    

--- a/src/inspectors/ctrl/test/AxoAnalogueInspectorTests.st
+++ b/src/inspectors/ctrl/test/AxoAnalogueInspectorTests.st
@@ -55,7 +55,7 @@ NAMESPACE AXOpen.Inspectors.AxoInspector_Tests
         METHOD PRIVATE Initialize
             _context.InjectRtc(_rtcMock);
             _context.InjectRtm(_rtmMock);
-            _sequencer.Initialize(_context);          
+            _sequencer.InitializeWithContext(_context);          
             
             _analogueInspectorData.FailTime := T#10s;
             _analogueInspectorData.PassTime := T#2s;

--- a/src/inspectors/ctrl/test/AxoDataInspectorTests.st
+++ b/src/inspectors/ctrl/test/AxoDataInspectorTests.st
@@ -53,7 +53,7 @@ NAMESPACE AXOpen.Inspectors.AxoInspector_Tests
         METHOD PRIVATE Initialize
             _context.InjectRtc(_rtcMock);
             _context.InjectRtm(_rtmMock);
-            _sequencer.Initialize(_context);          
+            _sequencer.InitializeWithContext(_context);          
             
             _dataInspectorData.FailTime := T#10s;
             _dataInspectorData.PassTime := T#2s;

--- a/src/inspectors/ctrl/test/AxoDigitalInspectorTests.st
+++ b/src/inspectors/ctrl/test/AxoDigitalInspectorTests.st
@@ -61,7 +61,7 @@ NAMESPACE AXOpen.Inspectors.AxoInspector_Tests
         METHOD PRIVATE Initialize
             _context.InjectRtc(_rtcMock);
             _context.InjectRtm(_rtmMock);
-            _sequencer.Initialize(_context);          
+            _sequencer.InitializeWithContext(_context);          
             
             _digitalInspectorData.FailTime := T#10s;
             _digitalInspectorData.PassTime := T#2s;

--- a/src/io/ctrl/src/AxoIoComponent.st
+++ b/src/io/ctrl/src/AxoIoComponent.st
@@ -39,18 +39,18 @@ NAMESPACE AXOpen.Io
             THIS.Execute(hwID);           
         END_METHOD
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent  : IAxoContext;
-                hwID    :   WORD;
-            END_VAR
-            THIS.Initialize(parent);    
-            THIS.Execute(hwID);           
-        END_METHOD
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent  : IAxoContext;
+        //         hwID    :   WORD;
+        //     END_VAR
+        //     THIS.Initialize(parent);    
+        //     THIS.Execute(hwID);           
+        // END_METHOD
         
         METHOD PRIVATE Execute
             VAR_INPUT

--- a/src/probers/ctrl/src/Probers/AxoProber.st
+++ b/src/probers/ctrl/src/Probers/AxoProber.st
@@ -23,13 +23,13 @@ NAMESPACE AXOpen.Probers
             THIS.Run();
         END_METHOD
 
-        METHOD PUBLIC Run            
-            VAR_INPUT
-                Context : IAxoContext;
-            END_VAR    
-            THIS.Initialize(Context);
-            THIS.Run();
-        END_METHOD
+        // METHOD PUBLIC Run            
+        //     VAR_INPUT
+        //         Context : IAxoContext;
+        //     END_VAR    
+        //     THIS.Initialize(Context);
+        //     THIS.Run();
+        // END_METHOD
 
         METHOD PROTECTED ABSTRACT Test
              
@@ -57,13 +57,13 @@ NAMESPACE AXOpen.Probers
             THIS.Run();
         END_METHOD
 
-        METHOD PUBLIC Run            
-            VAR_INPUT
-                Context : IAxoContext;
-            END_VAR    
-            THIS.Initialize(Context);
-            THIS.Run();
-        END_METHOD
+        // METHOD PUBLIC Run            
+        //     VAR_INPUT
+        //         Context : IAxoContext;
+        //     END_VAR    
+        //     THIS.Initialize(Context);
+        //     THIS.Run();
+        // END_METHOD
 
         METHOD PROTECTED ABSTRACT Test : BOOL
              

--- a/src/template.axolibrary/app/src/Documentation/Component_1.st
+++ b/src/template.axolibrary/app/src/Documentation/Component_1.st
@@ -21,7 +21,7 @@ NAMESPACE Template.Axolibrary
 
         METHOD PUBLIC Run
             VAR_INPUT
-                parent : IAxoContext;
+                parent : IAxoObject;
             END_VAR    
 
             THIS.Initialize(parent);

--- a/src/template.axolibrary/app/src/Documentation/Component_2.st
+++ b/src/template.axolibrary/app/src/Documentation/Component_2.st
@@ -21,7 +21,7 @@ NAMESPACE Template.Axolibrary
 
         METHOD PUBLIC Run
             VAR_INPUT
-                parent : IAxoContext;
+                parent : IAxoObject;
             END_VAR    
 
             THIS.Initialize(parent);

--- a/src/template.axolibrary/app/src/Documentation/DocumentationContext.st
+++ b/src/template.axolibrary/app/src/Documentation/DocumentationContext.st
@@ -2,13 +2,15 @@ NAMESPACE Template.Axolibrary
     {S7.extern=ReadWrite}
     CLASS DocumentationContext EXTENDS AXOpen.Core.AxoContext
         VAR PUBLIC
-            componentOne : Template.Axolibrary.Component_1;
-            componentTwo : Template.Axolibrary.Component_2;
+            rootObject      : AxoObject;
+            componentOne    : Template.Axolibrary.Component_1;
+            componentTwo    : Template.Axolibrary.Component_2;
         END_VAR
 
         METHOD PROTECTED OVERRIDE Main
-            componentOne.Run(THIS);
-            componentTwo.Run(THIS);
+            rootObject.InitializeWithContext(THIS);
+            componentOne.Run(rootObject);
+            componentTwo.Run(rootObject);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/template.axolibrary/ctrl/src/TemplateComponent.st
+++ b/src/template.axolibrary/ctrl/src/TemplateComponent.st
@@ -179,64 +179,64 @@ NAMESPACE Template.Axolibrary
         END_METHOD
 
 
-        ///<summary>
-        /// Runs tasks and logic of this component.
-        /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
-        ///</summary>
-        METHOD PUBLIC Run 
-            VAR_INPUT
-                parent : IAxoContext;
-                hwID :   WORD;
-                homeSensor : REF_TO BOOL;
-                workSensor : REF_TO BOOL;    
-                moveHomeSignal : REF_TO BOOL;
-                moveWorkSignal : REF_TO BOOL;
-            END_VAR
+        // ///<summary>
+        // /// Runs tasks and logic of this component.
+        // /// >[!IMPORTANT] This method must or one of its overloads be called cyclically.
+        // ///</summary>
+        // METHOD PUBLIC Run 
+        //     VAR_INPUT
+        //         parent : IAxoContext;
+        //         hwID :   WORD;
+        //         homeSensor : REF_TO BOOL;
+        //         workSensor : REF_TO BOOL;    
+        //         moveHomeSignal : REF_TO BOOL;
+        //         moveWorkSignal : REF_TO BOOL;
+        //     END_VAR
 
-            THIS.Initialize(parent);
+        //     THIS.Initialize(parent);
 
-            THIS.Open();
+        //     THIS.Open();
 
-            Messenger.Serve(THIS);
-            Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#701,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#702,homeSensor = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#703,workSensor = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#704,moveHomeSignal = NULL, eAxoMessageCategory#ProgrammingError);
-            Messenger.ActivateOnCondition(ULINT#705,moveWorkSignal = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.Serve(THIS);
+        //     Messenger.ActivateOnCondition(ULINT#700,parent = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#701,hwID = WORD#0, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#702,homeSensor = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#703,workSensor = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#704,moveHomeSignal = NULL, eAxoMessageCategory#ProgrammingError);
+        //     Messenger.ActivateOnCondition(ULINT#705,moveWorkSignal = NULL, eAxoMessageCategory#ProgrammingError);
             
-            IF parent = NULL THEN
-                Status.Error.Id := UINT#700;
-                RETURN;
-            ELSIF hwID = WORD#0 THEN
-                Status.Error.Id := UINT#701;
-                RETURN;                
-            ELSIF homeSensor = NULL THEN
-                Status.Error.Id := UINT#702;
-                RETURN;
-            ELSIF workSensor = NULL THEN
-                Status.Error.Id := UINT#703;
-                RETURN;
-            ELSIF moveHomeSignal = NULL THEN
-                Status.Error.Id := UINT#704;
-                RETURN;
-            ELSIF moveWorkSignal = NULL THEN
-                Status.Error.Id := UINT#705;
-                RETURN;
-            END_IF;
+        //     IF parent = NULL THEN
+        //         Status.Error.Id := UINT#700;
+        //         RETURN;
+        //     ELSIF hwID = WORD#0 THEN
+        //         Status.Error.Id := UINT#701;
+        //         RETURN;                
+        //     ELSIF homeSensor = NULL THEN
+        //         Status.Error.Id := UINT#702;
+        //         RETURN;
+        //     ELSIF workSensor = NULL THEN
+        //         Status.Error.Id := UINT#703;
+        //         RETURN;
+        //     ELSIF moveHomeSignal = NULL THEN
+        //         Status.Error.Id := UINT#704;
+        //         RETURN;
+        //     ELSIF moveWorkSignal = NULL THEN
+        //         Status.Error.Id := UINT#705;
+        //         RETURN;
+        //     END_IF;
 
-            Inputs.Status.HomeSensor := homeSensor^;
-            Inputs.Status.WorkSensor := workSensor^;
-            _hwId := hwID;
+        //     Inputs.Status.HomeSensor := homeSensor^;
+        //     Inputs.Status.WorkSensor := workSensor^;
+        //     _hwId := hwID;
 
-            THIS.Execute();
+        //     THIS.Execute();
 
-            moveHomeSignal^  :=  Outputs.Control.MoveHomeSignal;
-            moveWorkSignal^  :=  Outputs.Control.MoveWorkSignal;
+        //     moveHomeSignal^  :=  Outputs.Control.MoveHomeSignal;
+        //     moveWorkSignal^  :=  Outputs.Control.MoveWorkSignal;
 
-            THIS.Close();
+        //     THIS.Close();
 
-        END_METHOD
+        // END_METHOD
 
         METHOD PRIVATE Execute 
 

--- a/src/template.axolibrary/ctrl/test/CylinderTests.st
+++ b/src/template.axolibrary/ctrl/test/CylinderTests.st
@@ -12,23 +12,42 @@ NAMESPACE Template.Axolibrary.Tests
     {TestFixture}
     {S7.extern=ReadWrite}
     CLASS CylinderTests 
-        VAR 
-            context : TestContext;
-            cylinder : TemplateComponent;
+        VAR PROTECTED
+            _context         :   TestContext;
+            _rootObject      :   MockAxoObject;
+            _cylinder : TemplateComponent;
             _homeSensor : BOOL;
             _workSensor : BOOL;
             _moveHomeSignal : BOOL;
             _moveWorkSignal : BOOL;
             _done : BOOL;
-        END_VAR           
+        END_VAR        
+                
+        VAR PRIVATE
+            _contextClean    :   TestContext;
+            _rtc             :   AXOpen.Core.Dummies.MockAxoRtc;
+            _rtm             :   AXOpen.Core.Dummies.MockAxoRtm;
+        END_VAR    
+
+        {TestSetup}
+        METHOD PUBLIC TestSetup
+            _context    :=  _contextClean;  
+            _rootObject.InitializeWithContext(_context);
+            _rtm.SetElapsed(LTIME#2s);
+            _context.InjectRtm(_rtm);
+            _rtc.SetNowUTC(LDATE_AND_TIME#2012-01-12-15:58:12.123);
+            _context.InjectRtc(_rtc);
+            _rootObject.InitializeWithContext(_context);
+        END_METHOD
+    
         {Test}
         METHOD PUBLIC MoveHome
             WHILE _done DO
-                context.Open();
-                _done := Cylinder.MoveToHome().IsDone();
-                cylinder.Run(context, WORD#64, REF(_homeSensor), REF(_workSensor), REF(_moveHomeSignal), REF(_moveWorkSignal));
+                _context.Open();
+                _done := _cylinder.MoveToHome().IsDone();
+                _cylinder.Run(_rootObject, WORD#64, REF(_homeSensor), REF(_workSensor), REF(_moveHomeSignal), REF(_moveWorkSignal));
                 AxUnit.Assert.Equal(_moveHomeSignal, _moveHomeSignal);   
-                context.Close();            
+                _context.Close();            
             END_WHILE;
         END_METHOD
     END_CLASS    


### PR DESCRIPTION
This pull request includes changes to several components in the `AXOpen` namespace, primarily focusing on the removal of the `Run` method from various files. The `Run` method has been commented out, which includes its input parameters, initialization, and error handling logic.

Key changes include:

### Method Removals:
* [`src/components.abb.robotics/ctrl/src/AxoIrc5_v_1_x_x.st`](diffhunk://#diff-7818601baeaea61d1f9a8e9a5984edefa9b3bbb3aea14328e733a5bbfc47ed09L159-R196): Commented out the `Run` method, which includes the initialization and error handling for `parent`, `hwID`, `hwIdDI_64_bytes`, and `hwIdDO_64_bytes`.
* [`src/components.abb.robotics/ctrl/src/AxoOmnicore_v_1_x_x.st`](diffhunk://#diff-49585acb2afa91a41db66546782e454cc8f2e6b6a3faa60a30227ec1cf278e7dL159-R196): Commented out the `Run` method, which includes the initialization and error handling for `parent`, `hwID`, `hwIdDI_64_bytes`, and `hwIdDO_64_bytes`.
* [`src/components.balluff.identification/ctrl/src/Axo_BIS_M_4XX_045.st`](diffhunk://#diff-8c1c1ff707067acf72131e50c682b3ae2c530a6cf9dc250d329cf3d6ac8b0639L183-R210): Commented out the `Run` method, which includes the initialization and error handling for `parent`, `hwID`, and `hwId_BISM`.
* [`src/components.cognex.vision/ctrl/src/AxoDataman/v_6_0_0/AxoDataman.st`](diffhunk://#diff-26f7e74abe175b4fec95d6123b07627c2c6009aff48143599350f97b37368a90L216-R288): Commented out the `Run` method, which includes the initialization and error handling for various hardware IDs and result data sizes.
* [`src/components.cognex.vision/ctrl/src/AxoInsight/v_6_0_0/AxoInsight.st`](diffhunk://#diff-51bb9bd34ff3e769381cf73a46ad14ed2d734f9e0c9bf108cd0f84cef3a15a3aL260-R338): Commented out the `Run` method, which includes the initialization and error handling for various hardware IDs and result data sizes.

### New Methods:
* [`src/abstractions/ctrl/src/AxoObject/IAxoObject.st`](diffhunk://#diff-547ffbcca9175723888de9ef71dd848a240870a75a8f0fdf76889728117f3d52R7): Added a new method `GetParent` to the `IAxoObject` interface.

closes #605