### PR TITLE
Update to sdk 2504 

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.24.0-preview.158",
+      "version": "0.30.0-alpha.187",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.24.0-preview.158",
+      "version": "0.30.0-alpha.187",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.24.0-preview.158",
+      "version": "0.30.0-alpha.187",
       "commands": [
         "ixr"
       ],

--- a/scripts/check_requisites.ps1
+++ b/scripts/check_requisites.ps1
@@ -6,7 +6,7 @@ $dotNetWingetInstall = "Microsoft.DotNet.SDK.9 --version 9.0.100"
 
 $visualStudioRequiredVersionRange = "[17.8.0,18.0)";
 
-$apaxRequiredVersion = "3.4.2"
+$apaxRequiredVersion = "3.5.0"
 $apaxUrl = "https://console.simatic-ax.siemens.io/"
 $axCodeRequiredVersion = "1.94.2"
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,12 +9,15 @@
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
 
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.24.0-preview.158" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.24.0-preview.158" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.24.0-preview.158" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.24.0-preview.158" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.24.0-preview.158" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.30.0-alpha.187" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.30.0-alpha.187" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.30.0-alpha.187" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.30.0-alpha.187" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.30.0-alpha.187" />    
     <!-- AX# END -->
+
+    <!-- Other -->
+    <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.44" />
 
     <PackageVersion Include="ClosedXML" Version="0.104.2" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
@@ -29,7 +32,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
     <PackageVersion Include="Siemens.Simatic.S7.Webserver.API" Version="3.2.1" />    
-    <PackageVersion Include="AXOpen.KristofferStrube.Blazor.SVGEditor" Version="0.4.4-alpha.296" />
+    <PackageVersion Include="AXOpen.KristofferStrube.Blazor.SVGEditor" Version="0.4.4-alpha.298" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -10,6 +10,7 @@
     <packageSource key="gh-packages-inxton">
       <package pattern="AXSharp.*"/>
       <package pattern="AXOpen.*"/>
+      <package pattern="Inxton.*" />
     </packageSource>
     
     <!-- Get all other packages from nuget.org -->

--- a/src/abstractions/app/apax.yml
+++ b/src/abstractions/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/abstractions/app/apax.yml
+++ b/src/abstractions/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -6,15 +6,15 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
-  "@ax/simatic-1500-clocks": 9.0.1
-  "@ax/system-bitaccess": 9.0.12
-  "@ax/system-math": 9.0.12
-  "@ax/system-serde": 9.0.12
-  "@ax/dcp-utility": 1.1.3
+  "@ax/simatic-1500-clocks": 10.0.6
+  "@ax/system-bitaccess": 10.0.24
+  "@ax/system-math": 10.0.24
+  "@ax/system-serde": 10.0.24
+  "@ax/dcp-utility": 1.2.0
   "@ax/hardware-diagnostics": 0.3.0
 installStrategy: strict
 apaxVersion: 3.4.2

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -6,17 +6,17 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
   "@inxton/ax.axopen.min": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": 9.0.3
-  "@ax/simatic-1500-diagnostics-hardware": 9.0.0
-  "@ax/simatic-1500-clocks": 9.0.1
-  "@ax/system-timer": 9.0.12
-  "@ax/system-serde": 9.0.12
-  "@ax/system-bitaccess": 9.0.12
+  "@ax/simatic-1500-distributedio": 10.0.1
+  "@ax/simatic-1500-diagnostics-hardware": 10.0.0
+  "@ax/simatic-1500-clocks": 10.0.6
+  "@ax/system-timer": 10.0.24
+  "@ax/system-serde": 10.0.24
+  "@ax/system-bitaccess": 10.0.24
 installStrategy: strict
 apaxVersion: 3.4.2
 scripts:

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -6,11 +6,11 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
-  "@ax/system-strings": 9.0.12
+  "@ax/system-strings": 10.0.24
 installStrategy: strict
 apaxVersion: 3.4.2
 scripts:

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.catalog/apax.yml
+++ b/src/ax.catalog/apax.yml
@@ -1,79 +1,78 @@
 name: "@inxton/ax.catalog"
-version: '0.0.19'
+version: '0.0.22'
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 type: catalog
 keywords:
   - "catalog"
 catalogDependencies:
