### PR TITLE
Refactor cylinder test cases and enhance UI components

### DIFF
--- a/src/components.pneumatics/app/src/Documentation/DocumentationContext.st
+++ b/src/components.pneumatics/app/src/Documentation/DocumentationContext.st
@@ -34,13 +34,13 @@ NAMESPACE AXOpen.Components.Pneumatics
 
         METHOD Examples
             //<MoveToHome>
-            IF myAxoCylinder.MoveToHome().IsDone() THEN
+            IF myAxoCylinder.MoveIn().IsDone() THEN
                 ;
             END_IF;
             //</MoveToHome>
 
             //<MoveToWork>
-            IF myAxoCylinder.MoveToWork().IsDone() THEN
+            IF myAxoCylinder.MoveOut().IsDone() THEN
                 ;
             END_IF;
             //</MoveToWork>

--- a/src/components.pneumatics/components.pneumatics.code-workspace
+++ b/src/components.pneumatics/components.pneumatics.code-workspace
@@ -1,10 +1,12 @@
 {
 	"folders": [
 		{
-			"path": "ctrl"
+			"name": "app",
+			"path": "app"
 		},
 		{
-			"path": "app"
+			"name": "ctrl",
+			"path": "ctrl"
 		}
 	],
 	"settings": {}

--- a/src/components.pneumatics/ctrl/docs/AXOCYLINDER.md
+++ b/src/components.pneumatics/ctrl/docs/AXOCYLINDER.md
@@ -19,10 +19,10 @@ To accomplish this, call the `Run` method cyclically with the proper variables (
 **Example of the initialization and hardware signal assignment**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=DeclarationAndHWIO_Assignement)]
 
-To trigger the movements, two public methods, `MoveToHome` and `MoveToWork` are present. 
+To trigger the movements, two public methods, `MoveToHome` and `MoveOut` are present. 
 **Example of using MoveToHome method**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=MoveToHome)]
-**Example of using MoveToWork method**
+**Example of using MoveOut method**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=MoveToWork)]
 
 To stop the movement, when the cylinder is moving, the public `Stop` method is present. 
@@ -33,15 +33,15 @@ To stop the movement, when the cylinder is moving, the public `Stop` method is p
 
 **Blocking the movement**
 To block the movement, there are four public methods present:
-`SuspendMoveToHomeWhile(Condition)` - Suspends the movement to the home position while the `Condition` is `TRUE`. If the task was already invoked, it remains still executing and, with the falling edge of the `Condition` cylinder, continues its movement to the home position. If the task is invoked when `Condition` is already `TRUE`, the task starts to be executed, but the movement starts also with the falling edge of the `Condition`. 
-`SuspendMoveToWorkWhile(Condition)` - Works exactly the same as `SuspendMoveToHomeWhile(Condition)` but in the opposite direction.
+`SuspendMoveToHomeWhile(Condition)` - Suspends the movement to the in position while the `Condition` is `TRUE`. If the task was already invoked, it remains still executing and, with the falling edge of the `Condition` cylinder, continues its movement to the in position. If the task is invoked when `Condition` is already `TRUE`, the task starts to be executed, but the movement starts also with the falling edge of the `Condition`. 
+`SuspendMoveToWorkWhile(Condition)` - Works exactly the same as `SuspendMoveToHomeWhile(Condition)` but in the opposite direction (to the out position).
 **Example of using SuspendMoveToHomeWhile method**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=SuspendMoveToHomeWhile)]
 **Example of using SuspendMoveToWorkWhile method**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=SuspendMoveToWorkWhile)]
 
-`AbortMoveToHomeWhen(Condition)` - Aborts the movement to the home position when the `Condition` is `TRUE`. If the task was already invoked, it is restored and disabled. After the falling edge of the `Condition` cylinder does not continue its movement to the home position. The task needs to be invoked again to start the movement. 
-`AbortMoveToWorkWhen(Condition)` - Works exactly the same as `AbortMoveToHomeWhen(Condition)` but in the opposite direction.
+`AbortMoveToHomeWhen(Condition)` - Aborts the movement to the in position when the `Condition` is `TRUE`. If the task was already invoked, it is restored and disabled. After the falling edge of the `Condition` cylinder does not continue its movement to the in position. The task needs to be invoked again to start the movement. 
+`AbortMoveToWorkWhen(Condition)` - Works exactly the same as `AbortMoveToHomeWhen(Condition)` but in the opposite direction (to the out position).
 **Example of using AbortMoveToHomeWhen method**
 [!code-smalltalk[](../../../../src/components.pneumatics/app/src/Documentation/DocumentationContext.st?name=AbortMoveToHomeWhen)]
 **Example of using AbortMoveToWorkWhen method**

--- a/src/components.pneumatics/ctrl/src/AxoCylinder.st
+++ b/src/components.pneumatics/ctrl/src/AxoCylinder.st
@@ -4,6 +4,10 @@ USING AXOpen.Messaging.Static;
 
 
 NAMESPACE AXOpen.Components.Pneumatics
