### PR TITLE
fix tests in AXOpen.Data.Tests.AxoDataExchangeTests.ImportComplexTest

### DIFF
--- a/cake/ApaxCmd.cs
+++ b/cake/ApaxCmd.cs
@@ -583,9 +583,9 @@ public static class ApaxCmd
         {
             if (root.Children.TryGetValue(new YamlScalarNode("catalogs"), out var catalogNode))
             {
-                var apaxArguments = "install --catalog";
+                var apaxArguments = "install --catalog --strict";
                 var folder = Path.GetDirectoryName(yamlFilePath);
-                context.Log.Information($"apax install --catalog started in '{folder}'");
+                context.Log.Information($"apax install --catalog --strict started in '{folder}'");
                 context.ProcessRunner.Start(Helpers.GetApaxCommand(), new ProcessSettings()
                 {
                     Arguments = apaxArguments,

--- a/src/abstractions/app/apax.yml
+++ b/src/abstractions/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/abstractions/ctrl/apax.yml
+++ b/src/abstractions/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -27,7 +27,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -29,7 +29,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -21,7 +21,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -29,7 +29,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.abb.robotics/app/apax.yml
+++ b/src/components.abb.robotics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.abb.robotics/ctrl/apax.yml
+++ b/src/components.abb.robotics/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.abstractions/app/apax.yml
+++ b/src/components.abstractions/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.abstractions/ctrl/apax.yml
+++ b/src/components.abstractions/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.balluff.identification/app/apax.yml
+++ b/src/components.balluff.identification/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.balluff.identification/ctrl/apax.yml
+++ b/src/components.balluff.identification/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.cognex.vision/app/apax.yml
+++ b/src/components.cognex.vision/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.cognex.vision/ctrl/apax.yml
+++ b/src/components.cognex.vision/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.desoutter.tightening/app/apax.yml
+++ b/src/components.desoutter.tightening/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.desoutter.tightening/ctrl/apax.yml
+++ b/src/components.desoutter.tightening/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.drives/app/apax.yml
+++ b/src/components.drives/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.drives/ctrl/apax.yml
+++ b/src/components.drives/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.dukane.welders/app/apax.yml
+++ b/src/components.dukane.welders/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.dukane.welders/ctrl/apax.yml
+++ b/src/components.dukane.welders/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.elements/app/apax.yml
+++ b/src/components.elements/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.elements/ctrl/apax.yml
+++ b/src/components.elements/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.festo.drives/app/apax.yml
+++ b/src/components.festo.drives/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.festo.drives/ctrl/apax.yml
+++ b/src/components.festo.drives/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.keyence.vision/app/apax.yml
+++ b/src/components.keyence.vision/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.keyence.vision/ctrl/apax.yml
+++ b/src/components.keyence.vision/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.kuka.robotics/app/apax.yml
+++ b/src/components.kuka.robotics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.kuka.robotics/ctrl/apax.yml
+++ b/src/components.kuka.robotics/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.mitsubishi.robotics/app/apax.yml
+++ b/src/components.mitsubishi.robotics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.mitsubishi.robotics/ctrl/apax.yml
+++ b/src/components.mitsubishi.robotics/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.pneumatics/app/apax.yml
+++ b/src/components.pneumatics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.pneumatics/ctrl/apax.yml
+++ b/src/components.pneumatics/ctrl/apax.yml
@@ -29,7 +29,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.drives/app/apax.yml
+++ b/src/components.rexroth.drives/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.drives/ctrl/apax.yml
+++ b/src/components.rexroth.drives/ctrl/apax.yml
@@ -12,7 +12,7 @@ devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
   "@inxton/axopen.components.drives": '0.0.0-dev.0'
-  "@ax/simatic-1500-distributedio": ^10.0.1
+  "@ax/simatic-1500-distributedio": 10.0.1
 installStrategy: strict
 apaxVersion: 3.5.0
 scripts:
@@ -25,7 +25,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.press/app/apax.yml
+++ b/src/components.rexroth.press/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.press/ctrl/apax.yml
+++ b/src/components.rexroth.press/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.tightening/app/apax.yml
+++ b/src/components.rexroth.tightening/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.rexroth.tightening/ctrl/apax.yml
+++ b/src/components.rexroth.tightening/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.robotics/app/apax.yml
+++ b/src/components.robotics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.robotics/ctrl/apax.yml
+++ b/src/components.robotics/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.siem.communication/app/apax.yml
+++ b/src/components.siem.communication/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.siem.communication/ctrl/apax.yml
+++ b/src/components.siem.communication/ctrl/apax.yml
@@ -12,7 +12,7 @@ devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:
   "@inxton/axopen.io": '0.0.0-dev.0'
-  "@ax/simatic-pointtopoint": ^4.0.6
+  "@ax/simatic-pointtopoint": 4.0.6
 installStrategy: strict
 apaxVersion: 3.5.0
 scripts:
@@ -25,7 +25,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.siem.identification/app/apax.yml
+++ b/src/components.siem.identification/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.siem.identification/ctrl/apax.yml
+++ b/src/components.siem.identification/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.ur.robotics/app/apax.yml
+++ b/src/components.ur.robotics/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.ur.robotics/ctrl/apax.yml
+++ b/src/components.ur.robotics/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.zebra.vision/app/apax.yml
+++ b/src/components.zebra.vision/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/components.zebra.vision/ctrl/apax.yml
+++ b/src/components.zebra.vision/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/core/app/apax.yml
+++ b/src/core/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/core/ctrl/apax.yml
+++ b/src/core/ctrl/apax.yml
@@ -26,7 +26,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/data/app/apax.yml
+++ b/src/data/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/data/ctrl/apax.yml
+++ b/src/data/ctrl/apax.yml
@@ -25,7 +25,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/data/tests/AXOpen.Data.Exporters.ExcelTests/Data/ExcelTests.cs
+++ b/src/data/tests/AXOpen.Data.Exporters.ExcelTests/Data/ExcelTests.cs
@@ -83,178 +83,327 @@ namespace AXOpen.Data.Tests
         [Fact()]
         public async void ExportTest()
         {
-            var parent = NSubstitute.Substitute.For<ITwinObject>();
-            parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
-            var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
-            sut.SetRepository(repo);
-
-            repo.Create("hey remote create", new Pocos.axosimple.SharedProductionData() { ComesFrom = 48, GoesTo = 68 });
-
-            Assert.Equal(1, repo.Count);
-
-            var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
-
-            // export
-            sut.ExportData(zipFile, exportFileType: "Excel");
-
-            Assert.True(File.Exists(zipFile));
-
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+            while (attempt < maxRetries)
             {
-                Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r", GetTextFromExcel(zip.Entries[0].Open(), "b"));
+                attempt++;
+                try
+                {
+                    var parent = NSubstitute.Substitute.For<ITwinObject>();
+                    parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+
+                    var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
+                    var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
+                    sut.SetRepository(repo);
+
+                    repo.Create("hey remote create", new Pocos.axosimple.SharedProductionData() { ComesFrom = 48, GoesTo = 68 });
+
+                    Assert.Equal(1, repo.Count);
+
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
+
+                    // export
+                    sut.ExportData(zipFile, exportFileType: "Excel");
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+                    {
+                        Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r", GetTextFromExcel(zip.Entries[0].Open(), "b"));
+                    }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ExportComplexTest()
         {
-            var parent = NSubstitute.Substitute.For<ITwinObject>();
-            parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
-            var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
-            sut.SetRepository(repo);
-
-            repo.Create("first", new Pocos.axosimple.SharedProductionData() { ComesFrom = 10, GoesTo = 11 });
-            repo.Create("second", new Pocos.axosimple.SharedProductionData() { ComesFrom = 20, GoesTo = 21 });
-
-            Assert.Equal(2, repo.Count);
-
-            var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
-
-            var dictionary = new Dictionary<string, ExportData>
+            while (attempt < maxRetries)
             {
-                { "axosimple.SharedProductionData", new ExportData(true, new Dictionary<string, bool>
+                attempt++;
+                try
                 {
-                    { "_data.ComesFrom", false },
-                }) },
-            };
+                    var parent = NSubstitute.Substitute.For<ITwinObject>();
+                    parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
 
-            // export
-            sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "Excel");
+                    var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
+                    var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
+                    sut.SetRepository(repo);
 
-            Assert.True(File.Exists(zipFile));
+                    repo.Create("first", new Pocos.axosimple.SharedProductionData() { ComesFrom = 10, GoesTo = 11 });
+                    repo.Create("second", new Pocos.axosimple.SharedProductionData() { ComesFrom = 20, GoesTo = 21 });
 
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
-            {
-                Assert.Equal("_data._EntityId;_data.GoesTo;\r_data._EntityId;_data.GoesTo;\rsecond;21;\r", GetTextFromExcel(zip.Entries[0].Open(), "b"));
+                    Assert.Equal(2, repo.Count);
+
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
+
+                    var dictionary = new Dictionary<string, ExportData>
+                    {
+                        { "axosimple.SharedProductionData", new ExportData(true, new Dictionary<string, bool>
+                        {
+                            { "_data.ComesFrom", false },
+                        }) },
+                    };
+
+                    // export
+                    sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "Excel");
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+                    {
+                        Assert.Equal("_data._EntityId;_data.GoesTo;\r_data._EntityId;_data.GoesTo;\rsecond;21;\r", GetTextFromExcel(zip.Entries[0].Open(), "b"));
+                    }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ImportTest()
         {
-            var parent = NSubstitute.Substitute.For<ITwinObject>();
-            parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
-            var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
-            sut.SetRepository(repo);
+            while (attempt < maxRetries)
+            {
+                attempt++;
+                try
+                {
+                    var parent = NSubstitute.Substitute.For<ITwinObject>();
+                    parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
 
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
-            var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
+                    var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
+                    var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
+                    sut.SetRepository(repo);
 
-            Directory.CreateDirectory(tempDirectory);
+                    var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
 
-            File.Delete(zipFile);
+                    Directory.CreateDirectory(tempDirectory);
 
-            CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r" } });
+                    File.Delete(zipFile);
 
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+                    CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r" } });
 
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
 
-            var shared = sut.DataRepository.Read("hey remote create");
-            Assert.Equal(48, shared.ComesFrom);
-            Assert.Equal(68, shared.GoesTo);
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
 
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+                    var shared = sut.DataRepository.Read("hey remote create");
+                    Assert.Equal(48, shared.ComesFrom);
+                    Assert.Equal(68, shared.GoesTo);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
+            }
+
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ImportComplexTest()
         {
- 
-            var parent = NSubstitute.Substitute.For<ITwinObject>();
-            parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
-            var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
-            sut.SetRepository(repo);
+            while (attempt < maxRetries)
+            {
+                attempt++;
+                try
+                {
+                    var parent = NSubstitute.Substitute.For<ITwinObject>();
+                    parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
 
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
-            var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
+                    var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
+                    var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
+                    sut.SetRepository(repo);
 
-            Directory.CreateDirectory(tempDirectory);
+                    var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
 
-            File.Delete(zipFile);
+                    Directory.CreateDirectory(tempDirectory);
 
-            CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.GoesTo;\r_data._EntityId;_data.GoesTo;\rfirst;11;\r" } });
+                    File.Delete(zipFile);
 
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+                    CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.GoesTo;\r_data._EntityId;_data.GoesTo;\rfirst;11;\r" } });
 
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
 
-            var shared = sut.DataRepository.Read("first");
-            Assert.Equal(0, shared.ComesFrom);
-            Assert.Equal(11, shared.GoesTo);
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
 
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+                    var shared = sut.DataRepository.Read("first");
+                    Assert.Equal(0, shared.ComesFrom);
+                    Assert.Equal(11, shared.GoesTo);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
+            }
+
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ImportTestWithExtraElements()
         {
-            var parent = NSubstitute.Substitute.For<ITwinObject>();
-            parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
-            var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
-            sut.SetRepository(repo);
+            while (attempt < maxRetries)
+            {
+                attempt++;
+                try
+                {
+                    var parent = NSubstitute.Substitute.For<ITwinObject>();
+                    parent.GetConnector().Returns(AXSharp.Connector.ConnectorAdapterBuilder.Build().CreateDummy().GetConnector(null));
 
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "importDataPrepare");
-            var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "ImportData.zip");
+                    var sut = new axosimple.SharedProductionDataManager(parent, "a", "b");
+                    var repo = new InMemoryRepository<Pocos.axosimple.SharedProductionData>();
+                    sut.SetRepository(repo);
 
-            Directory.CreateDirectory(tempDirectory);
+                    var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "importDataPrepare");
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "ImportData.zip");
 
-            File.Delete(zipFile);
+                    Directory.CreateDirectory(tempDirectory);
 
-            CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\rhey remote create;48;68;130;\r" } });
+                    File.Delete(zipFile);
 
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+                    CreateExcelFromText(Path.Combine(tempDirectory, "Export.xlsx"), new Dictionary<string, string> { { "b", "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\rhey remote create;48;68;130;\r" } });
 
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
 
-            var shared = sut.DataRepository.Read("hey remote create");
-            Assert.Equal(48, shared.ComesFrom);
-            Assert.Equal(68, shared.GoesTo);
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "Excel");
 
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+                    var shared = sut.DataRepository.Read("hey remote create");
+                    Assert.Equal(48, shared.ComesFrom);
+                    Assert.Equal(68, shared.GoesTo);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
+            }
+
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
     }
 }

--- a/src/data/tests/AXOpen.Data.Tests_L1/Tests_L1/DataExchange/AxoDataExchangeTests.cs
+++ b/src/data/tests/AXOpen.Data.Tests_L1/Tests_L1/DataExchange/AxoDataExchangeTests.cs
@@ -579,92 +579,152 @@ namespace AXOpen.Data.Tests
         [Fact()]
         public async void ExportTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.DataExchange.SharedHeaderManager;
-            var repo = new InMemoryRepository<SharedEntityHeader>();
-            sut.SetRepository(repo);
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            repo.Create("hey remote create", new SharedEntityHeader() { ComesFrom = 48, GoesTo = 68 });
-
-            Assert.Equal(1, repo.Count);
-
-            var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
-
-            // export
-            sut.ExportData(zipFile);
-
-            Assert.True(File.Exists(zipFile));
-
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+            while (attempt < maxRetries)
             {
-                foreach (ZipArchiveEntry entry in zip.Entries)
+                attempt++;
+                try
                 {
-                    TextReader tr = new StreamReader(entry.Open());
-                    string text = tr.ReadToEnd();
-                    switch (entry.Name)
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.DataExchange.SharedHeaderManager;
+                    var repo = new InMemoryRepository<SharedEntityHeader>();
+                    sut.SetRepository(repo);
+
+                    repo.Create("hey remote create", new SharedEntityHeader() { ComesFrom = 48, GoesTo = 68 });
+
+                    Assert.Equal(1, repo.Count);
+
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
+
+                    // export
+                    sut.ExportData(zipFile);
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
                     {
-                        case "axosimple.SharedProductionDataManager.csv":
-                            Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r", text);
-                            break;
+                        foreach (ZipArchiveEntry entry in zip.Entries)
+                        {
+                            TextReader tr = new StreamReader(entry.Open());
+                            string text = tr.ReadToEnd();
+                            switch (entry.Name)
+                            {
+                                case "axosimple.SharedProductionDataManager.csv":
+                                    Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;48;68;\r", text);
+                                    break;
+                            }
+                        }
                     }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
                 }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ExportComplexTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.DataExchange.SharedHeaderManager;
-            var repo = new InMemoryRepository<SharedEntityHeader>();
-            sut.SetRepository(repo);
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            repo.Create("first", new SharedEntityHeader() { ComesFrom = 10, GoesTo = 11 });
-            repo.Create("second", new SharedEntityHeader() { ComesFrom = 20, GoesTo = 21 });
-
-            Assert.Equal(2, repo.Count);
-
-            var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
-
-            var dictionary = new Dictionary<string, ExportData>
+            while (attempt < maxRetries)
             {
-                { "Tests_L1.SharedEntityHeader", new ExportData(true, new Dictionary<string, bool>
+                attempt++;
+                try
                 {
-                    { "_data.ComesFrom", false },
-                    { "_data.Name", false },
-                }) },
-            };
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.DataExchange.SharedHeaderManager;
+                    var repo = new InMemoryRepository<SharedEntityHeader>();
+                    sut.SetRepository(repo);
 
-            // export
-            sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "CSV", '*');
+                    repo.Create("first", new SharedEntityHeader() { ComesFrom = 10, GoesTo = 11 });
+                    repo.Create("second", new SharedEntityHeader() { ComesFrom = 20, GoesTo = 21 });
 
-            Assert.True(File.Exists(zipFile));
+                    Assert.Equal(2, repo.Count);
 
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
-            {
-                foreach (ZipArchiveEntry entry in zip.Entries)
-                {
-                    TextReader tr = new StreamReader(entry.Open());
-                    string text = tr.ReadToEnd();
-                    switch (entry.Name)
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ExportDataTest", "ExportData.zip");
+
+                    var dictionary = new Dictionary<string, ExportData>
                     {
-                        case "SharedHeaderManager.csv":
-                            Assert.Equal("_data._EntityId*_data.GoesTo*\r_data._EntityId*_data.GoesTo*\rsecond*21*\r", text);
-                            break;
-                        default:
-                            Assert.Fail("More entries tahn expected!");
-                            break;
+                        { "Tests_L1.SharedEntityHeader", new ExportData(true, new Dictionary<string, bool>
+                        {
+                            { "_data.ComesFrom", false },
+                            { "_data.Name", false },
+                        }) },
+                    };
+
+                    // export
+                    sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "CSV", '*');
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+                    {
+                        foreach (ZipArchiveEntry entry in zip.Entries)
+                        {
+                            TextReader tr = new StreamReader(entry.Open());
+                            string text = tr.ReadToEnd();
+                            switch (entry.Name)
+                            {
+                                case "SharedHeaderManager.csv":
+                                    Assert.Equal("_data._EntityId*_data.GoesTo*\r_data._EntityId*_data.GoesTo*\rsecond*21*\r", text);
+                                    break;
+                                default:
+                                    Assert.Fail("More entries tahn expected!");
+                                    break;
+                            }
+                        }
                     }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
                 }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
@@ -741,82 +801,141 @@ namespace AXOpen.Data.Tests
         [Fact()]
         public async void ImportComplexTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.DataExchange.SharedHeaderManager;
-            var repo = new InMemoryRepository<SharedEntityHeader>();
-            sut.SetRepository(repo);
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
-            var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
-
-            Directory.CreateDirectory(tempDirectory);
-
-            File.Delete(zipFile);
-
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, "SharedHeaderManager.csv")))
+            while (attempt < maxRetries)
             {
-                sw.Write(
-                    "_data._EntityId*_data.GoesTo*\r" +
-                    "_data._EntityId*_data.GoesTo*\r" +
-                    "first*11*\r"
-                    );
+                attempt++;
+                try
+                {
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.DataExchange.SharedHeaderManager;
+                    var repo = new InMemoryRepository<SharedEntityHeader>();
+                    sut.SetRepository(repo);
+
+                    var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTest", "importDataPrepare");
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTest", "ImportData.zip");
+
+                    Directory.CreateDirectory(tempDirectory);
+
+                    File.Delete(zipFile);
+
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, "SharedHeaderManager.csv")))
+                    {
+                        sw.Write(
+                            "_data._EntityId*_data.GoesTo*\r" +
+                            "_data._EntityId*_data.GoesTo*\r" +
+                            "first*11*\r"
+                            );
+                    }
+
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), separator: '*');
+
+                    var shared = sut.DataRepository.Read("first");
+                    Assert.Equal(0, shared.ComesFrom);
+                    Assert.Equal(11, shared.GoesTo);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
 
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
-
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), separator: '*');
-
-            var shared = sut.DataRepository.Read("first");
-            Assert.Equal(0, shared.ComesFrom);
-            Assert.Equal(11, shared.GoesTo);
-
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ImportTestWithExtraElements()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.DataExchange.SharedHeaderManager;
-            var repo = new InMemoryRepository<SharedEntityHeader>();
-            sut.SetRepository(repo);
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-
-            var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "importDataPrepare");
-            var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "ImportData.zip");
-
-            Directory.CreateDirectory(tempDirectory);
-
-            File.Delete(zipFile);
-
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, "SharedHeaderManager.csv")))
+            while (attempt < maxRetries)
             {
-                sw.Write(
-                    "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r" +
-                    "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r" +
-                    "hey remote create;48;68;130;\r"
-                    );
+                attempt++;
+                try
+                {
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.DataExchange.SharedHeaderManager;
+                    var repo = new InMemoryRepository<SharedEntityHeader>();
+                    sut.SetRepository(repo);
+
+                    var tempDirectory = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "importDataPrepare");
+                    var zipFile = Path.Combine(Path.GetTempPath(), "ImportDataTestWithExtraElements", "ImportData.zip");
+
+                    Directory.CreateDirectory(tempDirectory);
+
+                    File.Delete(zipFile);
+
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, "SharedHeaderManager.csv")))
+                    {
+                        sw.Write(
+                            "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r" +
+                            "_data._EntityId;_data.ComesFrom;_data.GoesTo;_data.ExtraElement;\r" +
+                            "hey remote create;48;68;130;\r"
+                            );
+                    }
+
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()));
+
+                    var shared = sut.DataRepository.Read("hey remote create");
+                    Assert.Equal(48, shared.ComesFrom);
+                    Assert.Equal(68, shared.GoesTo);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
 
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
-
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()));
-
-            var shared = sut.DataRepository.Read("hey remote create");
-            Assert.Equal(48, shared.ComesFrom);
-            Assert.Equal(68, shared.GoesTo);
-
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]