-  "@ax/apax-build": 2.0.20
-  "@ax/ax2tia": 11.0.18
-  "@ax/axunit-mocking": 8.0.33
-  "@ax/axunitst": 8.0.33
-  "@ax/axunitst-library": 8.0.33
-  "@ax/axunitst-ls-contrib": 8.0.33
-  "@ax/build-native": 16.1.17
-  "@ax/certificate-management": 1.2.0
-  "@ax/dcp-utility": 1.2.0
-  "@ax/diagnostic-buffer": 1.3.2
-  "@ax/hardware-diagnostics": 0.3.0
-  "@ax/hw-s7-1500": 3.0.0
-  "@ax/hwc": 3.0.0
-  "@ax/hwld": 3.0.0
-  "@ax/mod": 1.7.6
-  "@ax/mon": 1.7.6
-  "@ax/performance-info": 1.1.2
-  "@ax/plc-control": 1.2.50
-  "@ax/plc-info": 3.1.0
-  "@ax/sdb": 1.7.6
-  "@ax/simatic-1500-alarming": 4.0.0
-  "@ax/simatic-1500-clocks": 10.0.6
-  "@ax/simatic-1500-communication": 10.0.0
-  "@ax/simatic-1500-crypto": 3.0.2
-  "@ax/simatic-1500-diagnostics": 4.0.2
-  "@ax/simatic-1500-diagnostics-hardware": 10.0.0
-  "@ax/simatic-1500-distributedio": 10.0.1
-  "@ax/simatic-1500-fileaccess": 9.0.3
-  "@ax/simatic-1500-hardware-utilities": 5.0.5
-  "@ax/simatic-1500-ip-configuration": 10.0.2
-  "@ax/simatic-1500-memoryaccess": 5.0.5
-  "@ax/simatic-1500-modbusrtu": 3.0.5
-  "@ax/simatic-1500-motioncontrol-native-v5": 9.0.1
-  "@ax/simatic-1500-motioncontrol-native-v6": 9.0.1
-  "@ax/simatic-1500-motioncontrol-native-v7": 9.0.1
-  "@ax/simatic-1500-motioncontrol-native-v8": 9.0.1
-  "@ax/simatic-1500-motioncontrol-native-v9": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v7": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v7-mocking": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v8": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v8-mocking": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v9": 9.0.1
-  "@ax/simatic-1500-motioncontrol-v9-mocking": 9.0.1
-  "@ax/simatic-1500-pointtopoint": 3.0.4
-  "@ax/simatic-1500-tasks": 10.0.1
-  "@ax/simatic-1500-technology-objects": 3.0.8
-  "@ax/simatic-package-tool": 2.0.15
-  "@ax/sld": 3.2.4
-  "@ax/st-lang-contrib-xlad": 1.2.0
-  "@ax/st-ls": 10.0.85
-  "@ax/st-opcua.stc-plugin": 1.0.0
-  "@ax/st-resources.stc-plugin": 3.0.23
-  "@ax/stc": 10.0.85
-  "@ax/system": 10.0.24
-  "@ax/system-bitaccess": 10.0.24
-  "@ax/system-conversion": 10.0.24
-  "@ax/system-counters": 10.0.24
-  "@ax/system-datetime": 10.0.24
-  "@ax/system-edgedetection": 10.0.24
-  "@ax/system-fastmath": 10.0.24
-  "@ax/system-math": 10.0.24
-  "@ax/system-selection": 10.0.24
-  "@ax/system-serde": 10.0.24
-  "@ax/system-strings": 10.0.24
-  "@ax/system-timer": 10.0.24
-  "@ax/target-llvm": 10.0.85
-  "@ax/target-mc7plus": 10.0.85
-  "@ax/trace": 2.9.0
-  "@ax/xlad-transpile-cli": 1.2.0
-  # "@ax/sdk": 2504.0.0
-
+  "@ax/apax-build": 2.0.20                                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  2.0.20
+  "@ax/ax2tia": 11.0.18                                           # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  11.0.18
+  "@ax/axunit-mocking": 8.0.33                                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  8.0.33  
+  "@ax/axunitst": 8.0.33                                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  8.0.33  
+  "@ax/axunitst-library": 8.0.33                                  # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  8.0.33  
+  "@ax/axunitst-ls-contrib": 8.0.33                               # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  8.0.33  
+  "@ax/build-native": 16.1.17                                     # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  16.1.17
+  "@ax/certificate-management": 1.2.0                             # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.2.0
+  "@ax/dcp-utility": 1.2.0                                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.2.0
+  "@ax/diagnostic-buffer": 1.3.2                                  # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.3.2
+  "@ax/hardware-diagnostics": 0.3.0                               # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  0.3.0
+  "@ax/hw-s7-1500": 3.1.0                                         # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.0
+  "@ax/hwc": 3.1.0                                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.0
+  "@ax/hwld": 3.1.0                                               # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.0
+  "@ax/mod": 1.7.6                                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.7.6
+  "@ax/mon": 1.7.6                                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.7.6
+  "@ax/performance-info": 1.1.2			                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.1.2
+  "@ax/plc-control": 1.2.50                                       # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.2.50
+  "@ax/plc-info": 3.1.0			                                      # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.1.0
+  "@ax/sdb": 1.7.6			                                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.7.6
+  "@ax/simatic-1500-alarming": 4.0.0			                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  4.0.0
+  "@ax/simatic-1500-clocks": 10.0.6			                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.6
+  "@ax/simatic-1500-communication": 10.0.0		                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.0
+  "@ax/simatic-1500-crypto": 3.0.2			                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.2
+  "@ax/simatic-1500-diagnostics": 4.0.2			                      # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  4.0.2
+  "@ax/simatic-1500-diagnostics-hardware": 10.0.0	                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.0
+  "@ax/simatic-1500-distributedio": 10.0.1		                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.1
+  "@ax/simatic-1500-fileaccess": 9.0.3			                      # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.3
+  "@ax/simatic-1500-hardware-utilities": 5.0.5			              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  5.0.5
+  "@ax/simatic-1500-ip-configuration": 10.0.2 			              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.2
+  "@ax/simatic-1500-memoryaccess": 5.0.5			                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  5.0.5
+  "@ax/simatic-1500-modbusrtu": 3.0.5   			                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.5
+  "@ax/simatic-1500-motioncontrol-native-v5": 9.0.1 			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v6": 9.0.1 			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v7": 9.0.1 			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v8": 9.0.1 			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v9": 9.0.1 			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v7": 9.0.1			                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v7-mocking": 9.0.1			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v8": 9.0.1			                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v8-mocking": 9.0.1			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v9": 9.0.1			                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-motioncontrol-v9-mocking": 9.0.1			        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  9.0.1
+  "@ax/simatic-1500-pointtopoint": 3.0.4			                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.4
+  "@ax/simatic-1500-tasks": 10.0.1		                            # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.1
+  "@ax/simatic-1500-technology-objects": 3.0.8                    # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.8
+  "@ax/simatic-package-tool": 2.0.15			                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  2.0.15
+  "@ax/sld": 3.3.0			                                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.2.4
+  "@ax/st-lang-contrib-xlad": 1.2.0                               # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.2.0
+  "@ax/st-ls": 10.0.85		                                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.85
+  "@ax/st-opcua.stc-plugin": 1.0.0                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.0.0
+  "@ax/st-resources.stc-plugin": 3.0.23			                      # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  3.0.23
+  "@ax/stc": 10.0.85		                                          # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.85
+  "@ax/system": 10.0.24			                                      # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-bitaccess": 10.0.24			                            # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-conversion": 10.0.24		                            # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-counters": 10.0.24		                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-datetime": 10.0.24		                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-edgedetection": 10.0.24			                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-fastmath": 10.0.24		                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-math": 10.0.24		                                  # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-selection": 10.0.24			                            # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-serde": 10.0.24			                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-strings": 10.0.24			                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/system-timer": 10.0.24			                                # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.24
+  "@ax/target-llvm": 10.0.85		                                  # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.85
+  "@ax/target-mc7plus": 10.0.85			                              # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  10.0.85
+  "@ax/trace": 2.9.0			                                        # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  2.9.0
+  "@ax/xlad-transpile-cli": 1.2.0                                 # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  1.2.0
+  # "@ax/sdk": 2504.0.0-rc.2			                                  # @ax/simatic-ax@2504.0.0  contained at the time of creation this catalog (7.5.2025) version  2504.0.0

