### PR TITLE
[NEW-FEATURE] Sequencer, step should contain UID for state identification

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.3.2" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
+    <PackageVersion Include="K4os.Hash.xxHash" Version="1.0.8" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Serilog" Version="4.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/src/components.abb.robotics/ctrl/src/AxoIrc5_v_1_x_x.st
+++ b/src/components.abb.robotics/ctrl/src/AxoIrc5_v_1_x_x.st
@@ -11,7 +11,6 @@ NAMESPACE AXOpen.Components.Abb.Robotics
     CLASS AxoIrc5_v_1_x_x EXTENDS AXOpen.Core.AxoComponent IMPLEMENTS AXOpen.Components.Abstractions.Robotics.IAxoRobotics
         VAR PRIVATE
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
             _errorTime              :   LTIME := LT#5S;
             _blink                  :   AXOpen.Timers.AxoBlinker;
@@ -146,7 +145,7 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             SUPER.Run(parent);
 
             Messenger.Serve(THIS);
-
+            _errorTime := Config.ErrorTime;
             IF NOT _initHwCheckDone THEN
                 IF parent = NULL THEN
                     Messenger.Activate(ULINT#700, eAxoMessageCategory#ProgrammingError);
@@ -403,9 +402,6 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             Inputs.EventId                  := TO_UDINT(_dword);
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
 // THIS SHOULD BE PROBABLY REMOVED =>            
@@ -1778,8 +1774,8 @@ NAMESPACE AXOpen.Components.Abb.Robotics
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > T#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND _errorTime > LT#0S , _errorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.abb.robotics/ctrl/src/AxoOmnicore_v_1_x_x.st
+++ b/src/components.abb.robotics/ctrl/src/AxoOmnicore_v_1_x_x.st
@@ -11,7 +11,6 @@ NAMESPACE AXOpen.Components.Abb.Robotics
     CLASS AxoOmnicore_v_1_x_x EXTENDS AXOpen.Core.AxoComponent IMPLEMENTS AXOpen.Components.Abstractions.Robotics.IAxoRobotics
         VAR PRIVATE
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
             _errorTime              :   LTIME := LT#5S;
             _blink                  :   AXOpen.Timers.AxoBlinker;
@@ -156,7 +155,7 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             SUPER.Run(parent);
 
             Messenger.Serve(THIS);
-
+            _errorTime := Config.ErrorTime;
             IF NOT _initHwCheckDone THEN
                 IF parent = NULL THEN
                     Messenger.Activate(UINT#700, eAxoMessageCategory#ProgrammingError);
@@ -412,9 +411,6 @@ NAMESPACE AXOpen.Components.Abb.Robotics
             Inputs.EventId                  := TO_UDINT(_dword);
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             RestoreTask.Run(THIS);
@@ -1789,8 +1785,8 @@ NAMESPACE AXOpen.Components.Abb.Robotics
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND _errorTime > LT#0S , _errorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.balluff.identification/ctrl/src/Axo_BIS_M_4XX_045.st
+++ b/src/components.balluff.identification/ctrl/src/Axo_BIS_M_4XX_045.st
@@ -11,9 +11,7 @@ NAMESPACE AXOpen.Components.Balluff.Identification
     CLASS Axo_BIS_M_4XX_045 EXTENDS AXOpen.Core.AxoComponent
         VAR PRIVATE
             _infoTimer                  :   AXOpen.Timers.OnDelayTimer;
-            _infoTime                   :   LTIME := LT#2S;
             _errorTimer                 :   AXOpen.Timers.OnDelayTimer;
-            _errorTime                  :   LTIME := LT#5S;
             _context                    :   IAxoContext;
             _someTaskIsActive           :   BOOL;
             _hwID                       :   WORD;
@@ -295,9 +293,6 @@ NAMESPACE AXOpen.Components.Balluff.Identification
         
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             RestoreTask.Run(THIS);
@@ -1218,8 +1213,8 @@ NAMESPACE AXOpen.Components.Balluff.Identification
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.cognex.vision/app/hwc/plc_line.hwl.yml
+++ b/src/components.cognex.vision/app/hwc/plc_line.hwl.yml
@@ -2,12 +2,13 @@ Devices:
 - Name: plc_line
   Modules:
   - Apply:
-     TemplateName: 6ES7516-3AP03-0AB0_v4_1
+     TemplateName: 6ES7516-3AP03-0AB0_v4_0
      Arguments:
        PLCName: plc_line
        IpAddress_X1: 192.168.100.120/24
        ProfinetDeviceName_X1: plc_line_x1
        AdminName: admin
+       CycleCommunicationLoad : 50
 IoSystems:
 - Name: profinet_plc_line
   ControllerInterfaces:

--- a/src/components.cognex.vision/app/ix-blazor/Pages/Index.razor
+++ b/src/components.cognex.vision/app/ix-blazor/Pages/Index.razor
@@ -6,4 +6,12 @@
 
 Welcome to your new app.
 
-<AXOpen.Core.AxoTaskCommandView Component="@Entry.Plc.documentation.componentFour.Sequencer" />
+
+<button type="button" class="btn btn-primary" @onclick="CreateToast">Add Toast</button>
+
+@code {
+    public void CreateToast()
+    {
+        //DialogService.AddAlertDialog("Success", "Test", "test", 30);
+    }
+}

--- a/src/components.cognex.vision/ctrl/src/AxoDataman/v_6_0_0/AxoDataman.st
+++ b/src/components.cognex.vision/ctrl/src/AxoDataman/v_6_0_0/AxoDataman.st
@@ -1032,8 +1032,8 @@ NAMESPACE AXOpen.Components.Cognex.Vision.v_6_0_0_0
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
   
         METHOD PRIVATE ContinuousReading

--- a/src/components.cognex.vision/ctrl/src/AxoInsight/v_24_0_0/AxoInsight.st
+++ b/src/components.cognex.vision/ctrl/src/AxoInsight/v_24_0_0/AxoInsight.st
@@ -2422,8 +2422,8 @@ NAMESPACE AXOpen.Components.Cognex.Vision.v_24_0_0
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
         METHOD PRIVATE SetUserData: BOOL

--- a/src/components.cognex.vision/ctrl/src/AxoInsight/v_6_0_0/AxoInsight.st
+++ b/src/components.cognex.vision/ctrl/src/AxoInsight/v_6_0_0/AxoInsight.st
@@ -1753,8 +1753,8 @@ NAMESPACE AXOpen.Components.Cognex.Vision.v_6_0_0_0
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
         METHOD PRIVATE SetUserData: BOOL

--- a/src/components.cognex.vision/ctrl/src/AxoVisionPro/AxoVisionPro.st
+++ b/src/components.cognex.vision/ctrl/src/AxoVisionPro/AxoVisionPro.st
@@ -159,7 +159,7 @@ NAMESPACE AXOpen.Components.Cognex.Vision
             _Clock_1Hz              :   AxoBlinker;
             _readResultsJobID       :   BYTE;
             _readResultsLength      :   UINT;
-            _data_                :   ARRAY[0..1300] OF BYTE;
+            _data_                  :   ARRAY[0..1300] OF BYTE;
             _data_out               :   ARRAY[0..1300] OF BYTE;
             _sendDataInspectionType :   BYTE;
             _sendDataBufferID       :   BYTE;
@@ -4361,8 +4361,8 @@ NAMESPACE AXOpen.Components.Cognex.Vision
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal ,Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime);
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
     END_CLASS

--- a/src/components.desoutter.tightening/ctrl/src/CVIC_II/AxoCVIC_II.st
+++ b/src/components.desoutter.tightening/ctrl/src/CVIC_II/AxoCVIC_II.st
@@ -1063,8 +1063,8 @@ NAMESPACE AXOpen.Components.Desoutter.Tightening
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal ,Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime);
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
 