--- a/src/data/tests/AXOpen.Data.Tests_L1/Tests_L1/DataExchangeFragments/AxoDataFragmentExchange.cs
+++ b/src/data/tests/AXOpen.Data.Tests_L1/Tests_L1/DataExchangeFragments/AxoDataFragmentExchange.cs
@@ -456,218 +456,338 @@ namespace AXOpen.Data.Fragments.Tests
         [Fact()]
         public async void ExportTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.Fragments.DataManager;
-            var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
-            s.Station.SetRepository(new InMemoryRepository<StationData>());
-
-            await sut.EntityHeader.Set.ComesFrom.SetAsync(10);
-            await sut.EntityHeader.Set.GoesTo.SetAsync(20);
-            await sut.Station.Set.CounterDelay.SetAsync(20);
-            await sut.RemoteCreate("hey remote create");
-
-            var shared = sut.EntityHeader.DataRepository.Read("hey remote create");
-            Assert.Equal(10, shared.ComesFrom);
-            Assert.Equal(20, shared.GoesTo);
-
-            var manip = sut.Station.DataRepository.Read("hey remote create");
-            Assert.Equal(20ul, manip.CounterDelay);
-
-            var zipFile = Path.Combine(TempPath, "ExportDataFragmentTest", "ExportDataFragment.zip");
-
-            // export
-            sut.ExportData(zipFile);
-
-            Assert.True(File.Exists(zipFile));
-
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+            while (attempt < maxRetries)
             {
-                foreach (ZipArchiveEntry entry in zip.Entries)
+                attempt++;
+                try
                 {
-                    TextReader tr = new StreamReader(entry.Open());
-                    string text = tr.ReadToEnd();
-                    switch (entry.Name)
-                    {
-                        case "axosimple.SharedProductionDataManager.csv":
-                            Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;10;20;\r", text);
-                            break;
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.Fragments.DataManager;
+                    var s = sut.CreateDataFragments<FragmentProcessDataManager>();
 
-                        case "examples.PneumaticManipulator.FragmentProcessDataManger.csv":
-                            Assert.Equal("_data._EntityId;_data.CounterDelay;\r_data._EntityId;_data.CounterDelay;\rhey remote create;20;\r", text);
-                            break;
+                    s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
+                    s.Station.SetRepository(new InMemoryRepository<StationData>());
+
+                    await sut.EntityHeader.Set.ComesFrom.SetAsync(10);
+                    await sut.EntityHeader.Set.GoesTo.SetAsync(20);
+                    await sut.Station.Set.CounterDelay.SetAsync(20);
+                    await sut.RemoteCreate("hey remote create");
+
+                    var shared = sut.EntityHeader.DataRepository.Read("hey remote create");
+                    Assert.Equal(10, shared.ComesFrom);
+                    Assert.Equal(20, shared.GoesTo);
+
+                    var manip = sut.Station.DataRepository.Read("hey remote create");
+                    Assert.Equal(20ul, manip.CounterDelay);
+
+                    var zipFile = Path.Combine(TempPath, "ExportDataFragmentTest", "ExportDataFragment.zip");
+
+                    // export
+                    sut.ExportData(zipFile);
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+                    {
+                        foreach (ZipArchiveEntry entry in zip.Entries)
+                        {
+                            TextReader tr = new StreamReader(entry.Open());
+                            string text = tr.ReadToEnd();
+                            switch (entry.Name)
+                            {
+                                case "axosimple.SharedProductionDataManager.csv":
+                                    Assert.Equal("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;10;20;\r", text);
+                                    break;
+
+                                case "examples.PneumaticManipulator.FragmentProcessDataManger.csv":
+                                    Assert.Equal("_data._EntityId;_data.CounterDelay;\r_data._EntityId;_data.CounterDelay;\rhey remote create;20;\r", text);
+                                    break;
+                            }
+                        }
                     }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
                 }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ExportComplexTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.Fragments.DataManager;
-            var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
-            s.Station.SetRepository(new InMemoryRepository<StationData>());
-
-            await sut.EntityHeader.Set.ComesFrom.SetAsync(10);
-            await sut.EntityHeader.Set.GoesTo.SetAsync(11);
-            await sut.Station.Set.CounterDelay.SetAsync(12);
-            await sut.RemoteCreate("first");
-
-            await sut.EntityHeader.Set.ComesFrom.SetAsync(20);
-            await sut.EntityHeader.Set.GoesTo.SetAsync(21);
-            await sut.Station.Set.CounterDelay.SetAsync(22);
-            await sut.RemoteCreate("second");
-
-            var shared = sut.EntityHeader.DataRepository.Read("first");
-            Assert.Equal(10, shared.ComesFrom);
-            Assert.Equal(11, shared.GoesTo);
-
-            var manip = sut.Station.DataRepository.Read("first");
-            Assert.Equal(12ul, manip.CounterDelay);
-
-            shared = sut.EntityHeader.DataRepository.Read("second");
-            Assert.Equal(20, shared.ComesFrom);
-            Assert.Equal(21, shared.GoesTo);
-
-            manip = sut.Station.DataRepository.Read("second");
-            Assert.Equal(22ul, manip.CounterDelay);
-
-            var zipFile = Path.Combine(TempPath, "ExportDataFragmentTest", "ExportDataFragment.zip");
-
-            var dictionary = new Dictionary<string, ExportData>
+            while (attempt < maxRetries)
             {
-                { "Tests_L1.SharedEntityHeader", new ExportData(false, new Dictionary<string, bool>()) },
-                { "Tests_L1.StationData", new ExportData(true, new Dictionary<string, bool>
+                attempt++;
+                try
                 {
-                    { "_data.CounterDelay", false },
-                }) }
-            };
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.Fragments.DataManager;
+                    var s = sut.CreateDataFragments<FragmentProcessDataManager>();
 
-            // export
-            sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "TXT", '*');
+                    s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
+                    s.Station.SetRepository(new InMemoryRepository<StationData>());
 
-            Assert.True(File.Exists(zipFile));
+                    await sut.EntityHeader.Set.ComesFrom.SetAsync(10);
+                    await sut.EntityHeader.Set.GoesTo.SetAsync(11);
+                    await sut.Station.Set.CounterDelay.SetAsync(12);
+                    await sut.RemoteCreate("first");
 
-            using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
-            {
-                foreach (ZipArchiveEntry entry in zip.Entries)
-                {
-                    TextReader tr = new StreamReader(entry.Open());
-                    string text = tr.ReadToEnd();
-                    switch (entry.Name)
+                    await sut.EntityHeader.Set.ComesFrom.SetAsync(20);
+                    await sut.EntityHeader.Set.GoesTo.SetAsync(21);
+                    await sut.Station.Set.CounterDelay.SetAsync(22);
+                    await sut.RemoteCreate("second");
+
+                    var shared = sut.EntityHeader.DataRepository.Read("first");
+                    Assert.Equal(10, shared.ComesFrom);
+                    Assert.Equal(11, shared.GoesTo);
+
+                    var manip = sut.Station.DataRepository.Read("first");
+                    Assert.Equal(12ul, manip.CounterDelay);
+
+                    shared = sut.EntityHeader.DataRepository.Read("second");
+                    Assert.Equal(20, shared.ComesFrom);
+                    Assert.Equal(21, shared.GoesTo);
+
+                    manip = sut.Station.DataRepository.Read("second");
+                    Assert.Equal(22ul, manip.CounterDelay);
+
+                    var zipFile = Path.Combine(TempPath, "ExportDataFragmentTest", "ExportDataFragment.zip");
+
+                    var dictionary = new Dictionary<string, ExportData>
                     {
-                        case "Station.txt":
-                            Assert.Equal("_data._EntityId*\r_data._EntityId*\rsecond*\r", text);
-                            break;
+                        { "Tests_L1.SharedEntityHeader", new ExportData(false, new Dictionary<string, bool>()) },
+                        { "Tests_L1.StationData", new ExportData(true, new Dictionary<string, bool>
+                        {
+                            { "_data.CounterDelay", false },
+                        }) }
+                    };
 
-                        default:
-                            Assert.Fail("More entries than expected!");
-                            break;
+                    // export
+                    sut.ExportData(zipFile, dictionary, eExportMode.Exact, 2, 2, "TXT", '*');
+
+                    Assert.True(File.Exists(zipFile));
+
+                    using (ZipArchive zip = ZipFile.Open(zipFile, ZipArchiveMode.Read))
+                    {
+                        foreach (ZipArchiveEntry entry in zip.Entries)
+                        {
+                            TextReader tr = new StreamReader(entry.Open());
+                            string text = tr.ReadToEnd();
+                            switch (entry.Name)
+                            {
+                                case "Station.txt":
+                                    Assert.Equal("_data._EntityId*\r_data._EntityId*\rsecond*\r", text);
+                                    break;
+
+                                default:
+                                    Assert.Fail("More entries than expected!");
+                                    break;
+                            }
+                        }
                     }
+
+                    // clear
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
                 }
             }
 
-            // clear
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
+            // If we get here, all retries failed
+            if (lastException != null)
+            {
+                throw lastException;
+            }
         }
 
         [Fact()]
         public async void ImportTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.Fragments.DataManager;