--- a/src/ax.catalog/apax.yml
+++ b/src/ax.catalog/apax.yml
@@ -1,73 +1,79 @@
 name: "@inxton/ax.catalog"
-version: '0.0.9'
+version: '0.0.19'
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 type: catalog
 keywords:
   - "catalog"
 catalogDependencies:
-  "@ax/apax-build": 2.0.20                                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.20
-  "@ax/axunit-mocking": 7.1.6                                     # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  7.0.11
-  "@ax/axunitst": 7.1.6                                           # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  7.0.11
-  "@ax/axunitst-library": 7.1.6                                   # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  7.0.11
-  "@ax/axunitst-ls-contrib": 7.1.6                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  7.0.11
-  "@ax/build-native": 16.0.3                                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  16.0.3
-  "@ax/certificate-management": 1.1.3                             # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.1.3
-  "@ax/dcp-utility": 1.1.3                                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.1.3
-  "@ax/diagnostic-buffer": 1.3.2                                  # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.3.2
-  "@ax/hardware-diagnostics": 0.3.0                               # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  0.3.0
-  "@ax/hw-s7-1500": 2.1.0                                         # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.65
-  "@ax/hwc": 2.1.0                                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.65
-  "@ax/hwld": 2.1.0                                               # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.20
-  "@ax/mod": 1.6.5                                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.6.5
-  "@ax/mon": 1.6.5                                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.6.5
-  "@ax/opcua-server-config": 2.0.0			                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.0
-  "@ax/performance-info": 1.1.2			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.1.2
-  "@ax/plc-info": 3.0.0			                                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  3.0.0
-  "@ax/sdb": 1.6.5			                                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  1.6.5
-  "@ax/simatic-1500": 8.0.3			                                  # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.3
-  "@ax/simatic-1500-alarming": 3.0.3			                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  3.0.3
-  "@ax/simatic-1500-clocks": 9.0.1			                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.1
-  "@ax/simatic-1500-communication": 9.0.0			                    # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.0
-  "@ax/simatic-1500-crypto": 2.0.7			                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.7
-  "@ax/simatic-1500-diagnostics": 3.0.3			                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  3.0.3
-  "@ax/simatic-1500-diagnostics-hardware": 9.0.0	                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.0
-  "@ax/simatic-1500-distributedio": 9.0.3			                    # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.3
-  "@ax/simatic-1500-fileaccess": 8.0.1			                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.1
-  "@ax/simatic-1500-hardware-utilities": 4.0.7			              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  4.0.7
-  "@ax/simatic-1500-memoryaccess": 4.0.7			                    # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  4.0.7
-  "@ax/simatic-1500-motioncontrol-native-v5": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-native-v6": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-native-v7": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-native-v8": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-native-v9": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v7": 8.0.11			                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v7-mocking": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v8": 8.0.11			                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v8-mocking": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v9": 8.0.11			                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-motioncontrol-v9-mocking": 8.0.11			        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  8.0.11
-  "@ax/simatic-1500-processimage": 9.0.1			                    # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.1
-  "@ax/simatic-1500-tasks": 9.0.3			                            # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.3
-  "@ax/simatic-package-tool": 2.0.11			                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.11
-  "@ax/simatic-pragma-stc-plugin": 5.0.8			                    # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  5.0.8
-  "@ax/sld": 3.1.3			                                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  3.1.2
-  "@ax/st-ls": 9.0.72			                                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.72
-  "@ax/st-resources.stc-plugin": 2.0.10			                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.0.10
-  "@ax/stc": 9.0.72			                                          # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.72
-  "@ax/system": 9.0.12			                                      # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-bitaccess": 9.0.12			                            # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-conversion": 9.0.12			                            # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-counters": 9.0.12			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-datetime": 9.0.12			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-edgedetection": 9.0.12			                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-fastmath": 9.0.12			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-math": 9.0.12			                                  # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-selection": 9.0.12			                            # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-serde": 9.0.12			                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-strings": 9.0.12			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/system-timer": 9.0.12			                                # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.12
-  "@ax/target-llvm": 9.0.72			                                  # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.72
-  "@ax/target-mc7plus": 9.0.72			                              # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  9.0.72
-  "@ax/trace": 2.9.0			                                        # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2.8.1
-# "@ax/sdk": 2504.0.0-rc.1			                                  # @ax/simatic-ax@2504.0.0-rc.1  contained at the time of creation this catalog (1.3.2025) version  2504.0.0-rc.1
+  "@ax/apax-build": 2.0.20
+  "@ax/ax2tia": 11.0.18
+  "@ax/axunit-mocking": 8.0.33
+  "@ax/axunitst": 8.0.33
+  "@ax/axunitst-library": 8.0.33
+  "@ax/axunitst-ls-contrib": 8.0.33
+  "@ax/build-native": 16.1.17
+  "@ax/certificate-management": 1.2.0
+  "@ax/dcp-utility": 1.2.0
+  "@ax/diagnostic-buffer": 1.3.2
+  "@ax/hardware-diagnostics": 0.3.0
+  "@ax/hw-s7-1500": 3.0.0
+  "@ax/hwc": 3.0.0
+  "@ax/hwld": 3.0.0
+  "@ax/mod": 1.7.6
+  "@ax/mon": 1.7.6
+  "@ax/performance-info": 1.1.2
+  "@ax/plc-control": 1.2.50
+  "@ax/plc-info": 3.1.0
+  "@ax/sdb": 1.7.6
+  "@ax/simatic-1500-alarming": 4.0.0
+  "@ax/simatic-1500-clocks": 10.0.6
+  "@ax/simatic-1500-communication": 10.0.0
+  "@ax/simatic-1500-crypto": 3.0.2
+  "@ax/simatic-1500-diagnostics": 4.0.2
+  "@ax/simatic-1500-diagnostics-hardware": 10.0.0
+  "@ax/simatic-1500-distributedio": 10.0.1
+  "@ax/simatic-1500-fileaccess": 9.0.3
+  "@ax/simatic-1500-hardware-utilities": 5.0.5
+  "@ax/simatic-1500-ip-configuration": 10.0.2
+  "@ax/simatic-1500-memoryaccess": 5.0.5
+  "@ax/simatic-1500-modbusrtu": 3.0.5
+  "@ax/simatic-1500-motioncontrol-native-v5": 9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v6": 9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v7": 9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v8": 9.0.1
+  "@ax/simatic-1500-motioncontrol-native-v9": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v7": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v7-mocking": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v8": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v8-mocking": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v9": 9.0.1
+  "@ax/simatic-1500-motioncontrol-v9-mocking": 9.0.1
+  "@ax/simatic-1500-pointtopoint": 3.0.4
+  "@ax/simatic-1500-tasks": 10.0.1
+  "@ax/simatic-1500-technology-objects": 3.0.8
+  "@ax/simatic-package-tool": 2.0.15
+  "@ax/sld": 3.2.4
+  "@ax/st-lang-contrib-xlad": 1.2.0
+  "@ax/st-ls": 10.0.85
+  "@ax/st-opcua.stc-plugin": 1.0.0
+  "@ax/st-resources.stc-plugin": 3.0.23
+  "@ax/stc": 10.0.85
+  "@ax/system": 10.0.24
+  "@ax/system-bitaccess": 10.0.24
+  "@ax/system-conversion": 10.0.24
+  "@ax/system-counters": 10.0.24
+  "@ax/system-datetime": 10.0.24
+  "@ax/system-edgedetection": 10.0.24
+  "@ax/system-fastmath": 10.0.24
+  "@ax/system-math": 10.0.24
+  "@ax/system-selection": 10.0.24
+  "@ax/system-serde": 10.0.24
+  "@ax/system-strings": 10.0.24
+  "@ax/system-timer": 10.0.24
+  "@ax/target-llvm": 10.0.85
+  "@ax/target-mc7plus": 10.0.85
+  "@ax/trace": 2.9.0
+  "@ax/xlad-transpile-cli": 1.2.0
+  # "@ax/sdk": 2504.0.0
+

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -8,17 +8,17 @@ devDependencies:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 dependencies:
-  "@ax/simatic-1500-clocks": 9.0.1
-  "@ax/system-bitaccess": 9.0.12
-  "@ax/system-math": 9.0.12
-  "@ax/system-serde": 9.0.12
-  "@ax/hwc": 2.1.0
-  "@ax/hw-s7-1500": 2.1.0
-  "@ax/hwld": 2.1.0
-  "@ax/stc": 9.0.72
-  "@ax/sld": 3.1.3
+  "@ax/simatic-1500-clocks": 10.0.6
+  "@ax/system-bitaccess": 10.0.24
+  "@ax/system-math": 10.0.24
+  "@ax/system-serde": 10.0.24
+  "@ax/hwc": 3.1.0
+  "@ax/hw-s7-1500": 3.1.0
+  "@ax/hwld": 3.1.0
+  "@ax/stc": 10.0.85
+  "@ax/sld": 3.3.0
 installStrategy: strict
 apaxVersion: 3.4.2
 scripts:

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -8,7 +8,7 @@ devDependencies:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 dependencies:
   "@ax/simatic-1500-clocks": 9.0.1
   "@ax/system-bitaccess": 9.0.12

