### PR TITLE
updates create issue branch script to consider any assigne

### DIFF
--- a/scripts/_create_issue_branch.ps1
+++ b/scripts/_create_issue_branch.ps1
@@ -18,8 +18,12 @@ if(-not $is_on_dev_nothing_to_commit)
 }
 
 
-gh issue list --assignee "@me" --state "open"
-$issues = gh issue list --state "open" --assignee "@me" --json number,title | ConvertFrom-Json
+# gh issue list --assignee "@me" --state "open"
+# $issues = gh issue list --state "open" --assignee "@me" --json number,title | ConvertFrom-Json
+
+gh issue list --state "open"
+$issues = gh issue list --state "open" --json number,title | ConvertFrom-Json
+
 $issueIDs = $issues | ForEach-Object { $_.number }
 
 if (-not $IssueId) 


### PR DESCRIPTION
This pull request makes a minor update to the `scripts/_create_issue_branch.ps1` script. The change removes the filtering of issues by assignee, so now all open issues are listed instead of only those assigned to the current user.

- Removed the `--assignee "@me"` filter from `gh issue list` commands, causing the script to retrieve all open issues rather than only those assigned to the current user.