--- a/src/components.elements/ctrl/src/AxoCarousel/AxoCarousel.st
+++ b/src/components.elements/ctrl/src/AxoCarousel/AxoCarousel.st
@@ -404,8 +404,8 @@ NAMESPACE AXOpen.Elements
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal ,Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime);
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
     END_CLASS

--- a/src/components.festo.drives/ctrl/src/AxoCmmtAs/AxoCmmtAs.st
+++ b/src/components.festo.drives/ctrl/src/AxoCmmtAs/AxoCmmtAs.st
@@ -132,9 +132,7 @@ NAMESPACE AXOpen.Components.Festo.Drives
             _outputsAddress         :   UDINT;  
             _outputsCount           :   UINT; 
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
-            _errorTime              :   LTIME := LT#5S;
         END_VAR
 
         ///<summary>
@@ -155,8 +153,6 @@ NAMESPACE AXOpen.Components.Festo.Drives
                 //                                      |     -10   |     -9    |    -8    |    -7   |   -6   |   -5  |  -4  | -3  | -2 |-1|  0 | 1  |  2  |  3   |   4   |   5    |   6     |    7     |     8     |    9      |     10    |
                 _exp    :   ARRAY [-10..10] OF LREAL := [0.000000001,0.000000001,0.00000001,0.0000001,0.000001,0.00001,0.0001,0.001,0.01,0.1,1.0,10.0,100.0,1000.0,10000.0,100000.0,1000000.0,10000000.0,100000000.0,100000000.0,100000000.0];
             END_VAR