--- a/src/components.abb.robotics/app/apax.yml
+++ b/src/components.abb.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.abb.robotics/app/apax.yml
+++ b/src/components.abb.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.abstractions/app/apax.yml
+++ b/src/components.abstractions/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.abstractions/app/apax.yml
+++ b/src/components.abstractions/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.balluff.identification/app/apax.yml
+++ b/src/components.balluff.identification/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.balluff.identification/app/apax.yml
+++ b/src/components.balluff.identification/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.cognex.vision/app/apax.yml
+++ b/src/components.cognex.vision/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.cognex.vision/app/apax.yml
+++ b/src/components.cognex.vision/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.desoutter.tightening/app/apax.yml
+++ b/src/components.desoutter.tightening/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.desoutter.tightening/app/apax.yml
+++ b/src/components.desoutter.tightening/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.drives/app/apax.yml
+++ b/src/components.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.drives/app/apax.yml
+++ b/src/components.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.elements/app/apax.yml
+++ b/src/components.elements/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.elements/app/apax.yml
+++ b/src/components.elements/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.festo.drives/app/apax.yml
+++ b/src/components.festo.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.festo.drives/app/apax.yml
+++ b/src/components.festo.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.keyence.vision/app/apax.yml
+++ b/src/components.keyence.vision/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.keyence.vision/app/apax.yml
+++ b/src/components.keyence.vision/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.kuka.robotics/app/apax.yml
+++ b/src/components.kuka.robotics/app/apax.yml
@@ -18,7 +18,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.kuka.robotics/app/apax.yml
+++ b/src/components.kuka.robotics/app/apax.yml
@@ -18,7 +18,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.mitsubishi.robotics/app/apax.yml
+++ b/src/components.mitsubishi.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.mitsubishi.robotics/app/apax.yml
+++ b/src/components.mitsubishi.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.pneumatics/app/apax.yml
+++ b/src/components.pneumatics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.pneumatics/app/apax.yml
+++ b/src/components.pneumatics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.rexroth.drives/app/apax.yml
+++ b/src/components.rexroth.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.rexroth.drives/app/apax.yml
+++ b/src/components.rexroth.drives/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.rexroth.press/app/apax.yml
+++ b/src/components.rexroth.press/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.rexroth.press/app/apax.yml
+++ b/src/components.rexroth.press/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.robotics/app/apax.yml
+++ b/src/components.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.robotics/app/apax.yml
+++ b/src/components.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.siem.identification/app/apax.yml
+++ b/src/components.siem.identification/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.siem.identification/app/apax.yml
+++ b/src/components.siem.identification/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.ur.robotics/app/apax.yml
+++ b/src/components.ur.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/components.ur.robotics/app/apax.yml
+++ b/src/components.ur.robotics/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/core/app/apax.yml
+++ b/src/core/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/core/app/apax.yml
+++ b/src/core/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/data/app/apax.yml
+++ b/src/data/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/data/app/apax.yml
+++ b/src/data/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
+++ b/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
@@ -18,7 +18,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
+++ b/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
@@ -18,7 +18,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/inspectors/app/apax.yml
+++ b/src/inspectors/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/inspectors/app/apax.yml
+++ b/src/inspectors/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/integrations/app/apax.yml
+++ b/src/integrations/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/integrations/app/apax.yml
+++ b/src/integrations/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/io/app/apax.yml
+++ b/src/io/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/io/app/apax.yml
+++ b/src/io/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/probers/app/apax.yml
+++ b/src/probers/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/probers/app/apax.yml
+++ b/src/probers/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/scripts/check_requisites_apax.sh
+++ b/src/scripts/check_requisites_apax.sh
@@ -1,5 +1,5 @@
 apaxUrl="https://console.simatic-ax.siemens.io/"