-            var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
-            s.Station.SetRepository(new InMemoryRepository<StationData>());
-
-            var tempDirectory = Path.Combine(TempPath, "ImportDataFragmentTest", "importDataFragmentPrepare");
-            var zipFile = Path.Combine(TempPath, "ImportDataFragmentTest", "ImportDataFragment.zip");
-
-            Directory.CreateDirectory(tempDirectory);
-
-            File.Delete(zipFile);
-
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, tempDirectory, sut.EntityHeader.GetSymbolTail() + ".csv")))
+            while (attempt < maxRetries)
             {
-                sw.Write("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;10;20;\r");
+                attempt++;
+                try
+                {
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.Fragments.DataManager;
+                    var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+
+                    s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
+                    s.Station.SetRepository(new InMemoryRepository<StationData>());
+
+                    var tempDirectory = Path.Combine(TempPath, "ImportDataFragmentTest", "importDataFragmentPrepare");
+                    var zipFile = Path.Combine(TempPath, "ImportDataFragmentTest", "ImportDataFragment.zip");
+
+                    Directory.CreateDirectory(tempDirectory);
+
+                    File.Delete(zipFile);
+
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, tempDirectory, sut.EntityHeader.GetSymbolTail() + ".csv")))
+                    {
+                        sw.Write("_data._EntityId;_data.ComesFrom;_data.GoesTo;\r_data._EntityId;_data.ComesFrom;_data.GoesTo;\rhey remote create;10;20;\r");
+                    }
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, tempDirectory, sut.Station.GetSymbolTail() + ".csv")))
+                    {
+                        sw.Write("_data._EntityId;_data.CounterDelay;\r_data._EntityId;_data.CounterDelay;\rhey remote create;20;\r");
+                    }
+
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()));
+
+                    var shared = sut.EntityHeader.DataRepository.Read("hey remote create");
+                    Assert.Equal(10, shared.ComesFrom);
+                    Assert.Equal(20, shared.GoesTo);
+
+                    var manip = sut.Station.DataRepository.Read("hey remote create");
+                    Assert.Equal(20ul, manip.CounterDelay);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, tempDirectory, sut.Station.GetSymbolTail() + ".csv")))
+
+            // If we get here, all retries failed
+            if (lastException != null)
             {
-                sw.Write("_data._EntityId;_data.CounterDelay;\r_data._EntityId;_data.CounterDelay;\rhey remote create;20;\r");
+                throw lastException;
             }