-            _infoTime   :=  DriveConfig.InfoTime;
-            _errorTime  :=  DriveConfig.ErrorTime;
             SUPER.Run(parent);
             Messenger.Serve(THIS);
 

--- a/src/components.keyence.vision/ctrl/src/Axo_SR_1000.st
+++ b/src/components.keyence.vision/ctrl/src/Axo_SR_1000.st
@@ -2110,8 +2110,8 @@ NAMESPACE AXOpen.Components.Keyence.Vision
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
   
         METHOD PRIVATE ContinuousReading //TODO 

--- a/src/components.keyence.vision/ctrl/src/Axo_SR_750.st
+++ b/src/components.keyence.vision/ctrl/src/Axo_SR_750.st
@@ -2104,8 +2104,8 @@ NAMESPACE AXOpen.Components.Keyence.Vision
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
   
         METHOD PRIVATE ContinuousReading //TODO 

--- a/src/components.kuka.robotics/ctrl/src/AxoKrc4_v_5_x_x.st
+++ b/src/components.kuka.robotics/ctrl/src/AxoKrc4_v_5_x_x.st
@@ -10,9 +10,7 @@ NAMESPACE AXOpen.Components.Kuka.Robotics
     CLASS AxoKrc4_v_5_x_x EXTENDS AXOpen.Core.AxoComponent IMPLEMENTS AXOpen.Components.Abstractions.Robotics.IAxoRobotics
         VAR PRIVATE
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
-            _errorTime              :   LTIME := LT#5S;
             _context                :   IAxoContext;
             _stopTasksAreActive     :   BOOL;
             _stopType               :   eAxoRoboticsStopType;
@@ -391,9 +389,6 @@ NAMESPACE AXOpen.Components.Kuka.Robotics
             Inputs.EventId                  := TO_UDINT(_dword);
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             RestoreTask.Run(THIS);
@@ -1768,8 +1763,8 @@ NAMESPACE AXOpen.Components.Kuka.Robotics
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
+++ b/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
@@ -10,9 +10,7 @@ NAMESPACE AXOpen.Components.Mitsubishi.Robotics
     CLASS AxoCr800_v_1_x_x EXTENDS AXOpen.Core.AxoComponent IMPLEMENTS AXOpen.Components.Abstractions.Robotics.IAxoRobotics
         VAR PRIVATE
             _infoTimer          :   AXOpen.Timers.OnDelayTimer;
-            _infoTime           :   LTIME := LT#2S;
             _errorTimer         :   AXOpen.Timers.OnDelayTimer;
-            _errorTime          :   LTIME := LT#5S;
             _blink              :   AXOpen.Timers.AxoBlinker;
             _context            :   IAxoContext;
             _hwID               :   WORD;
@@ -324,9 +322,6 @@ NAMESPACE AXOpen.Components.Mitsubishi.Robotics
    
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             RestoreTask.Run(THIS);
@@ -1160,8 +1155,8 @@ NAMESPACE AXOpen.Components.Mitsubishi.Robotics
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal AND _infoTime>LT#0s , _infoTime);
-            _errorTimer.OnDelay(THIS, signal AND _errorTime>LT#0s , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.rexroth.drives/ctrl/src/AxoCtrlxDriveXsc/AxoCtrlxDriveXsc.st
+++ b/src/components.rexroth.drives/ctrl/src/AxoCtrlxDriveXsc/AxoCtrlxDriveXsc.st
@@ -162,9 +162,7 @@ NAMESPACE AXOpen.Components.Rexroth.Drives
             _P_0_0450               :   REAL;       // 2bytes, 2decimal places
 
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
-            _errorTime              :   LTIME := LT#5S;
             _lastMessageCodeFromMC  :   ULINT;
         END_VAR
 
@@ -184,8 +182,6 @@ NAMESPACE AXOpen.Components.Rexroth.Drives
                 //                                      |     -10   |     -9    |    -8    |    -7   |   -6   |   -5  |  -4  | -3  | -2 |-1|  0 | 1  |  2  |  3   |   4   |   5    |   6     |    7     |     8     |    9      |     10    |
                 _exp    :   ARRAY [-10..10] OF LREAL := [0.000000001,0.000000001,0.00000001,0.0000001,0.000001,0.00001,0.0001,0.001,0.01,0.1,1.0,10.0,100.0,1000.0,10000.0,100000.0,1000000.0,10000000.0,100000000.0,100000000.0,100000000.0];
             END_VAR
-            _infoTime   :=  DriveConfig.InfoTime;
-            _errorTime  :=  DriveConfig.ErrorTime;
             SUPER.Run(parent);
             Messenger.Serve(THIS);
 
@@ -5992,8 +5988,8 @@ NAMESPACE AXOpen.Components.Rexroth.Drives
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND DriveConfig.InfoTime > LT#0S ,DriveConfig.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND DriveConfig.ErrorTime > LT#0S , DriveConfig.ErrorTime);
         END_METHOD
         METHOD PRIVATE CallTimers
             VAR_INPUT
@@ -6001,8 +5997,8 @@ NAMESPACE AXOpen.Components.Rexroth.Drives
                 signal_2 : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal_1 , _infoTime);