-expectedApaxVersion="3.4.2"
+expectedApaxVersion="3.5.0"
 
 export GREEN='\033[0;32m'
 export RED='\033[0;31m'

--- a/src/scripts/clean_plc.sh
+++ b/src/scripts/clean_plc.sh
@@ -27,7 +27,7 @@ if [ -z $PASSWORD ]; then
     exit 1
 fi
 
-apax hwld --target $PLC_IP_ADDRESS --reset-plc KeepOnlyIP --username $USERNAME --password $PASSWORD --accept-security-disclaimer
+apax hwld load --target $PLC_IP_ADDRESS --reset-plc KeepOnlyIP --username $USERNAME --password $PASSWORD --accept-security-disclaimer
 if [[ $? -eq 0 ]]; then
 	printf "${GREEN}PLC was reseted succesfully.${NC}"
 else

--- a/src/scripts/hw_download_only.sh
+++ b/src/scripts/hw_download_only.sh
@@ -48,7 +48,7 @@ if ! [[ -e "$certfile" ]]; then
 	exit 1
 fi        
 
-apax hwld --input bin/hwc/$PLC_NAME --target $PLC_IP_ADDRESS  --username $USERNAME --password $PASSWORD --certificate $certfile --no-input --accept-security-disclaimer --log Information
+apax hwld load --input bin/hwc/$PLC_NAME --target $PLC_IP_ADDRESS  --username $USERNAME --password $PASSWORD --certificate $certfile --no-input --accept-security-disclaimer --log Information
 if [[ $? -eq 0 ]]; then
 	printf "${GREEN}Hardware configuration has been succesfully downloaded.${NC}"
 else