+    //<summary>
+    /// Represents a pneumatic cylinder with two positions: in and out. It provides tasks to move the cylinder in and out, as well as to stop its movement.
+    /// The component also includes sensors to detect the cylinder's position and signals to control its movement
+    /// </summary>
     {S7.extern=ReadWrite}
     {#ix-prop:public string InLabel}
     {#ix-prop:public string OutLabel}
@@ -61,14 +65,14 @@ NAMESPACE AXOpen.Components.Pneumatics
 
 
         ///<summary>
-        /// Returns 'true' if the movement to the out position is currently suspended.
+        /// Returns 'true' if the movement to the extended position is currently suspended.
         ///</summary>
         METHOD PUBLIC IsMoveToOutSuspended : BOOL
             IsMoveToOutSuspended := _MoveToOutIsSuspended;
         END_METHOD
 
         ///<summary>
-        /// Returns 'true' if the movement to the in position is currently suspended.
+        /// Returns 'true' if the movement to the retracted position is currently suspended.
         /// </summary>
         METHOD PUBLIC IsMoveToInSuspended : BOOL
             IsMoveToInSuspended := _MoveToInIsSuspended;
@@ -167,14 +171,14 @@ NAMESPACE AXOpen.Components.Pneumatics
         END_METHOD        
 
         ///<summary>
-		/// Invokes the movement to the out position and returns the task state. 	
+		/// Invokes the movement to the extended position and returns the task state. 	
         ///</summary>       
         METHOD PUBLIC MoveOut : IAxoTaskState
             MoveOut := _MoveOutTask.Invoke(THIS);
         END_METHOD
 
         ///<summary>
-		/// Invokes the movement to the in position and returns the task state. 	
+		/// Invokes the movement to the retracted position and returns the task state. 	
         ///</summary>       
         METHOD PUBLIC MoveIn : IAxoTaskState
             MoveIn := _MoveInTask.Invoke(THIS);
@@ -186,9 +190,9 @@ NAMESPACE AXOpen.Components.Pneumatics
         METHOD PUBLIC Stop : IAxoTaskState
             Stop := _StopTask.Invoke(THIS);
         END_METHOD
-
+     
         ///<summary>
-        /// Suspends the movement to the out position while the condition is 'true'. Task remains still executing.
+        /// Suspends the movement to the extended position while the condition is 'true'. Task remains still executing.
         ///</summary>
         METHOD PUBLIC SuspendMoveToWorkWhile 
             VAR_INPUT
@@ -219,7 +223,7 @@ NAMESPACE AXOpen.Components.Pneumatics
         END_METHOD        
 
         ///<summary>
-        /// Suspends the movement to the in position while the condition is 'true'. Task remains still executing.
+        /// Suspends the movement to the retracted position while the condition is 'true'. Task remains still executing.
         ///</summary>
         METHOD PUBLIC SuspendMoveToHomeWhile 
             VAR_INPUT
@@ -250,7 +254,7 @@ NAMESPACE AXOpen.Components.Pneumatics
         END_METHOD   
 
         ///<summary>
-        /// Aborts the movement to the out position when the condition is 'true' and restores the respective task.
+        /// Aborts the movement to the extended position when the condition is 'true' and restores the respective task.
         ///</summary>
         METHOD PUBLIC AbortMoveToWorkWhen 
             VAR_INPUT
@@ -266,7 +270,7 @@ NAMESPACE AXOpen.Components.Pneumatics
         END_METHOD        
 
         ///<summary>
-        /// Aborts the movement to the in position when the condition is 'true' and restores the respective task.
+        /// Aborts the movement to the retracted position when the condition is 'true' and restores the respective task.
         ///</summary>
         METHOD PUBLIC AbortMoveToHomeWhen 
             VAR_INPUT

--- a/src/components.pneumatics/ctrl/src/AxoCylinder.st
+++ b/src/components.pneumatics/ctrl/src/AxoCylinder.st
@@ -5,16 +5,20 @@ USING AXOpen.Messaging.Static;
 
 NAMESPACE AXOpen.Components.Pneumatics
     {S7.extern=ReadWrite}
+    {#ix-prop:public string InLabel}
+    {#ix-prop:public string OutLabel}
+    {#ix-set:InLabel = "<#In#>"}
+    {#ix-set:OutLabel = "<#Out#>"}
     CLASS AxoCylinder EXTENDS AXOpen.Core.AxoComponent
         VAR PUBLIC
             {#ix-attr:[Container(Layout.Wrap)]}
             {#ix-attr:[ComponentHeader()]}
-            {#ix-set:AttributeName = "<#Move to work#>"}
-            _MoveToWorkTask : AxoTask; 
+            {#ix-set:AttributeName = "<#Move in#>"}
+            _MoveInTask : AxoTask; 
 
             {#ix-attr:[ComponentHeader()]}            
-            {#ix-set:AttributeName = "<#Move to home#>"}
-            _MoveToHomeTask : AxoTask;
+            {#ix-set:AttributeName = "<#Move out#>"}
+            _MoveOutTask : AxoTask;
 
             {#ix-attr:[ComponentDetails("Tasks")]}            
             {#ix-set:AttributeName = "<#Stop#>"}
@@ -23,51 +27,51 @@ NAMESPACE AXOpen.Components.Pneumatics
             {#ix-attr:[Container(Layout.Stack)]}
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
-            {#ix-set:AttributeName = "<#Home sensor#>"}
-            _HomeSensor : BOOL;
+            {#ix-set:AttributeName = "<#In sensor#>"}
+            _InSensor : BOOL;
 
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
-            {#ix-set:AttributeName = "<#Work sensor#>"}
-            _WorkSensor : BOOL;
+            {#ix-set:AttributeName = "<#Out sensor#>"}
+            _OutSensor : BOOL;
 
             {#ix-attr:[Container(Layout.Stack)]}
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
-            {#ix-set:AttributeName = "<#Move home signal#>"}
-            _MoveHomeSignal : BOOL;
+            {#ix-set:AttributeName = "<#Move in signal#>"}
+            _MoveInSignal : BOOL;
 
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
-            {#ix-set:AttributeName = "<#Move work signal#>"}
-            _MoveWorkSignal : BOOL;
+            {#ix-set:AttributeName = "<#Move out signal#>"}
+            _MoveOutSignal : BOOL;
 
             _Messenger : AXOpen.Messaging.Static.AxoMessenger;
         END_VAR
 
         VAR PRIVATE
-            _MoveToWorkIsSuspended : BOOL;
-            _MoveToHomeIsSuspended : BOOL;
+            _MoveToOutIsSuspended : BOOL;
+            _MoveToInIsSuspended : BOOL;
 
-            _MoveToWorkIsBusy : BOOL;
-            _MoveToHomeIsBusy : BOOL;
+            _MoveToOutIsBusy : BOOL;
+            _MoveToInIsBusy : BOOL;
 
             _context : IAxoContext;
         END_VAR
 
 
         ///<summary>
-        /// Returns 'true' if the movement to the work position is currently suspended.
+        /// Returns 'true' if the movement to the out position is currently suspended.
         ///</summary>
-        METHOD PUBLIC IsMoveToWorkSuspended : BOOL
-            IsMoveToWorkSuspended := _MoveToWorkIsSuspended;
+        METHOD PUBLIC IsMoveToOutSuspended : BOOL
+            IsMoveToOutSuspended := _MoveToOutIsSuspended;
         END_METHOD
 
         ///<summary>
-        /// Returns 'true' if the movement to the home position is currently suspended.
+        /// Returns 'true' if the movement to the in position is currently suspended.
         /// </summary>
-        METHOD PUBLIC IsMoveToHomeSuspended : BOOL
-            IsMoveToHomeSuspended := _MoveToHomeIsSuspended;
+        METHOD PUBLIC IsMoveToInSuspended : BOOL
+            IsMoveToInSuspended := _MoveToInIsSuspended;
         END_METHOD
 
         ///<summary>
@@ -77,12 +81,12 @@ NAMESPACE AXOpen.Components.Pneumatics
         METHOD PUBLIC Run 
             VAR_INPUT
                 inParent : IAxoObject;
-                inHomeSensor : BOOL;
-                inWorkSensor : BOOL;    
+                inInSensor : BOOL;
+                inOutSensor : BOOL;    
             END_VAR
             VAR_OUTPUT
-                outMoveHomeSignal : BOOL;
-                outMoveWorkSignal : BOOL;
+                outMoveInSignal : BOOL;
+                outMoveOutSignal : BOOL;
             END_VAR
 
             IF (inParent = NULL) THEN 
@@ -96,57 +100,57 @@ NAMESPACE AXOpen.Components.Pneumatics
 
             SUPER.Run(inParent);
 
-            _homeSensor := inHomeSensor;
-            _workSensor := inWorkSensor;
+            _InSensor := inInSensor;
+            _OutSensor := inOutSensor;
 
 
             _Messenger.Serve(THIS);
 
-            _Messenger.ActivateOnCondition(UINT#3, _workSensor AND _homeSensor, eAxoMessageCategory#Error);
+            _Messenger.ActivateOnCondition(UINT#3, _OutSensor AND _InSensor, eAxoMessageCategory#Error);
 
             IF(_StopTask.Execute(THIS)) THEN
-                _MoveHomeSignal := FALSE;
-                _MoveWorkSignal := FALSE;
-                _MoveToHomeTask.Restore();
-                _MoveToWorkTask.Restore();                
+                _MoveInSignal := FALSE;
+                _MoveOutSignal := FALSE;
+                _MoveInTask.Restore();
+                _MoveOutTask.Restore();                
                 _StopTask.DoneWhen(TRUE);
             END_IF;    
 
-            IF(_MoveToWorkTask.Execute(THIS)) THEN  
-                IF(_MoveToWorkTask.IsFirstExecutionCycle()) THEN
-                    _MoveToHomeTask.Restore(); 
+            IF(_MoveOutTask.Execute(THIS)) THEN  
+                IF(_MoveOutTask.IsFirstExecutionCycle()) THEN
+                    _MoveInTask.Restore(); 
                 END_IF;                 
-                _MoveHomeSignal := FALSE;
-                _MoveWorkSignal := TRUE;                
-                _MoveToWorkTask.DoneWhen(_workSensor);                               
+                _MoveInSignal := FALSE;
+                _MoveOutSignal := TRUE;                
+                _MoveOutTask.DoneWhen(_OutSensor);                               
             END_IF;        
 
-            _MoveToWorkIsBusy := _MoveToWorkTask.IsBusy();
+            _MoveToOutIsBusy := _MoveOutTask.IsBusy();
 
-           _Messenger.ActivateOnCondition(UINT#1, (_MoveToWorkIsBusy AND NOT _MoveToWorkIsSuspended AND _MoveToWorkTask.Duration >= T#10S), eAxoMessageCategory#Error);   
-           _Messenger.ActivateOnCondition(UINT#9, (_MoveToWorkTask.IsDone() AND NOT _workSensor), eAxoMessageCategory#Warning); 
+           _Messenger.ActivateOnCondition(UINT#1, (_MoveToOutIsBusy AND NOT _MoveToOutIsSuspended AND _MoveOutTask.Duration >= T#10S), eAxoMessageCategory#Error);   
+           _Messenger.ActivateOnCondition(UINT#9, (_MoveOutTask.IsDone() AND NOT _OutSensor), eAxoMessageCategory#Warning); 
             
 
-            IF(_MoveToHomeTask.Execute(THIS)) THEN    
-                IF(_MoveToHomeTask.IsFirstExecutionCycle()) THEN
-                    _MoveToWorkTask.Restore();
+            IF(_MoveInTask.Execute(THIS)) THEN    
+                IF(_MoveInTask.IsFirstExecutionCycle()) THEN
+                    _MoveOutTask.Restore();
                 END_IF;
-                _MoveHomeSignal := TRUE;
-                _MoveWorkSignal := FALSE;
-                _MoveToHomeTask.DoneWhen(_homeSensor);                           
+                _MoveInSignal := TRUE;
+                _MoveOutSignal := FALSE;
+                _MoveInTask.DoneWhen(_InSensor);                           
             END_IF; 
 
-            _MoveToHomeIsBusy := _MoveToHomeTask.IsBusy();
+            _MoveToInIsBusy := _MoveInTask.IsBusy();
 
-            _Messenger.ActivateOnCondition(UINT#2, (_MoveToHomeIsBusy AND NOT _MoveToHomeIsSuspended AND _MoveToHomeTask.Duration >= T#10S), eAxoMessageCategory#Error);
-            _Messenger.ActivateOnCondition(UINT#8, (_MoveToHomeTask.IsDone() AND NOT _homeSensor), eAxoMessageCategory#Warning);
+            _Messenger.ActivateOnCondition(UINT#2, (_MoveToInIsBusy AND NOT _MoveToInIsSuspended AND _MoveInTask.Duration >= T#10S), eAxoMessageCategory#Error);
+            _Messenger.ActivateOnCondition(UINT#8, (_MoveInTask.IsDone() AND NOT _InSensor), eAxoMessageCategory#Warning);
 
 
-            outMoveHomeSignal := _moveHomeSignal AND NOT _MoveToHomeIsSuspended;
-            outMoveWorkSignal := _moveWorkSignal AND NOT _MoveToWorkIsSuspended;
+            outMoveInSignal := _MoveInSignal AND NOT _MoveToInIsSuspended;
+            outMoveOutSignal := _MoveOutSignal AND NOT _MoveToOutIsSuspended;
 
-            _MoveToHomeIsSuspended := FALSE;
-            _MoveToWorkIsSuspended := FALSE;
+            _MoveToInIsSuspended := FALSE;
+            _MoveToOutIsSuspended := FALSE;
         END_METHOD
 
         METHOD PROTECTED OVERRIDE ManualControl
@@ -157,23 +161,23 @@ NAMESPACE AXOpen.Components.Pneumatics
         /// Restores this component into intial state.        
         ///</summary>
         METHOD PUBLIC OVERRIDE Restore 
-            _MoveToWorkTask.Restore();
-            _MoveToHomeTask.Restore();
+            _MoveOutTask.Restore();
+            _MoveInTask.Restore();
             _StopTask.Restore();
         END_METHOD        
 
         ///<summary>
-		/// Invokes the movement to the work position and returns the task state. 	
+		/// Invokes the movement to the out position and returns the task state. 	
         ///</summary>       
-        METHOD PUBLIC MoveToWork : IAxoTaskState
-            MoveToWork := _MoveToWorkTask.Invoke(THIS);
+        METHOD PUBLIC MoveOut : IAxoTaskState
+            MoveOut := _MoveOutTask.Invoke(THIS);
         END_METHOD
 
         ///<summary>
-		/// Invokes the movement to the home position and returns the task state. 	
+		/// Invokes the movement to the in position and returns the task state. 	
         ///</summary>       
-        METHOD PUBLIC MoveToHome : IAxoTaskState
-            MoveToHome := _MoveToHomeTask.Invoke(THIS);
+        METHOD PUBLIC MoveIn : IAxoTaskState
+            MoveIn := _MoveInTask.Invoke(THIS);
         END_METHOD
 
         ///<summary>
@@ -184,7 +188,7 @@ NAMESPACE AXOpen.Components.Pneumatics
         END_METHOD
 
         ///<summary>
-        /// Suspends the movement to the work position while the condition is 'true'. Task remains still executing.
+        /// Suspends the movement to the out position while the condition is 'true'. Task remains still executing.
         ///</summary>
         METHOD PUBLIC SuspendMoveToWorkWhile 
             VAR_INPUT
@@ -197,8 +201,8 @@ NAMESPACE AXOpen.Components.Pneumatics
                 _messageCondition : BOOL;
             END_VAR
 
-            _suspendCondition := NOT _workSensor && inCondition;
-            _messageCondition := _suspendCondition && _MoveToWorkTask.IsEngaged();
+            _suspendCondition := NOT _OutSensor && inCondition;
+            _messageCondition := _suspendCondition && _MoveOutTask.IsEngaged();
 
             IF(_messageCondition) THEN
                 IF inMessage = '' THEN
@@ -209,13 +213,13 @@ NAMESPACE AXOpen.Components.Pneumatics
             END_IF;  
               
             IF(_suspendCondition) THEN
-                _moveWorkSignal := FALSE;  
-                _MoveToWorkIsSuspended := TRUE;
+                _MoveOutSignal := FALSE;  
+                _MoveToOutIsSuspended := TRUE;
             END_IF;
         END_METHOD        
 
         ///<summary>
-        /// Suspends the movement to the home position while the condition is 'true'. Task remains still executing.
+        /// Suspends the movement to the in position while the condition is 'true'. Task remains still executing.
         ///</summary>
         METHOD PUBLIC SuspendMoveToHomeWhile 
             VAR_INPUT
@@ -228,8 +232,8 @@ NAMESPACE AXOpen.Components.Pneumatics
                 _messageCondition : BOOL;
             END_VAR
 
-            _suspendCondition := NOT _homeSensor && inCondition;
-            _messageCondition := _suspendCondition && _MoveToHomeTask.IsEngaged();
+            _suspendCondition := NOT _InSensor && inCondition;
+            _messageCondition := _suspendCondition && _MoveInTask.IsEngaged();
 
             IF(_messageCondition) THEN
                 IF inMessage = '' THEN
@@ -240,13 +244,13 @@ NAMESPACE AXOpen.Components.Pneumatics
             END_IF;  
               
             IF(_suspendCondition) THEN
-                _moveHomeSignal := FALSE;  
-                _MoveToHomeIsSuspended := TRUE;
+                _MoveInSignal := FALSE;  
+                _MoveToInIsSuspended := TRUE;
             END_IF;
         END_METHOD   
 
         ///<summary>
-        /// Aborts the movement to the work position when the condition is 'true' and restores the respective task.
+        /// Aborts the movement to the out position when the condition is 'true' and restores the respective task.
         ///</summary>
         METHOD PUBLIC AbortMoveToWorkWhen 
             VAR_INPUT
@@ -254,15 +258,15 @@ NAMESPACE AXOpen.Components.Pneumatics
             END_VAR
 
             IF(Condition) THEN                        
-                _moveWorkSignal := FALSE;   
-                _MoveToWorkTask.Abort();
+                _MoveOutSignal := FALSE;   
+                _MoveOutTask.Abort();
                 _Messenger.Activate(UINT#6, eAxoMessageCategory#Info);
             END_IF;    
-            _MoveToWorkTask.SetIsDisabled(Condition);
+            _MoveOutTask.SetIsDisabled(Condition);
         END_METHOD        
 
         ///<summary>
-        /// Aborts the movement to the home position when the condition is 'true' and restores the respective task.
+        /// Aborts the movement to the in position when the condition is 'true' and restores the respective task.
         ///</summary>
         METHOD PUBLIC AbortMoveToHomeWhen 
             VAR_INPUT
@@ -270,11 +274,11 @@ NAMESPACE AXOpen.Components.Pneumatics
             END_VAR
 
             IF(Condition) THEN                        
-                _moveHomeSignal := FALSE;   
+                _MoveInSignal := FALSE;   
                 _Messenger.Activate(UINT#7, eAxoMessageCategory#Info);
-                _MoveToHomeTask.Abort();
+                _MoveInTask.Abort();
             END_IF;    
-            _MoveToHomeTask.SetIsDisabled(Condition);
+            _MoveInTask.SetIsDisabled(Condition);
         END_METHOD  
     END_CLASS
 END_NAMESPACE

--- a/src/components.pneumatics/ctrl/test/CylinderTests.st
+++ b/src/components.pneumatics/ctrl/test/CylinderTests.st
@@ -108,17 +108,17 @@ NAMESPACE Cylinder.Tests
             THIS.Init();  
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
         END_METHOD
         
         {Test}
@@ -126,17 +126,17 @@ NAMESPACE Cylinder.Tests
             THIS.Init();  
 
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD  
 
         {Test}
@@ -144,7 +144,7 @@ NAMESPACE Cylinder.Tests
             THIS.Init();  
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
@@ -155,12 +155,12 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD
         
         {Test}
@@ -168,7 +168,7 @@ NAMESPACE Cylinder.Tests
             THIS.Init();  
 
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
@@ -179,12 +179,12 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD  
         
         {Test}
@@ -195,15 +195,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt);  
 
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -215,8 +215,8 @@ NAMESPACE Cylinder.Tests
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());  
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());  
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -230,15 +230,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt);    
 
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(TRUE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -248,10 +248,10 @@ NAMESPACE Cylinder.Tests
             cylinder.SuspendMoveToWorkWhile(TRUE);
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -265,15 +265,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt);   
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(TRUE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -285,8 +285,8 @@ NAMESPACE Cylinder.Tests
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -300,15 +300,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt); 
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(TRUE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             context.Open();                                                              
@@ -317,10 +317,10 @@ NAMESPACE Cylinder.Tests
             cylinder.SuspendMoveToHomeWhile(TRUE);
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -344,23 +344,23 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                             
            
-            cylinder.MoveToWork();    
+            cylinder.MoveOut();    
             cylinder.SuspendMoveToWorkWhile(TRUE);       
           
             cylinder.Run(inParent := cylinderParent, 
-                        inHomeSensor := _homeSensor, 
-                        inWorkSensor := _workSensor,
-                        outMoveHomeSignal => _moveHomeSignal, 
-                        outMoveWorkSignal => _moveWorkSignal);
+                        inInSensor := _homeSensor, 
+                        inOutSensor := _workSensor,
+                        outMoveInSignal => _moveHomeSignal, 
+                        outMoveOutSignal => _moveWorkSignal);
 
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder.IsMoveToWorkSuspended());  
+            AxUnit.Assert.Equal(FALSE, cylinder.IsMoveToOutSuspended());  
             AxUnit.Assert.Equal(FALSE, _workSensor);   
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -384,14 +384,14 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
-            cylinder.MoveToHome();                                                        
+            cylinder.MoveIn();                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             // AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -407,15 +407,15 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
 
             context.Open();                                                              
             cylinder.AbortMoveToWorkWhen(TRUE);
@@ -423,10 +423,10 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());  
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());  
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -440,15 +440,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt);    
 
             context.Open();                                                              
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(TRUE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -458,10 +458,10 @@ NAMESPACE Cylinder.Tests
             cylinder.AbortMoveToWorkWhen(TRUE);
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -475,15 +475,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt);   
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(TRUE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -495,8 +495,8 @@ NAMESPACE Cylinder.Tests
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -510,15 +510,15 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt); 
 
             context.Open();                                                              
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(TRUE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
@@ -528,10 +528,10 @@ NAMESPACE Cylinder.Tests
             cylinder.AbortMoveToHomeWhen(TRUE);
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveWorkSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -549,15 +549,15 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.AbortMoveToWorkWhen(TRUE);
-            cylinder.MoveToWork();
+            cylinder.MoveOut();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToWorkTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToWork().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -575,15 +575,15 @@ NAMESPACE Cylinder.Tests
 
             context.Open();                                                              
             cylinder.AbortMoveToHomeWhen(TRUE);
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));
@@ -599,7 +599,7 @@ NAMESPACE Cylinder.Tests
             THIS.Init(dt); 
             context.Open();                                                              
             cylinder.SuspendMoveToHomeWhile(TRUE);
-            cylinder.MoveToHome();
+            cylinder.MoveIn();
             context.InitializeRootObject(cylinderParent);                                                        
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
@@ -614,8 +614,8 @@ NAMESPACE Cylinder.Tests
 
             AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
             AxUnit.Assert.Equal(FALSE, _moveHomeSignal);   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveToHomeTask.IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder.MoveToHome().IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(TRUE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             AxUnit.Assert.Equal(TRUE,THIS.AreEqual(dt, cylinder._Messenger.Risen));

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderCommandView.razor
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderCommandView.razor
@@ -1,0 +1,9 @@
+﻿@namespace AXOpen.Components.Pneumatics
+@inherits AxoCylinderView
+
+@* Control view with all actions and modifications enabled *@
+<AxoCylinderView Component="@Component" EnableControls="true"></AxoCylinderView>
+
+@code {
+    // Inherits all functionality from AxoCylinderView with controls enabled (default)
+}

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderStatusView.razor
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderStatusView.razor
@@ -1,0 +1,9 @@
+﻿@namespace AXOpen.Components.Pneumatics
+@inherits AxoCylinderView
+
+@* Status view with all actions and modifications disabled *@
+<AxoCylinderView Component="@Component" EnableControls="false"></AxoCylinderView>
+
+@code {
+    // Inherits all functionality from AxoCylinderView but disables controls
+}

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor
@@ -1,0 +1,132 @@
+@namespace AXOpen.Components.Pneumatics
+@using AXOpen.Core
+@using AXOpen.Messaging
+@using AXOpen.Messaging.Static
+@inherits RenderableComplexComponentBase<AXOpen.Components.Pneumatics.AxoCylinder>
+
+<div data-axo-cylinder-view class="flex flex-col gap-4 p-4 border rounded-lg bg-background @AlarmBorderClass">
+    <!-- Component Header -->
+    <div @onclick="ToggleAnimation" class="flex items-center justify-between border-b border-border pb-2 cursor-pointer hover:bg-background/20 transition-colors rounded px-2 -mx-2">
+        <div class="flex items-center gap-2">
+            <span class="text-xs">@(ShowAnimationPanel ? "▼" : "▶")</span>
+            <h4 class="text-lg font-semibold text-text">@Component.AttributeName</h4>
+        </div>
+        <div class="flex items-center gap-2" @onclick:stopPropagation="true">
+            @if (IsInInnerPosition)
+            {
+                <span class="badge badge-success">Home</span>
+            }
+            else if (IsInOuterPosition)
+            {
+                <span class="badge badge-info">Work</span>
+            }
+            else if (IsMoving)
+            {
+                <span class="badge badge-warning">Moving</span>
+            }
+            else
+            {
+                <span class="badge badge-primary">---</span>
+            }
+            
+            @if (HasActiveMessages)
+            {
+                <button @onclick="ToggleMessages" 
+                        class="badge @AlarmBadgeClass"
+                        title="@ActiveAlarmCount @(ActiveAlarmCount != 1 ? "alarms" : "alarm") active">
+                    @ActiveAlarmCount Active Alarm@(ActiveAlarmCount != 1 ? "s" : "")
+                </button>
+            }
+            
+            <button @onclick="ToggleServiceView" 
+                    class="badge badge-secondary"
+                    title="Toggle service view">
+                @(ShowServiceView ? "Normal" : "Service")
+            </button>
+        </div>
+    </div>
+
+    @if (ShowServiceView)
+    {
+        <!-- Service View -->
+        @* <AxoComponentView Component="@this.Component" Presentation="Command" /> *@
+    }
+    else
+    {
+        <!-- Alarms Display -->
+        @if (ShowMessages && _alarmCount > 0 && _messageProvider?.Messengers != null)
+        {
+            <div class="flex flex-col gap-2 border-t border-border pt-2">
+                @foreach (var alarm in _messageProvider.Messengers)
+                {
+                    if (alarm.State != eAxoMessengerState.Idle)
+                    {
+                        <AxoMessengerView Component="alarm" />
+                    }
+                }
+            </div>
+        }
+
+        <!-- Visual Representation -->
+    @if (ShowAnimationPanel)
+    {
+        <div class="flex flex-col gap-4 p-4 bg-background/40 rounded-lg w-full">
+            <!-- Cylinder Visual -->
+            <div class="flex items-center gap-4 w-full">
+                <!-- Inner Position with Label on Left -->
+                <div class="flex items-center gap-2 flex-shrink-0">
+                <span class="text-xs font-medium text-text/70">@Component.InLabel</span>
+                <div class="sensor-indicator @(IsInInnerPosition ? "active bg-success text-success" : "bg-border/30 text-border")"></div>
+            </div>
+
+            <!-- Pneumatic Cylinder Assembly -->
+            <div class="pneumatic-cylinder @(IsMoving && ShowAnimation ? "cylinder-moving" : "") flex-1">
+                <!-- Movement Direction Indicator -->
+                @if (ShowAnimation && Component._MoveInSignal.Cyclic)
+                {
+                    <div class="direction-indicator text-warning">◄</div>
+                }
+                @if (ShowAnimation && Component._MoveOutSignal.Cyclic)
+                {
+                    <div class="direction-indicator text-warning">►</div>
+                }
+                
+                <!-- Left End Cap -->
+                <div class="cylinder-cap rounded-l-md flex-shrink-0" style="width: 0.75rem; height: 3rem;"></div>
+                
+                <!-- Cylinder Barrel -->
+                <div class="cylinder-barrel flex-1" style="min-width: 8rem; height: 2.5rem; position: relative;">
+                    <!-- Piston Rod -->
+                    <div class="piston-rod" style="height: 0.5rem; width: @(IsInOuterPosition ? "100%" : IsInInnerPosition ? "10%" : "50%");"></div>
+                    
+                    <!-- Piston -->
+                    <div class="piston" style="width: 2rem; height: 2rem; left: @(IsInOuterPosition ? "calc(100% - 2rem)" : IsInInnerPosition ? "0" : "calc(50% - 1rem)");">
+                    </div>
+                </div>
+                
+                <!-- Right End Cap -->
+                <div class="cylinder-cap rounded-r-md flex-shrink-0" style="width: 0.75rem; height: 3rem;"></div>
+            </div>
+
+            <!-- Outer Position with Label on Right -->
+            <div class="flex items-center gap-2 flex-shrink-0">
+                <div class="sensor-indicator @(IsInOuterPosition ? "active bg-info text-info" : "bg-border/30 text-border")"></div>
+                <span class="text-xs font-medium text-text/70">@Component.OutLabel</span>
+            </div>
+        </div>    
+        </div>
+    }
+
+    <!-- Control Tasks -->
+    @if (EnableControls)
+    {
+        <div class="flex flex-col gap-2 w-full">
+            <div class="flex gap-2 w-full">                
+                <AxoTaskView class="flex-[2]" Text="@Component.InLabel" Component="Component._MoveInTask" HideRestoreButton="false"></AxoTaskView>
+                <AxoTaskView class="flex-1" Text="STOP" Component="Component._StopTask" HideRestoreButton="false"></AxoTaskView>
+                <AxoTaskView class="flex-[2]" Text="@Component.OutLabel" Component="Component._MoveOutTask" HideRestoreButton="false"></AxoTaskView>
+            </div>          
+        </div>
+    }
+    }
+</div>

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.cs
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.cs
@@ -1,0 +1,141 @@
+using AXOpen.Core;
+using AXOpen.Messaging;
+using AXOpen.Messaging.Static;
+using AXSharp.Connector;
+using AXSharp.Presentation.Blazor.Controls.RenderableContent;
+using Microsoft.AspNetCore.Components;
+
+namespace AXOpen.Components.Pneumatics
+{
+    public partial class AxoCylinderView : RenderableComplexComponentBase<AxoCylinder>
+    {
+        [Parameter]
+        public bool EnableControls { get; set; } = true;
+
+        [Parameter]
+        public bool ShowAnimation { get; set; } = true;
+
+        private bool ShowAnimationPanel { get; set; } = false;
+        private bool ShowServiceView { get; set; } = false;
+
+        protected bool IsInInnerPosition => Component._InSensor.Cyclic && !Component._OutSensor.Cyclic;
+        protected bool IsInOuterPosition => Component._OutSensor.Cyclic && !Component._InSensor.Cyclic;
+        protected bool IsMoving => Component._MoveInSignal.Cyclic || Component._MoveOutSignal.Cyclic;
+
+        private bool ShowMessages { get; set; } = false;
+        private AxoMessageProvider? _messageProvider { get; set; }
+        private int _previousAlarmCount { get; set; } = 0;
+
+        private bool HasActiveMessages => _alarmCount > 0;
+
+        private int _alarmCount => _messageProvider?.Messengers.Count(a => a.State != eAxoMessengerState.Idle) ?? 0;
+
+        private int ActiveAlarmCount => _alarmCount;
+
+        private eAlarmLevel _alarmLevel
+        {
+            get
+            {
+                var messengers = _messageProvider?.Messengers;
+                if (messengers == null) return eAlarmLevel.NoAlarms;
+
+                if (messengers.Any(p => p.State > eAxoMessengerState.Idle))
+                {
+                    var seriousness = (eAxoMessageCategory)messengers.Max(p => p.Category.LastValue);
+
+                    return seriousness switch
+                    {
+                        eAxoMessageCategory.Info => eAlarmLevel.ActiveInfo,
+                        eAxoMessageCategory.Warning => eAlarmLevel.ActiveWarnings,
+                        eAxoMessageCategory.Error or eAxoMessageCategory.ProgrammingError or eAxoMessageCategory.Critical => eAlarmLevel.ActiveErrors,
+                        _ => eAlarmLevel.NoAlarms
+                    };
+                }
+                else if (messengers.Any(p => p.State > eAxoMessengerState.InactiveWaitingForAcknowledge))
+                {
+                    return eAlarmLevel.Unacknowledged;
+                }
+
+                return eAlarmLevel.NoAlarms;
+            }
+        }
+
+        private string AlarmBadgeClass =>
+            _alarmLevel switch
+            {
+                eAlarmLevel.ActiveErrors => "animate-pulse-danger badge-danger",
+                eAlarmLevel.ActiveWarnings => "badge-warning",
+                eAlarmLevel.ActiveInfo => "badge-primary",
+                eAlarmLevel.Unacknowledged => "badge-warning",
+                _ => "badge-primary"
+            };
+
+        private string AlarmBorderClass =>
+            _alarmLevel switch
+            {
+                eAlarmLevel.NoAlarms => "",
+                eAlarmLevel.Unacknowledged => "border-warning",
+                eAlarmLevel.ActiveInfo => "border-info",
+                eAlarmLevel.ActiveWarnings => "border-warning/20! shadow-glow-warning",
+                eAlarmLevel.ActiveErrors => "border-danger/20! shadow-glow-danger",
+                _ => ""
+            };
+
+        private void ToggleMessages()
+        {
+            ShowMessages = !ShowMessages;
+        }
+
+        private void ToggleAnimation()
+        {
+            ShowAnimationPanel = !ShowAnimationPanel;
+        }
+
+        private void ToggleServiceView()
+        {
+            ShowServiceView = !ShowServiceView;
+        }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            _messageProvider = AxoMessageProvider.Create(new ITwinObject[] { this.Component });
+        }
+
+        protected override void OnAfterRender(bool firstRender)
+        {
+            base.OnAfterRender(firstRender);
+
+            // Auto-collapse alarm panel when all alarms are cleared
+            if (_previousAlarmCount > 0 && _alarmCount == 0 && ShowMessages)
+            {
+                ShowMessages = false;
+                StateHasChanged();
+            }
+
+            _previousAlarmCount = _alarmCount;
+        }
+
+        public override void ConfigurePolling()
+        {
+            // Poll sensor states
+            this.StartPolling(Component._InSensor);
+            this.StartPolling(Component._OutSensor);
+
+            // Poll signal states
+            this.StartPolling(Component._MoveInSignal);
+            this.StartPolling(Component._MoveOutSignal);
+
+            // Poll task statuses
+            this.StartPolling(Component._MoveOutTask.Status);
+            this.StartPolling(Component._MoveInTask.Status);
+            this.StartPolling(Component._StopTask.Status);
+
+            // Poll messenger state
+            if (Component._Messenger != null)
+            {
+                this.StartPolling(Component._Messenger.MessengerState, 1500);
+            }
+        }
+    }
+}

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.css
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.css
@@ -1,0 +1,125 @@
+/* Scoped styles for AxoCylinderView component */
+
+/* Generic pneumatic cylinder styling */
+.pneumatic-cylinder {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    position: relative;
+}
+
+/* Cylinder barrel - the main body */
+.cylinder-barrel {
+    position: relative;
+    background: linear-gradient(to bottom, 
+        #94a3b8 0%,
+        #cbd5e1 20%,
+        #e2e8f0 50%,
+        #cbd5e1 80%,
+        #94a3b8 100%
+    );
+    border-top: 2px solid #64748b;
+    border-bottom: 2px solid #64748b;
+    box-shadow: 
+        inset 0 2px 4px rgba(0, 0, 0, 0.15),
+        inset 0 -2px 4px rgba(255, 255, 255, 0.1),
+        0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Cylinder end caps */
+.cylinder-cap {
+    background: linear-gradient(to bottom,
+        #475569,
+        #64748b,
+        #475569
+    );
+    border: 2px solid #334155;
+    box-shadow: 
+        inset 1px 1px 2px rgba(255, 255, 255, 0.1),
+        inset -1px -1px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* Piston rod - extends from cylinder */
+.piston-rod {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    background: linear-gradient(to bottom,
+        #71717a,
+        #a1a1aa,
+        #d4d4d8,
+        #a1a1aa,
+        #71717a
+    );
+    border-top: 1px solid #52525b;
+    border-bottom: 1px solid #52525b;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Piston - the moving part inside cylinder */
+.piston {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: linear-gradient(135deg,
+        #3b82f6,
+        #60a5fa,
+        #93c5fd,
+        #60a5fa,
+        #3b82f6
+    );
+    border: 2px solid #1e40af;
+    border-radius: 2px;
+    box-shadow: 
+        0 2px 6px rgba(0, 0, 0, 0.3),
+        inset 1px 1px 2px rgba(255, 255, 255, 0.3),
+        inset -1px -1px 2px rgba(0, 0, 0, 0.2);
+    transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Position sensor indicator */
+.sensor-indicator {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    transition: all 0.2s ease;
+}
+
+.sensor-indicator.active {
+    box-shadow: 0 0 8px currentColor;
+}
+
+/* Signal indicator */
+.signal-indicator {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    transition: all 0.2s ease;
+}
+
+.signal-indicator.active {
+    box-shadow: 0 0 6px currentColor;
+}
+
+/* Movement direction indicator */
+.direction-indicator {
+    position: absolute;
+    top: -2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 1.5rem;
+    font-weight: bold;
+    opacity: 0.9;
+}
+
+/* State highlighting for moving cylinder */
+.cylinder-moving .piston {
+    box-shadow: 
+        0 2px 6px rgba(0, 0, 0, 0.3),
+        inset 1px 1px 2px rgba(255, 255, 255, 0.3),
+        inset -1px -1px 2px rgba(0, 0, 0, 0.2),
+        0 0 12px rgba(59, 130, 246, 0.4);
+}

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/_Imports.razor
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/_Imports.razor
@@ -1,3 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
 @using AXSharp.Presentation.Blazor.Controls.RenderableContent
 @using Microsoft.AspNetCore.Components.Authorization
+@using AXOpen.Core
+@using AXOpen.Messaging.Static

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics/AxoCylinder/AxoCylinder.cs
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics/AxoCylinder/AxoCylinder.cs
@@ -23,15 +23,15 @@ namespace AXOpen.Components.Pneumatics
             List<KeyValuePair<ulong, AxoMessengerTextItem>> messengerTextList = new List<KeyValuePair<ulong, AxoMessengerTextItem>>
             {
                 new KeyValuePair<ulong, AxoMessengerTextItem>(0, new AxoMessengerTextItem("  ", "  ")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(1, new AxoMessengerTextItem("Movement to work position did not succeed.", "Check the cyclinder that it is free to move, air pressure input and extremity sensor.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(2, new AxoMessengerTextItem("Movement to home position did not succeed.", "Check the cyclinder that it is free to move, air pressure input and extremity sensor.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(3, new AxoMessengerTextItem("Home and work position sensors are both active at the same time.", "Check the positions of the sensors.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(4, new AxoMessengerTextItem("Movement to work position is temporarily suspended.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(5, new AxoMessengerTextItem("Movement to home position is temporarily suspended.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(6, new AxoMessengerTextItem("Movement to work position is aborted.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(7, new AxoMessengerTextItem("Movement to home position is aborted.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(8, new AxoMessengerTextItem("Movement to home position overshot the extremity sensor.", "Check the sensor position.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(9, new AxoMessengerTextItem("Movement to work position overshot the extremity sensor.", "Check the sensor position.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(1, new AxoMessengerTextItem($"Movement position `{this.OutLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(2, new AxoMessengerTextItem($"Movement  position `{this.InLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(3, new AxoMessengerTextItem("Both extremity sensors are active at the same time.", "Check the positions of the sensors.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(4, new AxoMessengerTextItem($"Movement to position `{this.OutLabel}` is temporarily suspended.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(5, new AxoMessengerTextItem($"Movement to position `{this.InLabel}` is temporarily suspended.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(6, new AxoMessengerTextItem($"Movement position `{this.OutLabel}` is aborted.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(7, new AxoMessengerTextItem($"Movement position `{this.InLabel}` is aborted.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(8, new AxoMessengerTextItem($"Movement position `{this.InLabel}` overshot the extremity sensor.", "Check the sensor position.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(9, new AxoMessengerTextItem($"Movement  position `{this.OutLabel}` overshot the extremity sensor.", "Check the sensor position.")),
             };
 
             _Messenger.DotNetMessengerTextList = messengerTextList;


### PR DESCRIPTION
- Updated CylinderTests to replace MoveToHome and MoveToWork with MoveIn and MoveOut methods, reflecting the new functionality.
- Modified assertions in tests to align with the new movement methods and signals.
- Introduced AxoCylinderCommandView and AxoCylinderStatusView components for enhanced UI control and status display.
- Created AxoCylinderView component to encapsulate cylinder behavior and UI representation.
- Added CSS styles for the AxoCylinderView to improve visual representation of the cylinder and its components.
- Updated AxoCylinder class to provide more descriptive messages for movement failures and sensor states.

This pull request makes significant naming and documentation updates to the pneumatic cylinder component, standardizing the terminology from "Home/Work" to "In/Out" throughout the codebase, documentation, and workspace configuration. These changes clarify the meaning of the positions and signals, making the codebase more consistent and easier to understand.

The most important changes are:

**API and Internal Variable Renaming:**
* Renamed all public methods, internal variables, and signals in `AxoCylinder` from "Home/Work" to "In/Out" (e.g., `MoveToHome` → `MoveIn`, `MoveToWork` → `MoveOut`, `_HomeSensor` → `_InSensor`, `_WorkSensor` → `_OutSensor`, etc.) to standardize terminology. [[1]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fR8-R21) [[2]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL26-R74) [[3]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL80-R89) [[4]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL99-R153) [[5]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL160-R180) [[6]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL187-R191) [[7]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL200-R205) [[8]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL212-R222) [[9]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL231-R236) [[10]](diffhunk://#diff-e4c6112cb5d7a9b50ab004b4c9bd758e5fda2d07b125e3a927b1473d888f8f0fL243-R281)

**Documentation Updates:**
* Updated all documentation and code examples to use the new "In/Out" terminology, including method names and descriptions in `AXOCYLINDER.md` and `DocumentationContext.st`. [[1]](diffhunk://#diff-0b1faa47b970ca024581f689f0fd8a9114921fcefc016e67af6589570d8a6a10L22-R25) [[2]](diffhunk://#diff-0b1faa47b970ca024581f689f0fd8a9114921fcefc016e67af6589570d8a6a10L36-R44) [[3]](diffhunk://#diff-6ad97102d9e45b4a7ac927eb33c716f5672ac0bbcffcf2c70b74731993ea262cL37-R43)

**Workspace Configuration:**
* Updated the workspace configuration file to reflect the new folder naming, swapping the names of `app` and `ctrl` for clarity.

These changes improve clarity and consistency across the component's API, internal logic, and documentation.