-            _errorTimer.OnDelay(THIS, signal_2 , _errorTime );
+            _infoTimer.OnDelay(THIS, signal_1 AND DriveConfig.InfoTime > LT#0S ,DriveConfig.InfoTime);
+            _errorTimer.OnDelay(THIS, signal_2 AND DriveConfig.ErrorTime > LT#0S , DriveConfig.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.rexroth.press/ctrl/src/AxoSmartFunctionKit_v_4_x_x.st
+++ b/src/components.rexroth.press/ctrl/src/AxoSmartFunctionKit_v_4_x_x.st
@@ -14,9 +14,7 @@ NAMESPACE AXOpen.Components.Rexroth.Press
     CLASS PUBLIC AxoSmartFunctionKit_v_4_x_x EXTENDS AXOpen.Core.AxoComponent
         VAR PRIVATE
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
-            _errorTime              :   LTIME := LT#5S;
             _context                :   IAxoContext;
             _hwID                   :   WORD;
             _hwIdParamCh_IDN        :   WORD;
@@ -765,8 +763,8 @@ NAMESPACE AXOpen.Components.Rexroth.Press
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
 
         METHOD PROTECTED OVERRIDE ManualControl

--- a/src/components.rexroth.tightening/ctrl/src/Axo_CS351_compact/Axo_CS351_compact.st
+++ b/src/components.rexroth.tightening/ctrl/src/Axo_CS351_compact/Axo_CS351_compact.st
@@ -3582,8 +3582,8 @@ NAMESPACE AXOpen.Components.Rexroth.Tightening
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal ,Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime);
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.siem.identification/ctrl/src/IOLink/AxoIOLink_RF200Device.st
+++ b/src/components.siem.identification/ctrl/src/IOLink/AxoIOLink_RF200Device.st
@@ -10,9 +10,7 @@ NAMESPACE AXOpen.Components.Siem.Identification
     CLASS PUBLIC AxoIOLink_RF200Device EXTENDS AXOpen.Core.AxoComponent
         VAR PRIVATE
             _infoTimer                  :   AXOpen.Timers.OnDelayTimer;
-            _infoTime                   :   LTIME := LT#2S;
             _errorTimer                 :   AXOpen.Timers.OnDelayTimer;
-            _errorTime                  :   LTIME := LT#5S;
             _blink                      :   AXOpen.Timers.AxoBlinker;
             _context                    :   IAxoContext;
             _someTaskIsActive           :   BOOL;
@@ -252,9 +250,6 @@ NAMESPACE AXOpen.Components.Siem.Identification
 
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION****************
             // RestoreTask.Run(THIS);
@@ -667,8 +662,9 @@ NAMESPACE AXOpen.Components.Siem.Identification
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
+
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.siem.identification/ctrl/src/IdentProfile/Axo_IdentDevice.st
+++ b/src/components.siem.identification/ctrl/src/IdentProfile/Axo_IdentDevice.st
@@ -10,9 +10,7 @@ NAMESPACE AXOpen.Components.Siem.Identification
     CLASS PUBLIC Axo_IdentDevice EXTENDS AXOpen.Core.AxoComponent
         VAR PRIVATE
             _infoTimer                  :   AXOpen.Timers.OnDelayTimer;
-            _infoTime                   :   LTIME := LT#2S;
             _errorTimer                 :   AXOpen.Timers.OnDelayTimer;
-            _errorTime                  :   LTIME := LT#5S;
             _blink                      :   AXOpen.Timers.AxoBlinker;
             _context                    :   IAxoContext;
             _someTaskIsActive           :   BOOL;
@@ -223,9 +221,6 @@ NAMESPACE AXOpen.Components.Siem.Identification
             Status.IdentProfile_Status.Id := TO_ULINT(_identProfile_Status);
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             RestoreTask.Run(THIS);
@@ -910,8 +905,8 @@ NAMESPACE AXOpen.Components.Siem.Identification
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal , _infoTime);
-            _errorTimer.OnDelay(THIS, signal , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0S , Config.ErrorTime);
         END_METHOD
     END_CLASS
 END_NAMESPACE

