### PR TITLE
Bump AXSharp package versions to 0.24.0-alpha.383

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.24.0-alpha.383",
+      "version": "0.24.0-alpha.386",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.24.0-alpha.383",
+      "version": "0.24.0-alpha.386",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.24.0-alpha.383",
+      "version": "0.24.0-alpha.386",
       "commands": [
         "ixr"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.23.0-alpha.362",
+      "version": "0.24.0-alpha.383",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.23.0-alpha.362",
+      "version": "0.24.0-alpha.383",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.23.0-alpha.362",
+      "version": "0.24.0-alpha.383",
       "commands": [
         "ixr"
       ],

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,11 +9,11 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.24.0-alpha.383" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.24.0-alpha.383" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.24.0-alpha.383" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.24.0-alpha.383" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.24.0-alpha.383" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.24.0-alpha.386" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.24.0-alpha.386" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.24.0-alpha.386" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.24.0-alpha.386" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.24.0-alpha.386" />
     <!-- AX# END -->
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,11 +9,11 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.23.0-alpha.362" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.23.0-alpha.362" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.23.0-alpha.362" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.23.0-alpha.362" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.23.0-alpha.362" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.24.0-alpha.383" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.24.0-alpha.383" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.24.0-alpha.383" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.24.0-alpha.383" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.24.0-alpha.383" />
     <!-- AX# END -->
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />

--- a/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
+++ b/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
@@ -4,8 +4,8 @@ USING AXOpen.Core;
 NAMESPACE AXOpen.Messaging.Static    
 
     TYPE                    
-        eAxoMessengerState : (  ActiveAlreadyAcknowledged,      // 0 - Is still active, but already acknowledged, after acknowledgement goes to 1
-                                Idle,                           // 1 - Not active
+        eAxoMessengerState : (  Idle,                           // 0 - Not active
+                                ActiveAlreadyAcknowledged,      // 1 - Is still active, but already acknowledged, after acknowledgement goes to 1                               
                                 ActiveAcknowledgeRequired,      // 2 - Active and required acknowledgement. If acknowledged before deactivation, it goes to 0, if deactivated before acknowledgement, it goes to 4
                                 ActiveAcknowledgeNotRequired,   // 3 - Active without acknowledgement required. After deactivation it goes to 1.
                                 InactiveWaitingForAcknowledge,  // 4 - Not active waiting for acknowledgement. After acknowledgement it goes to 1.

--- a/src/core/ctrl/src/AxoTask/AxoTask.st
+++ b/src/core/ctrl/src/AxoTask/AxoTask.st
@@ -72,7 +72,9 @@ NAMESPACE AXOpen.Core
             /// Provides some error messages.            
             ///</summary> 
             {#ix-set:AttributeName = "<#Messenger#>"}
-            {#ix-set:PlcTextList = "[1]:'<#Execute method is not called cyclically.#>':'<#Check task calling in the code, task is not calling cyclically.#>;'[2]:'<#Execute method is called more then once inside one PLC cycle.#>':'<#Check task calling in the code, task is called more then once.#>';[3]:'<#Invalid Rtm.#>':'<#Check the inicialization of the Rtm.#>'"}
+            {#ix-set:PlcTextList = "[1]:'<#Execute method is not called cyclically.#>':'<#Check task calling in the code, task is not calling cyclically.#>'';
+                                    [2]:'<#Execute method is called more then once inside one PLC cycle.#>':'<#Check task calling in the code, task is called more then once.#>';
+                                    [3]:'<#Invalid Rtm.#>':'<#Check the inicialization of the Rtm.#>'"}
             _messenger : AXOpen.Messaging.Static.AxoMessenger;
         END_VAR    
         

--- a/src/core/src/AXOpen.Core.Blazor/AxoObject/AxoObjectDiagnosticsView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoObject/AxoObjectDiagnosticsView.razor
@@ -34,10 +34,7 @@
            @{
             foreach (var message in MessageProvider.Messengers)
             {
-                if (message.State >= eAxoMessengerState.Idle)
-                {
-                    <AxoMessengerView Component="message"></AxoMessengerView>
-                }
+                if (message.State != eAxoMessengerState.Idle)
                 {
                     <AxoMessengerView Component="message"></AxoMessengerView>
                 }

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
@@ -106,8 +106,8 @@ public partial class AxoMessenger
 
         return messages;
     }
-    
-    private Dictionary<ulong, AxoMessengerTextItem> plcMessengerTextList = new();
+
+    private Dictionary<ulong, AxoMessengerTextItem> plcMessengerTextList;
     public Dictionary<ulong, AxoMessengerTextItem> PlcMessengerTextList
     {
         get
@@ -121,6 +121,7 @@ public partial class AxoMessenger
             }
             catch (Exception)
             {
+                //plcMessengerTextList = new Dictionary<ulong, AxoMessengerTextItem>();
                 //swallow 
             }
             

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
@@ -1,4 +1,4 @@
-﻿// AXOpen.Core
+// AXOpen.Core
 // Copyright (c)2022 MTS spol. s r.o. and Contributors All Rights Reserved.
 // Contributors: https://github.com/inxton/AXOpen/graphs/contributors
 // See the LICENSE file in the repository root for more information.
@@ -34,6 +34,9 @@ public partial class AxoMessenger
     {
         var messages = new Dictionary<ulong, AxoMessengerTextItem>();
 
+        if(string.IsNullOrEmpty(input))
+            return messages;
+        
         // Split the input by semicolon and remove any empty entries.
         string[] entries = input.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
@@ -8,18 +8,107 @@
 using AXOpen.Base.Data;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Security.Principal;
+using System.Text.RegularExpressions;
 using AXOpen.Core;
 using AXSharp.Connector;
+using Serilog;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace AXOpen.Messaging.Static;
 
 public partial class AxoMessenger
 {
+    /// <summary>
+    /// Parses a string containing multiple message entries into a dictionary.
+    /// Each entry is expected to have the format:
+    /// [number]:'<#message text#>':'<#help text#>'
+    /// Entries should be separated by a semicolon (;).
+    /// Throws an exception if no matches are found, the format is invalid, or a duplicate key exists.
+    /// </summary>
+    /// <param name="input">The string to parse.</param>
+    /// <param name="messenger">Messenger to which the list of messages belongs.</param>
+    /// <returns>A dictionary mapping the key (number) to a MessageEntry instance.</returns>
+    private static Dictionary<ulong, AxoMessengerTextItem> ParseMessages(string input, AxoMessenger messenger)
+    {
+        var messages = new Dictionary<ulong, AxoMessengerTextItem>();
 
-    private List<KeyValuePair<ulong, AxoMessengerTextItem>> plcMessengerTextList;
-    public List<KeyValuePair<ulong, AxoMessengerTextItem>> PlcMessengerTextList
+        // Split the input by semicolon and remove any empty entries.
+        string[] entries = input.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (string entry in entries)
+        {
+            string trimmedEntry = entry.Trim();
+            if (trimmedEntry.Length == 0)
+                continue;
+
+            // Extract key: look for the text between '[' and ']'
+            int startBracket = trimmedEntry.IndexOf('[');
+            int endBracket = trimmedEntry.IndexOf(']', startBracket + 1);
+            if (startBracket == -1 || endBracket == -1)
+            {
+                Log.Error($"Invalid format: missing '[' or ']' for key in `{messenger.Symbol}`");
+                //throw new ArgumentException("Invalid format: missing '[' or ']' for key.");
+            }
+
+            string keyString = trimmedEntry.Substring(startBracket + 1, endBracket - startBracket - 1).Trim();
+            if (!ulong.TryParse(keyString, out ulong key))
+            {
+                Log.Error($"Invalid key format: `{keyString}` in `{messenger.Symbol}`");
+                //throw new ArgumentException($"Invalid key format: {keyString}");
+            }
+            if (messages.ContainsKey(key))
+            {
+                Log.Error($"Duplicate key found: `{key} `in `{messenger.Symbol}`");
+                //throw new ArgumentException($"Duplicate key found: {key}");
+            }
+
+            // After the key, the format should be :'<# ... #>':'<# ... #>'
+            // We'll locate the message and help texts using the positions of single quotes.
+            int firstQuote = trimmedEntry.IndexOf('\'', endBracket);
+            if (firstQuote == -1)
+            {
+                Log.Error($"Invalid format: missing opening quote for message text in `{messenger.Symbol}`");
+                //throw new ArgumentException("Invalid format: missing opening quote for message text.");
+            }
+
+            int secondQuote = trimmedEntry.IndexOf('\'', firstQuote + 1);
+            if (secondQuote == -1)
+            {
+                Log.Error($"Invalid format: missing closing quote for message text. `{messenger.Symbol}`");
+                //throw new ArgumentException("Invalid format: missing closing quote for message text.");
+            }
+
+            // Extract the message text (including the literal <# and #>).
+            string messageText = trimmedEntry.Substring(firstQuote + 1, secondQuote - firstQuote - 1).Trim();
+
+            // Locate the next pair of quotes for the help text.
+            int thirdQuote = trimmedEntry.IndexOf('\'', secondQuote + 1);
+            if (thirdQuote == -1)
+            {
+                Log.Error($"Invalid format: missing opening quote for message text in `{messenger.Symbol}`");
+                //throw new ArgumentException("Invalid format: missing opening quote for message text.");
+            }
+
+            int fourthQuote = trimmedEntry.IndexOf('\'', thirdQuote + 1);
+            if (fourthQuote == -1)
+            {
+                Log.Error($"Invalid format: missing closing quote for message text. `{messenger.Symbol}`");
+                //throw new ArgumentException("Invalid format: missing closing quote for message text.");
+            }
+
+            string helpText = trimmedEntry.Substring(thirdQuote + 1, fourthQuote - thirdQuote - 1).Trim();
+
+            // Add the entry to the dictionary.
+            messages.Add(key, new AxoMessengerTextItem(messageText, helpText));
+        }
+
+        return messages;
+    }
+    
+    private Dictionary<ulong, AxoMessengerTextItem> plcMessengerTextList = new();
+    public Dictionary<ulong, AxoMessengerTextItem> PlcMessengerTextList
     {
         get
         {
@@ -27,72 +116,15 @@ public partial class AxoMessenger
             {
                 if (plcMessengerTextList == null)
                 {
-                    plcMessengerTextList = new List<KeyValuePair<ulong, AxoMessengerTextItem>>();
-                    if (PlcTextList != null)
-                    {
-                        string[] items = PlcTextList.Split('\n');
-                        //All message texts and help texts are in one line
-                        if (items.Length == 1)
-                        {
-                            string[] delimiters = { "[", "]:'", "':'", "';", "'" };
-                            string[] itemSeparated = items[0].Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
-                            try
-                            {
-                                if (itemSeparated.Length >= 3 && itemSeparated.Length % 3 == 0)
-                                {
-                                    int itemsCount = itemSeparated.Length / 3;
-                                    for (int i = 0; i < itemsCount; i++)
-                                    {
-                                        ulong messageCode = 0;
-                                        if (ulong.TryParse(itemSeparated[3 * i], out messageCode))
-                                        {
-                                            string messageText = string.IsNullOrEmpty(itemSeparated[3 * i + 1]) ? "Message text not defined for the message code: " + messageCode.ToString() + "!" : itemSeparated[3 * i + 1];
-                                            string helpText = string.IsNullOrEmpty(itemSeparated[3 * i + 2]) ? "Help text not defined for the message code: " + messageCode.ToString() + "!" : itemSeparated[3 * i + 2];
-                                            plcMessengerTextList.Add(new KeyValuePair<ulong, AxoMessengerTextItem>(messageCode, new AxoMessengerTextItem(messageText, helpText)));
-                                        }
-                                    }
-                                }
-                            }
-                            catch (Exception)
-                            {
-                                throw;
-                            }
-                        }
-                        //Each pair of the  Id message text and help text are in the separate line (change on the compilator side needs to be implemented)
-                        else if (items.Length > 1)
-                        {
-                            foreach (string item in items)
-                            {
-                                string[] delimiters = { "[", "]:'", "':'", "'" };
-                                string[] itemSeparated = item.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
-                                try
-                                {
-                                    ulong messageCode = 0;
-                                    if (ulong.TryParse(itemSeparated[0], out messageCode))
-                                    {
-                                        string messageText = string.IsNullOrEmpty(itemSeparated[1]) ? "Message text not defined for the message code: " + messageCode.ToString() + "!" : itemSeparated[1];
-                                        string helpText = string.IsNullOrEmpty(itemSeparated[2]) ? "Help text not defined for the message code: " + messageCode.ToString() + "!" : itemSeparated[2];
-                                        plcMessengerTextList.Add(new KeyValuePair<ulong, AxoMessengerTextItem>(messageCode, new AxoMessengerTextItem(messageText, helpText)));
-                                    }
-                                }
-                                catch (Exception)
-                                {
-                                    throw;
-                                }
-                            }
-                        }
-
-                    }
+                    plcMessengerTextList = ParseMessages(this.PlcTextList, this);
                 }
-                return plcMessengerTextList;
             }
-
             catch (Exception)
             {
-
-                throw;
+                //swallow 
             }
-
+            
+            return plcMessengerTextList;
         }
     }
 


### PR DESCRIPTION
This pull request includes updates to various package versions in the project configuration files. The primary changes involve upgrading the versions of several `AXSharp` tools and packages to ensure compatibility and access to the latest features.

Version updates:

* [`.config/dotnet-tools.json`](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6): Updated versions for `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` from `0.23.0-alpha.362` to `0.24.0-alpha.383`. [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)
* [`src/Directory.Packages.props`](diffhunk://#diff-4d59c677ea4c9112e0ce2f2e527693f48dcbcf66ba4eeb4b01abb5f3da8bbe11L12-R16): Updated versions for `AXSharp.Abstractions`, `AXSharp.Connector`, `AXSharp.Connector.S71500.WebAPI`, `AXSharp.Presentation.Blazor`, and `AXSharp.Presentation.Blazor.Controls` from `0.23.0-alpha.362` to `0.24.0-alpha.383`.