-
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
-
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()));
-
-            var shared = sut.EntityHeader.DataRepository.Read("hey remote create");
-            Assert.Equal(10, shared.ComesFrom);
-            Assert.Equal(20, shared.GoesTo);
-
-            var manip = sut.Station.DataRepository.Read("hey remote create");
-            Assert.Equal(20ul, manip.CounterDelay);
-
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
         }
 
         [Fact()]
         public async void ImportComplexTest()
         {
-            var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
-            var sut = connector.Fragments.DataManager;
-            var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+            int maxRetries = 3;
+            int attempt = 0;
+            Exception lastException = null;
 
-            s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
-            s.Station.SetRepository(new InMemoryRepository<StationData>());
-
-            var tempDirectory = Path.Combine(TempPath, "ImportDataFragmentTest", "importDataFragmentPrepare");
-            var zipFile = Path.Combine(TempPath, "ImportDataFragmentTest", "ImportDataFragment.zip");
-
-            Directory.CreateDirectory(tempDirectory);
-
-            File.Delete(zipFile);
-
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, sut.EntityHeader.GetSymbolTail() + ".txt")))
+            while (attempt < maxRetries)
             {
-                sw.Write("_data._EntityId*_data.GoesTo*\r_data._EntityId*_data.GoesTo*\rfirst*11*\r");
+                attempt++;
+                try
+                {
+                    var connector = new axopen_data_tests_l1TwinController(ConnectorAdapterBuilder.Build().CreateDummy());
+                    var sut = connector.Fragments.DataManager;
+                    var s = sut.CreateDataFragments<FragmentProcessDataManager>();
+
+                    s.EntityHeader.SetRepository(new InMemoryRepository<SharedEntityHeader>());
+                    s.Station.SetRepository(new InMemoryRepository<StationData>());
+
+                    var tempDirectory = Path.Combine(TempPath, "ImportDataFragmentTest", "importDataFragmentPrepare");
+                    var zipFile = Path.Combine(TempPath, "ImportDataFragmentTest", "ImportDataFragment.zip");
+
+                    Directory.CreateDirectory(tempDirectory);
+
+                    File.Delete(zipFile);
+
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, sut.EntityHeader.GetSymbolTail() + ".txt")))
+                    {
+                        sw.Write("_data._EntityId*_data.GoesTo*\r_data._EntityId*_data.GoesTo*\rfirst*11*\r");
+                    }
+                    using (var sw = new StreamWriter(Path.Combine(tempDirectory, sut.Station.GetSymbolTail() + ".txt")))
+                    {
+                        sw.Write("_data._EntityId*\r_data._EntityId*\rfirst*\r");
+                    }
+
+                    ZipFile.CreateFromDirectory(tempDirectory, zipFile);
+
+                    // import
+                    sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "TXT", separator: '*');
+
+                    var shared = sut.EntityHeader.DataRepository.Read("first");
+                    Assert.Equal(0, shared.ComesFrom);
+                    Assert.Equal(11, shared.GoesTo);
+
+                    var manip = sut.Station.DataRepository.Read("first");
+                    Assert.Equal(0ul, manip.CounterDelay);
+
+                    // clear
+                    if (Directory.Exists(tempDirectory))
+                        Directory.Delete(tempDirectory, true);
+                    if (File.Exists(zipFile))
+                        File.Delete(zipFile);
+
+                    // Test passed, exit retry loop
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    lastException = ex;
+                    if (attempt >= maxRetries)
+                    {
+                        throw;
+                    }
+                    // Optional: Add delay between retries
+                    await Task.Delay(100);
+                }
             }