--- a/src/components.ur.robotics/ctrl/src/AxoUrCb3/AxoUrCb3_v_3_x_x.st
+++ b/src/components.ur.robotics/ctrl/src/AxoUrCb3/AxoUrCb3_v_3_x_x.st
@@ -10,9 +10,7 @@ NAMESPACE AXOpen.Components.Ur.Robotics
     CLASS AxoUrCb3_v_3_x_x EXTENDS AXOpen.Core.AxoComponent IMPLEMENTS AXOpen.Components.Abstractions.Robotics.IAxoRobotics
         VAR PRIVATE
             _infoTimer              :   AXOpen.Timers.OnDelayTimer;
-            _infoTime               :   LTIME := LT#2S;
             _errorTimer             :   AXOpen.Timers.OnDelayTimer;
-            _errorTime              :   LTIME := LT#0S;
             _context                :   IAxoContext;
             _stopTasksAreActive     :   BOOL;
             _stopType               :   eAxoRoboticsStopType;
@@ -653,9 +651,6 @@ NAMESPACE AXOpen.Components.Ur.Robotics
 
             //*******************************************
             _context := THIS.GetContext();
-
-            _infoTime := Config.InfoTime;
-            _errorTime := Config.ErrorTime;
 
             //*************INITIALIZATION*************
             // RestoreTask.Run(THIS);
