### PR TITLE
[BUG] Disabled task throws `execute not called error`

### DIFF
--- a/src/core/ctrl/src/AxoTask/AxoTaskLight.st
+++ b/src/core/ctrl/src/AxoTask/AxoTaskLight.st
@@ -253,9 +253,13 @@ NAMESPACE AXOpen.Core
 
             // task should not be Invoked, if the execute method was not called in this or previous PLC cycle
             IF Status = eAxoTaskState#Ready THEN
-                IF (THIS.IsExecuteCalledInThisPlcCycle() OR THIS.WasExecuteCalledInPreviousPlcCycle()) AND NOT _isDisabled THEN
-                    Status := eAxoTaskState#Kicking;      
-                    _context.GetLogger().Log('Task invoked', eLogLevel#Verbose, THIS);
+                IF (THIS.IsExecuteCalledInThisPlcCycle() OR THIS.WasExecuteCalledInPreviousPlcCycle()) THEN
+                    IF(NOT _isDisabled) THEN
+                        Status := eAxoTaskState#Kicking;      
+                        _context.GetLogger().Log('Task invoked', eLogLevel#Verbose, THIS);
+                    ELSE
+                        _context.GetLogger().Log('Attempt to invoke disabled task', eLogLevel#Information, THIS);    
+                    END_IF;    
                 ELSE
                     IF(NOT _suspendCyclicExecuteIsNotCalledCheck) THEN                                                               
                         _cyclicExecuteIsNotCalled := TRUE;                    

--- a/src/core/ctrl/test/AxoTask/AxoTaskTests.st
+++ b/src/core/ctrl/test/AxoTask/AxoTaskTests.st
@@ -1497,5 +1497,18 @@ NAMESPACE AXOpen.Core.AxoTask_Tests
             // TODO 
             // Assert.Equal(ULINT#3, myTask._messenger.MessageCode);           
         END_METHOD     
+
+        {Test}
+        METHOD PUBLIC invoke_disabled_task_should_not_enter_error_state
+            // Arrange/Act
+            myTask.Run(_rootObject);
+            _context.Open();
+            myTask.SetIsDisabled(TRUE);
+            myTask.Invoke();
+            myTask.Execute();          
+            _context.Close();   
+            
+            Assert.Equal(FALSE, myTask.HasError()); 
+        END_METHOD     
     END_CLASS
 END_NAMESPACE


### PR DESCRIPTION
## Summary
- Title: [BUG] Disabled task throws `execute not called error`
- Purpose: Fix a bug where invoking a disabled task could lead to an “execute not called” error; add logging for attempts to invoke disabled tasks.
- Status: Draft
- Branch: 743-bug-disabled-task-throws-execute-not-called-error → dev
- Linked issue: Closes #743
- Size: 2 files changed, +20 −3, 2 commits (005bb28, 073d144)

## Key changes
- File: `src/core/ctrl/src/AxoTask/AxoTaskLight.st`
  - Behavior when `Status = Ready` and `Execute` is called:
    - If task is not disabled: transition to `Kicking` and log “Task invoked” (Verbose).
    - If task is disabled: do not transition; log “Attempt to invoke disabled task” (Information).
  - Prevents falling into the branch that flags `_cyclicExecuteIsNotCalled` when `Execute` was indeed called but the task is disabled.

Why it matters: Previously, even with `Execute` called, a disabled task could still end up in an error state due to the combined condition. Separating the disabled check avoids incorrectly setting the “execute not called” error.

## Tests
- File: `src/core/ctrl/test/AxoTask/AxoTaskTests.st`
  - Added test `invoke_disabled_task_should_not_enter_error_state`
    - Steps: Run task, open context, disable task, Invoke, Execute, close context.
    - Asserts: `myTask.HasError()` is `FALSE`.

## Impact and risk
- Backward-compatible behavioral fix.
- Improves diagnostics with an informational log on disabled-invoke attempts.
- Low risk; guarded change within Ready-state invocation path and backed by a unit test.

## How to validate
- Run the new test to confirm disabled tasks don’t enter error state when invoked and executed.
- Manually reproduce:
  - Disable a task, call `Invoke()` and `Execute()` within an open context.
  - Verify no error state and check logs:
    - “Attempt to invoke disabled task” at Information level.
    - No transition to `Kicking` when disabled.

## Metadata
- Commits:
  - 005bb286… “Create draft PR for #743”
  - 073d1446… “Enhance AxoTaskLight to log attempts to invoke disabled tasks and add …”
- Files changed:
  - `AxoTaskLight.st` (+7/−3)
  - `AxoTaskTests.st` (+13)


closes #743