### PR TITLE
Public intarface IAxoSequncer  +  Method set/get stepping mode

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.40.1-alpha.279",
+      "version": "0.40.1-alpha.282",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.40.1-alpha.279",
+      "version": "0.40.1-alpha.282",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.40.1-alpha.279",
+      "version": "0.40.1-alpha.282",
       "commands": [
         "ixr"
       ],
@@ -53,4 +53,5 @@
     }
   }
 }
+
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -7,11 +7,11 @@
   <ItemGroup>
     <GlobalPackageReference Include="GitVersion.MsBuild" Version="5.10.3" />
     <!-- AX# START -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.40.1-alpha.279" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.40.1-alpha.279" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.40.1-alpha.279" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.40.1-alpha.279" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.40.1-alpha.279" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.40.1-alpha.282" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.40.1-alpha.282" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.40.1-alpha.282" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.40.1-alpha.282" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.40.1-alpha.282" />
     <PackageVersion Include="Inxton.Operon" Version="0.2.0-alpha.80" />
     <!-- AX# END -->
     <!-- Other -->
@@ -73,4 +73,5 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 </Project>
+
 

--- a/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
+++ b/src/core/ctrl/src/AxoCoordination/AxoSequencer/AxoSequencer.st
@@ -404,5 +404,17 @@ NAMESPACE AXOpen.Core
         METHOD PUBLIC GetCurrentStep : IAxoStep
             GetCurrentStep := CurrentStep;
         END_METHOD
+
+        METHOD PUBLIC GetSteppingMode : eAxoSteppingMode
+            GetSteppingMode := SteppingMode;
+        END_METHOD
+
+        METHOD PUBLIC SetSteppingMode 
+            VAR_INPUT
+                inSteppingMode : eAxoSteppingMode; 
+            END_VAR
+            SteppingMode := inSteppingMode;
+        END_METHOD
+
     END_CLASS    
 END_NAMESPACE

--- a/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
+++ b/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
@@ -1,4 +1,12 @@
 NAMESPACE AXOpen.Core
-    INTERFACE INTERNAL IAxoSequencer EXTENDS IAxoCoordinator
+    INTERFACE PUBLIC IAxoSequencer EXTENDS IAxoCoordinator, IAxoTask
+        METHOD  GetSteppingMode : eAxoSteppingMode END_METHOD
+
+        METHOD  SetSteppingMode 
+            VAR_INPUT
+                inSteppingMode : eAxoSteppingMode; 
+            END_VAR
+        END_METHOD
+        
     END_INTERFACE  
 END_NAMESPACE

--- a/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
+++ b/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
@@ -1,12 +1,19 @@
 NAMESPACE AXOpen.Core
-    INTERFACE PUBLIC IAxoSequencer EXTENDS IAxoCoordinator, IAxoTask
+    INTERFACE PUBLIC IAxoSequencer EXTENDS IAxoCoordinator
+    //, IAxoTask
         METHOD  GetSteppingMode : eAxoSteppingMode END_METHOD
 
         METHOD  SetSteppingMode 
             VAR_INPUT
                 inSteppingMode : eAxoSteppingMode; 
             END_VAR
-        END_METHOD
-        
+        END_METHOD 
+
+        METHOD IsReady : BOOL END_METHOD   
+        METHOD IsDone : BOOL END_METHOD   
+        METHOD IsBusy : BOOL END_METHOD   
+        METHOD HasError : BOOL END_METHOD 
+        METHOD Invoke : IAxoTaskState VAR_INPUT inParent : IAxoObject; END_VAR END_METHOD
+        METHOD Restore : IAxoTaskState END_METHOD                     
     END_INTERFACE  
 END_NAMESPACE

--- a/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
+++ b/src/core/ctrl/src/abstractions/AxoCoordination/AxoSequencer/IAxoSequencer.st
@@ -15,5 +15,10 @@ NAMESPACE AXOpen.Core
         METHOD HasError : BOOL END_METHOD 
         METHOD Invoke : IAxoTaskState VAR_INPUT inParent : IAxoObject; END_VAR END_METHOD
         METHOD Restore : IAxoTaskState END_METHOD                     
+        METHOD SetIsDisabled
+            VAR_INPUT
+                Disabled : BOOL;
+            END_VAR    
+        END_METHOD      
     END_INTERFACE  
 END_NAMESPACE


### PR DESCRIPTION
-This pull request introduces changes to the IAxoSequencer interface.

The main changes are:

- The IAxoSequencer interface is now public.
- Methods to get and set the stepping mode have been added.
- The IAxoSequencer interface no longer extends IAxoTask.
- A SetIsDisabled method has been added to the IAxoSequencer interface.
- The AXSharp package versions have been updated.