-            using (var sw = new StreamWriter(Path.Combine(tempDirectory, sut.Station.GetSymbolTail() + ".txt")))
+
+            // If we get here, all retries failed
+            if (lastException != null)
             {
-                sw.Write("_data._EntityId*\r_data._EntityId*\rfirst*\r");
+                throw lastException;
             }
-
-            ZipFile.CreateFromDirectory(tempDirectory, zipFile);
-
-            // import
-            sut.ImportData(zipFile, new Microsoft.AspNetCore.Components.Authorization.AuthenticationState(new System.Security.Claims.ClaimsPrincipal()), exportFileType: "TXT", separator: '*');
-
-            var shared = sut.EntityHeader.DataRepository.Read("first");
-            Assert.Equal(0, shared.ComesFrom);
-            Assert.Equal(11, shared.GoesTo);
-
-            var manip = sut.Station.DataRepository.Read("first");
-            Assert.Equal(0ul, manip.CounterDelay);
-
-            // clear
-            if (Directory.Exists(tempDirectory))
-                Directory.Delete(tempDirectory, true);
-            if (File.Exists(zipFile))
-                File.Delete(zipFile);
         }
 
         [Fact()]

--- a/src/data/tests/AXOpen.Data.Tests_L1/ax/apax.yml
+++ b/src/data/tests/AXOpen.Data.Tests_L1/ax/apax.yml
@@ -145,7 +145,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
+++ b/src/data/tests/AXOpen.Repository.Integration.Tests_L4/ax/apax.yml
@@ -150,7 +150,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/inspectors/app/apax.yml
+++ b/src/inspectors/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/inspectors/ctrl/apax.yml
+++ b/src/inspectors/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/integrations/app/apax.yml
+++ b/src/integrations/app/apax.yml
@@ -153,7 +153,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/io/app/apax.yml
+++ b/src/io/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/io/ctrl/apax.yml
+++ b/src/io/ctrl/apax.yml
@@ -25,7 +25,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/probers/app/apax.yml
+++ b/src/probers/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/probers/ctrl/apax.yml
+++ b/src/probers/ctrl/apax.yml
@@ -26,7 +26,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/scripts/check_requisites_apax.sh
+++ b/src/scripts/check_requisites_apax.sh
@@ -1,5 +1,5 @@
 apaxUrl="https://console.simatic-ax.siemens.io/"
