### PR TITLE
Update to AX# v0.40.1-alpha.279

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.40.1-alpha.275",
+      "version": "0.40.1-alpha.279",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.40.1-alpha.275",
+      "version": "0.40.1-alpha.279",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.40.1-alpha.275",
+      "version": "0.40.1-alpha.279",
       "commands": [
         "ixr"
       ],
@@ -53,3 +53,4 @@
     }
   }
 }
+

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,11 +7,11 @@
   <ItemGroup>
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.40.1-alpha.275" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.40.1-alpha.275" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.40.1-alpha.275" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.40.1-alpha.275" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.40.1-alpha.275" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.40.1-alpha.279" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.40.1-alpha.279" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.40.1-alpha.279" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.40.1-alpha.279" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.40.1-alpha.279" />
     <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.80" />
     <!-- AX# END -->
     <!-- Other -->
@@ -73,3 +73,4 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 </Project>
+


### PR DESCRIPTION
This pull request updates the AXSharp tool and package versions to the latest alpha release (`0.40.1-alpha.279`) across the project. These changes ensure that all AXSharp-related dependencies and tools are aligned to the same version, which helps maintain compatibility and stability.

Dependency and tool version updates:

**AXSharp tool updates:**
* Updated the versions of `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` tools in `.config/dotnet-tools.json` from `0.40.1-alpha.275` to `0.40.1-alpha.279`. [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)

**AXSharp NuGet package updates:**
* Updated the following AXSharp package references in `src/Directory.Packages.props` from `0.40.1-alpha.275` to `0.40.1-alpha.279`: `AXSharp.Abstractions`, `AXSharp.Connector`, `AXSharp.Connector.S71500.WebAPI`, `AXSharp.Presentation.Blazor`, and `AXSharp.Presentation.Blazor.Controls`.

No other functional or structural changes are included in this pull request.
closes #736