--- a/src/scripts/hw_first_compile_and_first_download.sh
+++ b/src/scripts/hw_first_compile_and_first_download.sh
@@ -71,7 +71,7 @@ else
 	printf "${RED}Please check the details above.${NC}\n"
 	exit 1
 fi
-apax hwld --input bin/hwc/$PLC_NAME --target $PLC_IP_ADDRESS --master-password $PASSWORD --accept-security-disclaimer --log Information
+apax hwld load --input bin/hwc/$PLC_NAME --target $PLC_IP_ADDRESS --master-password $PASSWORD --accept-security-disclaimer --log Information
 if [[ $? -eq 0 ]]; then
 	printf "${GREEN}Hardware configuration has been succesfully downloaded.${NC}"
 else

--- a/src/scripts/setup_secure_communication.sh
+++ b/src/scripts/setup_secure_communication.sh
@@ -132,8 +132,8 @@ if [ -e "$seconfile" ]; then
   rm "$seconfile"
 fi
 
-apax hwc setup-secure-communication --name $PLC_NAME --no-input --input ".\hwc" --master-password $PASSWORD
-apax hwc import-certificate --name $PLC_NAME --input ".\hwc" --certificate "./certs/$PLC_NAME/pkcs12ForCertificateImport.p12" --passphrase $PASSWORD --purpose "TLS"
-apax hwc import-certificate --name $PLC_NAME --input ".\hwc" --certificate "./certs/$PLC_NAME/pkcs12ForCertificateImport.p12" --passphrase $PASSWORD --purpose "WebServer"
-apax hwc set-accessprotection-password --name $PLC_NAME --input ".\hwc" --level "FullAccess" --password $PASSWORD
+apax hwc setup-secure-communication --module-name $PLC_NAME --no-input --input ".\hwc" --master-password $PASSWORD
+apax hwc import-certificate --module-name $PLC_NAME --input ".\hwc" --certificate "./certs/$PLC_NAME/pkcs12ForCertificateImport.p12" --passphrase $PASSWORD --purpose "TLS"
+apax hwc import-certificate --module-name $PLC_NAME --input ".\hwc" --certificate "./certs/$PLC_NAME/pkcs12ForCertificateImport.p12" --passphrase $PASSWORD --purpose "WebServer"
+apax hwc set-accessprotection-password --module-name $PLC_NAME --input ".\hwc" --level "FullAccess" --password $PASSWORD
 apax hwc manage-users --module-name $PLC_NAME --input ".\hwc" set-password --username $USERNAME --password $PASSWORD

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 dependencies:
   '@ax/apax-build': 2.0.20
   '@ax/axunitst': 7.1.6

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,29 +6,29 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 dependencies:
   '@ax/apax-build': 2.0.20