-expectedApaxVersion="4.1.1"
+expectedApaxVersion="4.2.0"
 
 export GREEN='\033[0;32m'
 export RED='\033[0;31m'

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -8,27 +8,27 @@ registries:
 catalogs:
   "@inxton/ax.catalog": 0.0.36
 dependencies:
-  '@ax/apax-build': ^2.0.20
-  '@ax/axunitst': ^8.3.9
-  '@ax/axunitst-ls-contrib': ^8.3.9
-  '@ax/certificate-management': ^1.2.0
-  '@ax/diagnostic-buffer': ^1.3.2
-  '@ax/hw-s7-1500': ^3.4.0
-  '@ax/hwc': ^4.0.0
-  '@ax/hwld': ^3.2.0
-  '@ax/mod': ^1.8.8
-  '@ax/mon': ^1.8.8
-  '@ax/performance-info': ^1.1.2
-  '@ax/plc-info': ^3.1.0
-  '@ax/sdb': ^1.8.8
-  '@ax/simatic-package-tool': ^2.0.15
-  '@ax/sld': ^3.3.3
-  '@ax/st-ls': ^10.2.95
-  '@ax/st-resources.stc-plugin': ^3.0.23
-  '@ax/stc': ^10.2.95
-  '@ax/target-llvm': ^10.2.95
-  '@ax/target-mc7plus': ^10.2.95
-  '@ax/trace': ^2.9.1
+  '@ax/apax-build': 2.0.20
+  '@ax/axunitst': 8.3.9
+  '@ax/axunitst-ls-contrib': 8.3.9
+  '@ax/certificate-management': 1.2.0
+  '@ax/diagnostic-buffer': 1.3.2
+  '@ax/hw-s7-1500': 3.4.0
+  '@ax/hwc': 4.0.0
+  '@ax/hwld': 3.2.0
+  '@ax/mod': 1.8.8
+  '@ax/mon': 1.8.8
+  '@ax/performance-info': 1.1.2
+  '@ax/plc-info': 3.1.0
+  '@ax/sdb': 1.8.8
+  '@ax/simatic-package-tool': 2.0.15
+  '@ax/sld': 3.3.3
+  '@ax/st-ls': 10.2.95
+  '@ax/st-resources.stc-plugin': 3.0.23
+  '@ax/stc': 10.2.95
+  '@ax/target-llvm': 10.2.95
+  '@ax/target-mc7plus': 10.2.95
+  '@ax/trace': 2.9.1
 installStrategy: strict
 apaxVersion: 3.5.0
 scripts:
@@ -41,7 +41,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/simatic1500/app/apax.yml
+++ b/src/simatic1500/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/simatic1500/ctrl/apax.yml
+++ b/src/simatic1500/ctrl/apax.yml
@@ -25,7 +25,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/template.axolibrary/app/apax.yml
+++ b/src/template.axolibrary/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/template.axolibrary/ctrl/apax.yml
+++ b/src/template.axolibrary/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/timers/app/apax.yml
+++ b/src/timers/app/apax.yml
@@ -151,7 +151,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/timers/ctrl/apax.yml
+++ b/src/timers/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/utils/app/apax.yml
+++ b/src/utils/app/apax.yml
@@ -152,7 +152,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |

--- a/src/utils/ctrl/apax.yml
+++ b/src/utils/ctrl/apax.yml
@@ -24,7 +24,7 @@ scripts:
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax ib' Finished in :" $(expr $(date +%s) - $START) "s"
   icb: |
     START=$(date +%s)
-    apax install --catalog
+    apax install --catalog --strict
     apax ib
     echo $(date +%D)"-"$(date +%H)":"$(date +%M)":"$(date +%S) " - 'apax icb' Finished in :" $(expr $(date +%s) - $START) "s"
   cib: |


### PR DESCRIPTION
# Implements retry logic for occasionally failing tests due to problem with file system access.