@@ -2737,8 +2732,8 @@ NAMESPACE AXOpen.Components.Ur.Robotics
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal AND _infoTime > LT#0s , _infoTime);
-            _errorTimer.OnDelay(THIS, signal AND _errorTime > LT#0s , _errorTime );
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > LT#0s , Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > LT#0s , Config.ErrorTime );
         END_METHOD
 
         METHOD PRIVATE GetRobotModeDescription : eAxoUrRoboticsRobotMode

--- a/src/core/app/SystemConstants/plc_line_HwIdentifiers.st
+++ b/src/core/app/SystemConstants/plc_line_HwIdentifiers.st
@@ -1,7 +1,7 @@
 CONFIGURATION HardwareIDs
     VAR_GLOBAL CONSTANT
         plc_line_HwID : UINT := UINT#32;
-        plc_line_Rail_0_HwID : UINT := UINT#257;
+        plc_line_Rail_0_HwID : UINT := UINT#273;
         plc_line_plc_line_HwID : UINT := UINT#48;
         plc_line_plc_line_CPU_display_1_HwID : UINT := UINT#54;
         plc_line_plc_line_Card_reader_writer_1_HwID : UINT := UINT#51;

--- a/src/core/app/apax.yml
+++ b/src/core/app/apax.yml
@@ -12,8 +12,8 @@ variables:
   DEFAULT_NAMESPACE: "AXOpen.Core"
   AXTARGET: 192.168.100.120
   AXTARGETPLATFORMINPUT: .\bin\1500\
-  AX_USERNAME: "adm"
-  AX_TARGET_PWD: "123ABCDabcd$#!"
+  AX_USERNAME: "admin"
+  AX_TARGET_PWD: "MTSservis1234+"
   USE_PLC_SIM_ADVANCED: "true"
   # <= Do not commit any changes to the following variables. You may modify them locally, but committing the changes will mess up the nightly build.
 registries:

--- a/src/core/app/ix-blazor/axopencore.blazor/Pages/AxoCore/AxoSequencer.razor
+++ b/src/core/app/ix-blazor/axopencore.blazor/Pages/AxoCore/AxoSequencer.razor
@@ -15,16 +15,18 @@
 <h7>RenderableContentControl Context="@Entry.Plc.AxoSequencers" Presentation="Command-Control"</h7>
 <div class="container">
     <div class="container text-left">
+        <AXOpen.Core.AxoTaskCommandView Component="@Entry.Plc.AxoSequencers.coord"/>
         <RenderableContentControl Context="@Entry.Plc.AxoSequencers" Presentation="Command-Control" />
     </div>
 </div>
 
-<h7>RenderableContentControl Context="@Entry.Plc.AxoSequencers" Presentation="Status-Display"</h7>
+@* <h7>RenderableContentControl Context="@Entry.Plc.AxoSequencers" Presentation="Status-Display"</h7>
 <div class="container">
     <div class="container text-left">
+        <AXOpen.Core.AxoTaskStatusView Component="@Entry.Plc.AxoSequencers.coord" />
         <RenderableContentControl Context="@Entry.Plc.AxoSequencers" Presentation="Status-Display" />
     </div>
-</div>
+</div> *@
 
 @code
 {

--- a/src/core/app/ix-blazor/axopencore.blazor/Pages/AxoCore/AxoSequencerExtended.razor
+++ b/src/core/app/ix-blazor/axopencore.blazor/Pages/AxoCore/AxoSequencerExtended.razor
@@ -15,6 +15,7 @@
 <h7>RenderableContentControl Context="@Entry.Plc.AxoSequencerContainer._SequencerContainerExample" Presentation="Command-Control"</h7>
 <div class="container">
     <div class="container text-left">
+        <AXOpen.Core.AxoTaskCommandView Component="@Entry.Plc.AxoSequencerContainer._SequencerContainerExample" />
         <RenderableContentControl Context="@Entry.Plc.AxoSequencerContainer._SequencerContainerExample" Presentation="Command-Control" />
     </div>
 </div>

--- a/src/core/app/ix/Entry.cs
+++ b/src/core/app/ix/Entry.cs
@@ -25,8 +25,8 @@ namespace axopencore
     {
         // Do not commit any changes to the following variables. You may modify them locally, but committing the changes will mess up the nightly build. =>
         public static string TargetIp { get; } = "192.168.100.120";//Environment.GetEnvironmentVariable("AXTARGET"); // <- replace by your IP 
-        private static string Pass => @"123ABCDabcd$#!"; //Environment.GetEnvironmentVariable("AX_TARGET_PWD");       //Environment.GetEnvironmentVariable("AX_TARGET_PWD"); // <- Pass in the password that you have set up for the user. NOT AS PLAIN TEXT! Use user secrets instead.
-        private static string UserName = "adm"; //Environment.GetEnvironmentVariable("AX_USERNAME"); //<- replace by user name you have set up in your WebAPI settings        
+        private static string Pass => @"MTSservis1234+"; //Environment.GetEnvironmentVariable("AX_TARGET_PWD");       //Environment.GetEnvironmentVariable("AX_TARGET_PWD"); // <- Pass in the password that you have set up for the user. NOT AS PLAIN TEXT! Use user secrets instead.
+        private static string UserName = "admin"; //Environment.GetEnvironmentVariable("AX_USERNAME"); //<- replace by user name you have set up in your WebAPI settings        
         private const bool IgnoreSslErrors = true; // <- When you have your certificates in order set this to false.
         private static string CertificatePath = "..\\..\\certs\\plc_line\\plc_line.cer"; //NFI why, but it works
         // <= Do not commit any changes to the following variables. You may modify them locally, but committing the changes will mess up the nightly build.

--- a/src/core/app/src/IO/HwIdentifiers.st
+++ b/src/core/app/src/IO/HwIdentifiers.st
@@ -3,7 +3,7 @@ NAMESPACE AXOpen.Core
         HwIdentifiers : WORD
         (
             plc_line_HwID :=	WORD#32,
-            plc_line_Rail_0_HwID :=	WORD#257,
+            plc_line_Rail_0_HwID :=	WORD#273,
             plc_line_plc_line_HwID :=	WORD#48,
             plc_line_plc_line_CPU_display_1_HwID :=	WORD#54,
             plc_line_plc_line_Card_reader_writer_1_HwID :=	WORD#51,

--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoStep/AxoStepHelper.cs
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoStep/AxoStepHelper.cs
@@ -6,9 +6,11 @@ namespace AXOpen.Core
     {
         public static string Description(AxoStep step)
         {
-            var text = string.IsNullOrEmpty(step.Descr.Cyclic)
-                ? step.Order.Cyclic.ToString()
-                : step.Descr.GetCyclic();
+            var text = !string.IsNullOrEmpty(step.Descr.Cyclic)
+                ? step.Descr.GetCyclic()
+                : !string.IsNullOrEmpty(step.Description) 
+                ? step.Description
+                : step.Order.Cyclic.ToString();
 
             if (step.IsActive.Cyclic)
             {

--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoStep/AxoStepView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoStep/AxoStepView.razor
@@ -14,6 +14,8 @@
         {
         <AxoTaskStatusView Component="@Component" Description="@Description" HideRestoreButton="true" />
         }*@
+    @* Just to test the UID generation *@
+    @* <p>@Component.UID</p> *@ 
     <p>@AxoStepHelper.Description(Component)</p>
     <p>@Component.Duration.Cyclic.TotalSeconds</p>
     <p>@Humanizer.DateHumanizeExtensions.Humanize(Component.StartTimeStamp.Cyclic, culture: CultureExtensions.Culture)</p>

--- a/src/core/src/AXOpen.Core/AxoCoordination/AxoStep.cs
+++ b/src/core/src/AXOpen.Core/AxoCoordination/AxoStep.cs
@@ -1,13 +1,29 @@
-﻿using System;
+﻿using AXSharp.Connector.Localizations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Security.Cryptography;
+using K4os.Hash.xxHash;
 
 namespace AXOpen.Core
 {
-    public partial class AxoStep
+    public partial class AxoStep : AXOpen.Core.AxoTaskLight, IAxoStep
     {
-        
+        private uint? _UID;
+        public uint UID
+        {
+            get
+            {
+                if (_UID == null)
+                {
+                    var bytes = Encoding.UTF8.GetBytes(Symbol ?? string.Empty);
+                    _UID = XXH32.DigestOf(bytes);
+                }
+                return _UID.Value;
+            }
+        }
     }
 }

--- a/src/core/src/AXOpen.Core/inxton_axopen_core.csproj
+++ b/src/core/src/AXOpen.Core/inxton_axopen_core.csproj
@@ -9,7 +9,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="AXSharp.Abstractions" />
-		<PackageReference Include="AXSharp.Connector" />		
+		<PackageReference Include="AXSharp.Connector" />
+		<PackageReference Include="K4os.Hash.xxHash" />		
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/scripts/check_requisites_apax.sh
+++ b/src/scripts/check_requisites_apax.sh
@@ -1,5 +1,5 @@
 apaxUrl="https://console.simatic-ax.siemens.io/"
-expectedApaxVersion="3.5.0"
+expectedApaxVersion="4.0.0"
 
 export GREEN='\033[0;32m'
 export RED='\033[0;31m'

--- a/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v3_0.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -70,7 +72,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v3_1.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -78,7 +80,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7511-1AL03-0AB0_v4_0.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -79,7 +81,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v3_0.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -70,7 +72,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v3_1.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -78,7 +80,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7513-1AM03-0AB0_v4_0.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -79,7 +81,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v3_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -92,7 +94,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v3_1.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -100,7 +102,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7515-2AN03-0AB0_v4_0.hwl.yml
@@ -12,7 +12,9 @@ Templates:
       Value: 192.168.101.120/24
     - Name: ProfinetDeviceName_X2
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -96,7 +98,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v3_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -92,7 +94,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v3_1.hwl.yml
@@ -17,7 +17,7 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
     - Name: CycleCommunicationLoad
       Value : 20
     Content:

--- a/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7516-3AP03-0AB0_v4_0.hwl.yml
@@ -13,7 +13,9 @@ Templates:
     - Name: ProfinetDeviceName_X2
       Value: plcname_profinet_interface_x2    
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -97,7 +99,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7517-3AP00-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7517-3AP00-0AB0_v3_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -92,7 +94,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7517-3AP00-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7517-3AP00-0AB0_v3_1.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -100,7 +102,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7517-3AQ10-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7517-3AQ10-0AB0_v4_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -118,7 +120,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7518-3AT10-0AB0_v4_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7518-3AT10-0AB0_v4_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -118,7 +120,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7518-4AP00-0AB0_v3_0.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7518-4AP00-0AB0_v3_0.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -105,7 +107,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7518-4AP00-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7518-4AP00-0AB0_v3_1.hwl.yml
@@ -17,7 +17,9 @@ Templates:
     - Name: ProfinetDeviceName_X3
       Value: plcname_profinet_interface_x3
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -113,7 +115,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/simatic1500/ctrl/assets/6ES7587-1AP00-0AB0_v3_1.hwl.yml
+++ b/src/simatic1500/ctrl/assets/6ES7587-1AP00-0AB0_v3_1.hwl.yml
@@ -9,7 +9,9 @@ Templates:
     - Name: ProfinetDeviceName_X1
       Value: plcname_profinet_interface_x1
     - Name: AdminName
-      Value: adm
+      Value: admin
+    - Name: CycleCommunicationLoad
+      Value: 20
     Content:
       Name: "${PLCName}"
       TypeIdentifier:
@@ -67,7 +69,7 @@ Templates:
         AdditionalInformation: ""
         # ClockMemoryByteAddress: 0
         ClockMemoryByte: False
-        CycleCommunicationLoad: 20
+        CycleCommunicationLoad: ${CycleCommunicationLoad}
         CycleEnableMinimumCycleTime: True
         CycleMaximumCycleTime: 150
         CycleMinimumCycleTime: 1

--- a/src/template.axolibrary/ctrl/src/TemplateComponent/TemplateComponent.st
+++ b/src/template.axolibrary/ctrl/src/TemplateComponent/TemplateComponent.st
@@ -5383,8 +5383,9 @@ NAMESPACE Template.Axolibrary
                 signal : BOOL;
             END_VAR
             
-            _infoTimer.OnDelay(THIS, signal ,Config.InfoTime);
-            _errorTimer.OnDelay(THIS, signal , Config.ErrorTime);
+            _infoTimer.OnDelay(THIS, signal AND Config.InfoTime > T#0S ,Config.InfoTime);
+            _errorTimer.OnDelay(THIS, signal AND Config.ErrorTime > T#0S , Config.ErrorTime);
+
         END_METHOD
 
     END_CLASS


### PR DESCRIPTION

### Summary

PR adds UID to sequencer steps for state identification using K4os.Hash.xxHash package.
Refactors timer logic in components (Abb Robotics, Balluff Identification, Cognex Vision, etc.) to use config times. Updates PLC template version and adds communication load. Adds toast button in Index.razor.




### Timer Logic Refactoring:
* Updated `_infoTimer` and `_errorTimer` logic across multiple components (e.g., `AxoIrc5_v_1_x_x`, `AxoOmnicore_v_1_x_x`, `Axo_BIS_M_4XX_045`, etc.) to dynamically use `Config.InfoTime` and `Config.ErrorTime` with conditional checks, ensuring timers are only activated for valid durations. [[1]](diffhunk://#diff-7818601baeaea61d1f9a8e9a5984edefa9b3bbb3aea14328e733a5bbfc47ed09L1781-R1778) [[2]](diffhunk://#diff-49585acb2afa91a41db66546782e454cc8f2e6b6a3faa60a30227ec1cf278e7dL1792-R1789) [[3]](diffhunk://#diff-8c1c1ff707067acf72131e50c682b3ae2c530a6cf9dc250d329cf3d6ac8b0639L1221-R1217) [[4]](diffhunk://#diff-26f7e74abe175b4fec95d6123b07627c2c6009aff48143599350f97b37368a90L1035-R1036) [[5]](diffhunk://#diff-f874d1d1bc721f32f81a9a06701c1decb19a725bf8d1193b0a1dbb26f6020086L2425-R2426) etc.)

### Component Initialization Cleanup:
* Removed redundant assignments of `_infoTime` and `_errorTime` during initialization in multiple components (e.g., `AxoIrc5_v_1_x_x`, `AxoOmnicore_v_1_x_x`, `Axo_BIS_M_4XX_045`, etc.), simplifying the code and deferring these values to configuration. [[1]](diffhunk://#diff-7818601baeaea61d1f9a8e9a5984edefa9b3bbb3aea14328e733a5bbfc47ed09L407-L409) [[2]](diffhunk://#diff-49585acb2afa91a41db66546782e454cc8f2e6b6a3faa60a30227ec1cf278e7dL416-L418) [[3]](diffhunk://#diff-8c1c1ff707067acf72131e50c682b3ae2c530a6cf9dc250d329cf3d6ac8b0639L299-L301) [[4]](diffhunk://#diff-b91e17793e8103da83fcf3b3a6e6f3ca722bd05403f48fe67656035e1d60a4c7L395-L397)

### Package and Configuration Updates:
* Added `K4os.Hash.xxHash` version `1.0.8` to `Directory.Packages.props` for enhanced hashing capabilities.
* Updated hardware configuration in `plc_line.hwl.yml` to use an older template version (`v4_0`) and added a new `CycleCommunicationLoad` parameter.

### UI Enhancements:
* Introduced a new button in `Index.razor` for adding toast notifications, replacing a previously static component reference.

### Codebase Simplification:
* Removed hardcoded default values for `_infoTime` and `_errorTime` in several components, ensuring all timer durations are driven by configuration. [[1]](diffhunk://#diff-49585acb2afa91a41db66546782e454cc8f2e6b6a3faa60a30227ec1cf278e7dL14) [[2]](diffhunk://#diff-8c1c1ff707067acf72131e50c682b3ae2c530a6cf9dc250d329cf3d6ac8b0639L14-L16) [[3]](diffhunk://#diff-b91e17793e8103da83fcf3b3a6e6f3ca722bd05403f48fe67656035e1d60a4c7L13-L15) [[4]](diffhunk://#diff-cae1a1d9d91e232499b05d2c9269a3a136fa26a05e88cc624256e99d929c81c9L13-L15)

These changes collectively enhance maintainability, configurability, and functionality across the codebase.


closes #685