### PR TITLE
Workaround for current stc behaviour. 

### DIFF
--- a/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoStep/AxoStep.st
@@ -115,6 +115,7 @@ NAMESPACE AXOpen.Core
             END_VAR
             VAR                
                 Sequencer : REF_TO AxoSequencer;
+                SequencerContainer : REF_TO AxoSequencerContainer;
                 coordAsAxoObject : IAxoObject;
                 _currentlyOpenCycleCount : ULINT;                
             END_VAR    
@@ -141,12 +142,16 @@ NAMESPACE AXOpen.Core
                 END_IF;
             END_IF;    
 
-            Sequencer ?= coord;
+            Sequencer ?= coord;            
+            SequencerContainer ?= coord;
             IF(Sequencer <> NULL) THEN 
                 // Sequencer^.SetSuspendMultipleExecuteCallCheck(TRUE);  // moved to Sequencer.Open
                 ExecuteInternal := Sequencer^.Execute(THIS, Enable);
+            ELSIF (SequencerContainer <> NULL) THEN
+                ExecuteInternal := SequencerContainer^.Execute(THIS, Enable);   
             END_IF;
 
+            
                 
             // Selector ?= coord;
             // IF(coord <> NULL) THEN Sequencer^.ExecuteWithSelector(THIS, Enable); END_IF;    


### PR DESCRIPTION
Adds SequencerContainer reference to AxoStep for conditional selection of `coord` cast

This pull request updates the coordination logic in `AxoStep` to support both `AxoSequencer` and `AxoSequencerContainer` The main changes include adding a reference to `AxoSequencerContainer` and updating the execution logic to handle both types.

**Coordination logic enhancements:**

* Added a `SequencerContainer` reference (`REF_TO AxoSequencerContainer`) to the `AxoStep` class to allow coordination with sequencer containers.
* Updated the execution logic in `AxoStep` to check for and execute using either `Sequencer` or `SequencerContainer`, depending on which is available.
