### PR TITLE
Update AxoDataLocalExchange variable visibility

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoObject/AxoObjectDiagnosticsView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoObject/AxoObjectDiagnosticsView.razor
@@ -34,7 +34,10 @@
            @{
             foreach (var message in MessageProvider.Messengers)
             {
-                if (message.State > eAxoMessengerState.Idle)
+                if (message.State >= eAxoMessengerState.Idle)
+                {
+                    <AxoMessengerView Component="message"></AxoMessengerView>
+                }
                 {
                     <AxoMessengerView Component="message"></AxoMessengerView>
                 }

--- a/src/data/ctrl/src/AxoDataLocalExchange.st
+++ b/src/data/ctrl/src/AxoDataLocalExchange.st
@@ -6,9 +6,9 @@ NAMESPACE AXOpen.Data
     /// </summary>
     {S7.extern=ReadWrite}
     CLASS PUBLIC ABSTRACT AxoDataLocalExchange EXTENDS AXOpen.Core.AxoObject IMPLEMENTS IAxoDataExchange                 
-        VAR  PROTECTED                              
-            operation : eCrudOperation;                              
-            dataExchangeTask : AxoTask; 
+        VAR  PUBLIC                              
+            dataExchangeTask : AxoDataCrudTask; 
+            operation : eCrudOperation;
         END_VAR
                                                            
         METHOD PUBLIC ABSTRACT Create : IAxoTaskState


### PR DESCRIPTION
This pull request includes changes to improve the diagnostics view and data exchange functionality in the `AXOpen` project. The most important changes include modifying the condition to display messenger views and changing the visibility of a variable in the `AxoDataLocalExchange` class.

Improvements to diagnostics view:

* [`src/core/src/AXOpen.Core.Blazor/AxoObject/AxoObjectDiagnosticsView.razor`](diffhunk://#diff-393e3948cbaf65d4e3224ae9046197357bde8278a0e9b6fc94d9b7d5390bb6faL37-R40): Modified the condition to display `AxoMessengerView` components by checking if the message state is greater than or equal to `eAxoMessengerState.Idle`.

Enhancements to data exchange functionality:

* [`src/data/ctrl/src/AxoDataLocalExchange.st`](diffhunk://#diff-e0d3a63520582bad1c97e3bb41d0db57afb324e0af9d26e05fe85cea2f731ba6L9-L11): Changed the visibility of the `dataExchangeTask` variable from `PROTECTED` to `PUBLIC` and updated its type to `AxoDataCrudTask`.