### PR TITLE
708 we need to add asset folder to the library when we pack bin

### DIFF
--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -434,7 +434,7 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
     {
         if (context.BuildParameters.PublishOnly)
         {
-            context.Log.Information("Skipping. Publish only.");
+            context.Log.Information("Skipping packaging. Publish only.");
             return;
         }
 
@@ -446,66 +446,58 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
 
         if(context.BuildParameters.DoPack)
         {
-            context.Libraries.ToList().ForEach(lib =>
-            {
-                foreach (var apaxfile in context.GetApaxFiles(lib))
-                {
-                    context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"" }, new[] { "bin/1500", "axsharp.companion.json" });
-                }
-            });
-
-            if (context.BuildParameters.DoPack)
-            {
-                if (context.BuildParameters.Paralellize)
-                {
-                    context.Libraries.ToList().ForEach(lib =>
-                    {
-                        context.Log.Information($"---------------------------------");
-                        context.Log.Information($"Packing {lib.folder}");
-                        context.Log.Information($"---------------------------------");
-                        context.ApaxClean(lib);
-                        context.ApaxInstall(context.GetLibraryAxFolders(lib));
-                        context.ApaxBuild(context.GetLibraryAxFolders(lib));
-                        context.ApaxPack(lib);
-                        context.ApaxCopyArtifacts(lib);
-                    });
-
-                }
-                else
-                {
-                    context.Libraries.ToList().ForEach(lib =>
-                    {
-                        context.Log.Information($"---------------------------------");
-                        context.Log.Information($"Packing {lib.folder}");
-                        context.Log.Information($"---------------------------------");
-                        context.ApaxClean(lib);
-                        context.ApaxInstall(context.GetLibraryAxFolders(lib));
-                        context.ApaxBuild(context.GetLibraryAxFolders(lib));
-                        context.ApaxPack(lib);
-                        context.ApaxCopyArtifacts(lib);
-                    });
-                }
-            }
-
-             //PackApax(context);
-            PackNugets(context);
+            PackApax(context);
+            PackNuGets(context);
         }
-        
-       
     }
 
     private static void PackApax(BuildContext context)
     {
+        context.Log.Information($"Pack APAX");
         context.Libraries.ToList().ForEach(lib =>
         {
-            context.ApaxPack(lib);
-            context.ApaxCopyArtifacts(lib);
+            foreach (var apaxfile in context.GetApaxFiles(lib))
+            {
+                context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"" }, new[] { "bin/1500", "axsharp.companion.json" });
+            }
         });
+
+        if (context.BuildParameters.Paralellize)
+        {
+            context.Libraries.Where(p => p.pack).ToList().ForEach(lib =>
+            {
+                context.Log.Information($"---------------------------------");
+                context.Log.Information($"Packing {lib.folder}");
+                context.Log.Information($"---------------------------------");
+                context.ApaxClean(lib);
+                context.ApaxInstall(context.GetLibraryAxFolders(lib));
+                context.ApaxBuild(context.GetLibraryAxFolders(lib));
+                context.ApaxPack(lib);
+                context.ApaxCopyArtifacts(lib);
+            });
+
+        }
+        else
+        {
+            context.Libraries.Where(p => p.pack).ToList().ForEach(lib =>
+            {
+                context.Log.Information($"---------------------------------");
+                context.Log.Information($"Packing {lib.folder}");
+                context.Log.Information($"---------------------------------");
+                context.ApaxClean(lib);
+                context.ApaxInstall(context.GetLibraryAxFolders(lib));
+                context.ApaxBuild(context.GetLibraryAxFolders(lib));
+                context.ApaxPack(lib);
+                context.ApaxCopyArtifacts(lib);
+            });
+        }
     }
 
 
-    private static void PackNugets(BuildContext context)
+    private static void PackNuGets(BuildContext context)
     {
+        context.Log.Information($"Pack NUGET");
+
         context.DotNetPack(context.PackableNugetsSlnf, 
             new Cake.Common.Tools.DotNet.Pack.DotNetPackSettings()
         {

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -458,7 +458,7 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
         {
             foreach (var apaxfile in context.GetApaxFiles(lib))
             {
-                context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"" }, new[] { "bin/1500", "axsharp.companion.json" });
+                context.ApaxChangeBuildProperties(apaxfile, new string[] { "\"1500\"" }, new[] {"assets", "bin/1500", "axsharp.companion.json" });
             }
         });
 
@@ -522,10 +522,10 @@ public sealed class PushPackages : FrostingTask<BuildContext>
 
         if (Helpers.CanReleaseInternal())
         {      
-            if(int.Parse(GitVersionInformation.Major) >= 1)
-            {
+            //if(int.Parse(GitVersionInformation.Major) >= 1)
+            //{
                 context.ApaxPublish();
-            }
+            //}
        
 
             foreach (var nugetFile in Directory.EnumerateFiles(Path.Combine(context.Artifacts, @"nugets"), "*.nupkg")

--- a/scripts/pack.ps1
+++ b/scripts/pack.ps1
@@ -1,4 +1,4 @@
 # run build
 
-dotnet run --project cake/Build.csproj --do-test --test-level 1 --do-pack -n 
+dotnet run --project cake/Build.csproj --do-pack -n 
 exit $LASTEXITCODE;


### PR DESCRIPTION
This pull request refactors the packaging logic in the `cake/Program.cs` file and updates the `scripts/pack.ps1` script to streamline the build and packaging process. The changes introduce separate methods for packaging APAX and NuGet artifacts, improve filtering for libraries to be packed, and remove unused or commented-out code for better maintainability.

### Refactoring and packaging improvements:

* **Introduced `PackApax` and `PackNuGets` methods**: Refactored the packaging logic into dedicated methods for APAX and NuGet artifacts, improving code clarity and separation of concerns (`cake/Program.cs`). [[1]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826R449-R467) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L490-L508)

* **Enhanced filtering for libraries to pack**: Updated the logic to filter libraries by the `pack` property, ensuring only the relevant libraries are processed during packaging (`cake/Program.cs`).

### Code cleanup and updates:

* **Removed unused or redundant code**: Deleted commented-out and redundant code, such as the old `PackApax` method and unnecessary conditional checks, to simplify the codebase (`cake/Program.cs`). [[1]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L490-L508) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L533-R528)

* **Improved logging messages**: Updated log messages for better clarity, such as specifying "Skipping packaging" and adding descriptive messages for APAX and NuGet packaging steps (`cake/Program.cs`). [[1]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L437-R437) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826R449-R467)

### Build script update:

* **Simplified `scripts/pack.ps1`**: Removed the `--do-test` and `--test-level` options from the build command, focusing solely on the packaging step (`scripts/pack.ps1`).