-  '@ax/axunitst': 7.1.6
-  '@ax/axunitst-ls-contrib': 7.1.6
-  '@ax/certificate-management': 1.1.3
+  '@ax/axunitst': 8.0.33
+  '@ax/axunitst-ls-contrib': 8.0.33
+  '@ax/certificate-management': 1.2.0
   '@ax/diagnostic-buffer': 1.3.2
-  '@ax/hw-s7-1500': 2.1.0
-  '@ax/hwc': 2.1.0
-  '@ax/hwld': 2.1.0
-  '@ax/mod': 1.6.5
-  '@ax/mon': 1.6.5
+  '@ax/hw-s7-1500': 3.1.0
+  '@ax/hwc': 3.1.0
+  '@ax/hwld': 3.1.0
+  '@ax/mod': 1.7.6
+  '@ax/mon': 1.7.6
   '@ax/performance-info': 1.1.2
-  '@ax/plc-info': 3.0.0
-  '@ax/sdb': 1.6.5
-  '@ax/simatic-package-tool': 2.0.11
+  '@ax/plc-info': 3.1.0
+  '@ax/sdb': 1.7.6
+  '@ax/simatic-package-tool': 2.0.15
   '@ax/simatic-pragma-stc-plugin': 5.0.8
-  '@ax/sld': 3.1.3
-  '@ax/st-ls': 9.0.72
-  '@ax/st-resources.stc-plugin': 2.0.10
-  '@ax/stc': 9.0.72
-  '@ax/target-llvm': 9.0.72
-  '@ax/target-mc7plus': 9.0.72
+  '@ax/sld': 3.3.0
+  '@ax/st-ls': 10.0.85
+  '@ax/st-resources.stc-plugin': 3.0.23
+  '@ax/stc': 10.0.85
+  '@ax/target-llvm': 10.0.85
+  '@ax/target-mc7plus': 10.0.85
   '@ax/trace': 2.9.0
 installStrategy: strict
 apaxVersion: 3.4.2

