### PR TITLE
Add Units property and enhance inspector display logic

### DIFF
--- a/src/inspectors/ctrl/src/AxoInspectorData.st
+++ b/src/inspectors/ctrl/src/AxoInspectorData.st
@@ -4,6 +4,7 @@ NAMESPACE AXOpen.Inspectors
     /// Data subjected to each inspector instance.
     ///</summary>
     {S7.extern=ReadWrite}
+    {#ix-prop:public string Units}
     CLASS AxoInspectorData 
 
         VAR PUBLIC

--- a/src/inspectors/src/AxOpen.Inspectors.Blazor/InspectorViewTemplate.razor
+++ b/src/inspectors/src/AxOpen.Inspectors.Blazor/InspectorViewTemplate.razor
@@ -5,7 +5,7 @@
 <div class="accordion my-3">
     <div class="accordion-item">
         <button class="accordion-button @(_accordionOpen ? "active" : null)" type="button" @onclick="() => _accordionOpen = !_accordionOpen">
-            <p class="overflow-visible my-auto">@Name</p>
+            <p class="overflow-visible my-auto">@NameWithUnit</p>
 
             <div class="flex flex-row items-center justify-end w-full mx-2 gap-2">
                 @if (!_accordionOpen)
@@ -33,7 +33,7 @@
                     }
                 }
 
-                <GenericIconView Result="@result" />
+                <GenericIconView Result="@Result" />
             </div>
 
             <Operon.Icons.HeroIcon Icon="chevron-down" Type="Operon.Icons.IconType.Outline" Class="@("size-5 ms-auto my-auto icon-button-rotate " + (_accordionOpen ? "rotated" : null))" />
@@ -94,7 +94,10 @@
     [Parameter]
     public string Name { get; set; }
 
-    private short result
+    private string NameWithUnit => string.IsNullOrEmpty(this.Data?.Units) ? this.Name : $"{Name} [{this.Data.Units}]";
+
+
+    private short Result
     {
         get
         {


### PR DESCRIPTION
- Introduced a new public `Units` property in `AxoInspectorData` to hold unit information for inspector data.
- Updated `InspectorViewTemplate.razor` to replace `Name` with `NameWithUnit`, providing clearer context by including measurement units.
- Changed `Result` from a private short to a calculated property based on `Presentation`, improving dynamic result retrieval.