### PR TITLE
axo componet and axo messenger changes w-full

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoComponent/AxoComponentView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoComponent/AxoComponentView.razor
@@ -24,14 +24,12 @@
     <!-- Alarms Panel (Collapsible) -->
     @if (_showAlarms && _alarmCount > 0 && _messageProvider?.Messengers != null)
     {
-        <div class="card m-2 p-2">
+        <div class="w-full p-2">
             @foreach (var alarm in _messageProvider.Messengers)
             {
                 if (alarm.State != eAxoMessengerState.Idle)
                 {
-                    <div class="w-full m-1">
-                        <AxoMessengerView Component="alarm" Class="w-full" />
-                    </div>
+                    <AxoMessengerView Component="alarm" />
                 }
             }
         </div>

--- a/src/core/src/AXOpen.Core.Blazor/AxoMessenger/Static/AxoMessengerView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoMessenger/Static/AxoMessengerView.razor
@@ -4,7 +4,7 @@
 @using Operon.Icons
 @implements IDisposable;
 
-<div data-axo-messenger-view class="card m-2 @ConvertToInternalShadowGlowSeverityName((eAxoMessageCategory)Component.Category.LastValue) @ConvertToInternalBgShadowSeverityName((eAxoMessageCategory)Component.Category.LastValue) @Class">
+<div data-axo-messenger-view class="card w-full @ConvertToInternalShadowGlowSeverityName((eAxoMessageCategory)Component.Category.LastValue) @ConvertToInternalBgShadowSeverityName((eAxoMessageCategory)Component.Category.LastValue) @Class">
     <div class="card-title flex flex-wrap flex-row justify-between gap-2 bg-background-light/40!">
         <div class="flux-flex flex-wrap items-center gap-2">
             <div class="flux-badge badge-primary gap-2" aria-label="Severity">


### PR DESCRIPTION
This pull request makes improvements to the alarm panel and messenger view layouts in the Blazor UI components. The main focus is on simplifying the markup and ensuring consistent full-width styling for alarm and messenger cards.

**UI layout and styling improvements:**

* In `AxoComponentView.razor`, the alarm panel and its items now use a simpler structure with `w-full` for full width and remove unnecessary wrapper divs and card classes for each alarm.
* In `AxoMessengerView.razor`, the root div now always includes the `w-full` class to ensure messenger cards span the full available width, improving visual consistency.