--- a/src/simatic1500/app/apax.yml
+++ b/src/simatic1500/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/simatic1500/app/apax.yml
+++ b/src/simatic1500/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/template.axolibrary/app/apax.yml
+++ b/src/template.axolibrary/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/template.axolibrary/app/apax.yml
+++ b/src/template.axolibrary/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/timers/app/apax.yml
+++ b/src/timers/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/timers/app/apax.yml
+++ b/src/timers/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/traversals/apax/apax.yml
+++ b/src/traversals/apax/apax.yml
@@ -13,7 +13,7 @@ dependencies:
   '@inxton/ax.axopen.app': 0.0.0-dev.0
   '@inxton/ax.axopen.hwlibrary': 0.0.0-dev.0
   '@inxton/ax.axopen.min': 0.0.0-dev.0
-  '@inxton/ax.catalog': 0.0.9
+  '@inxton/ax.catalog': 0.0.22
   '@inxton/ax.latest.packages': 0.0.0-dev.0
   app_axopen.components.abb.robotics: 0.0.0-dev.0
   '@inxton/axopen.components.abb.robotics': 0.0.0-dev.0

--- a/src/utils/app/apax.yml
+++ b/src/utils/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.19
+  "@inxton/ax.catalog": 0.0.22
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/utils/app/apax.yml
+++ b/src/utils/app/apax.yml
@@ -19,7 +19,7 @@ variables:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.9
+  "@inxton/ax.catalog": 0.0.19
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:


### PR DESCRIPTION
This pull request includes updates to dependency versions and catalog configurations across multiple files to ensure compatibility and maintain consistency. The changes primarily involve upgrading the `@inxton/ax.catalog` version, updating the `apaxRequiredVersion`, and revising catalog dependencies for the `@inxton/ax.catalog`.

### Dependency Version Updates:
* Updated `apaxRequiredVersion` in `scripts/check_requisites.ps1` from `3.4.2` to `3.5.0` to align with the latest requirements.
* Upgraded the `@inxton/ax.catalog` version from `0.0.9` to `0.0.19` across multiple `apax.yml` files, including components like `abb.robotics`, `festo.drives`, and `rexroth.drives`. These updates ensure consistency across projects. (e.g., [[1]](diffhunk://#diff-66a817b168854b13744e779f6f789c52368682b5a72b5da28272377b1b81b9b8L22-R22) [[2]](diffhunk://#diff-b7adc7d14d8f3cd2fa69625674b9dd8c3233b6bdc5651e126858427018481be9L11-R11) [[3]](diffhunk://#diff-0af7f816cd651fb1c6756f08cc42b17c168d567c2a377e6115e7fad3412e5df2L22-R22)

### Catalog Configuration Updates:
* Updated the `@inxton/ax.catalog` version in `src/ax.catalog/apax.yml` from `0.0.9` to `0.0.19` and revised catalog dependencies to reflect the latest package versions. This includes updates to dependencies such as `@ax/simatic-1500-clocks` and `@ax/system-math`.