# Use of `--strict`

This pull request updates all relevant project scripts and build tooling to use the `--strict` flag when running `apax install --catalog`. This change enforces stricter dependency resolution during the installation process, improving reliability and consistency across builds.

**Build and script improvements:**

* Updated all `icb` script steps in various `apax.yml` files to use `apax install --catalog --strict` instead of just `apax install --catalog`, ensuring stricter dependency checks during installation. [[1]](diffhunk://#diff-66a817b168854b13744e779f6f789c52368682b5a72b5da28272377b1b81b9b8L154-R154) [[2]](diffhunk://#diff-65a2a147d2a7b847fc6bf4b04748214cecc1e8e1994c93eea0b531caeef7a86cL27-R27) [[3]](diffhunk://#diff-5b95e3fc6089719f9f93af8ade09855489c751ae1ed8428143aa7118d7fc38adL30-R30) [[4]](diffhunk://#diff-8e9251619262f638b80a695996e639e8e3ee5835b15fa8dacff2f581771d355dL32-R32) [[5]](diffhunk://#diff-89e01002b9b9a648ebf8805d0bb03d193c0b56d7cdb9d797e1d253b244d6fc37L24-R24) [[6]](diffhunk://#diff-b7adc7d14d8f3cd2fa69625674b9dd8c3233b6bdc5651e126858427018481be9L32-R32) [[7]](diffhunk://#diff-ecc0a0f7fd41e6b0a670fea10db3ad912ef2ecd1a99fdd07e78aaa7d0f3f1b59L154-R154) [[8]](diffhunk://#diff-1f037e214953a8cd4cf6d48e9d6e7bf257ad8774455762c16276b01a794a0373L27-R27) [[9]](diffhunk://#diff-184786c16e6c1d73332a38ac7bb9dbb723e821dd3d205e2cfb987e9d8259d3e7L154-R154) [[10]](diffhunk://#diff-f5b3c08a7a7694e81f1f09b4cc8e967b29661b45e99769f66beb04bf714cc164L27-R27) [[11]](diffhunk://#diff-eae9cdbe2c10f6ecad9812faca3e1f168cc7a1ca4c1ddd98b8bccdada0d7cf80L154-R154) [[12]](diffhunk://#diff-013f54d9c0c779ef2e5e35af310932f31f608a17de1a54a09b250b2d106d0750L27-R27) [[13]](diffhunk://#diff-f1941c29fc3830c98c7ee6e82ee5ac31eaeccb369ab1d5a1d9d7feed3c096977L154-R154) [[14]](diffhunk://#diff-99b8b5d941ec7f01a3649e0f764b4abbbdda269943c2af07b9fa2ba287aaed39L27-R27) [[15]](diffhunk://#diff-ca894d7570d97bb84d60adae6334de081a5bd6a466cf2370f593d76e84cad413L154-R154) [[16]](diffhunk://#diff-e807be674468a422b67bdd206cec1a29609e307a410fcfa68c339fd2d92f8228L27-R27) [[17]](diffhunk://#diff-3ff4d13f585031e6e08d5b814c251b3199afadf4787194547ccb10f7e731c9d9L154-R154) [[18]](diffhunk://#diff-dd8d690cb350b4d4ae59ba1f47ecbd2057fa830595362b78c34cd5416e780674L27-R27) [[19]](diffhunk://#diff-566843161cb08066467e1379d8cbf6239cc4e548db9141c8401b0045b09c3009L154-R154)

* Modified the `ApaxCatalogInstall` method in `cake/ApaxCmd.cs` to include the `--strict` flag and updated log messages accordingly, aligning build automation with the new stricter installation behavior.

closes #827