### PR TITLE
AxoCyclinder should hide state variables

### DIFF
--- a/src/components.pneumatics/ctrl/src/AxoCylinder.st
+++ b/src/components.pneumatics/ctrl/src/AxoCylinder.st
@@ -24,35 +24,40 @@ NAMESPACE AXOpen.Components.Pneumatics
             {#ix-set:AttributeName = "<#Move out#>"}
             _MoveOutTask : AxoTask;
 
-            {#ix-attr:[ComponentDetails("Tasks")]}            
-            {#ix-set:AttributeName = "<#Stop#>"}
-            _StopTask : AxoTask;
-
             {#ix-attr:[Container(Layout.Stack)]}
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
             {#ix-set:AttributeName = "<#In sensor#>"}
-            _InSensor : BOOL;
+            InSensor : BOOL;
 
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
             {#ix-set:AttributeName = "<#Out sensor#>"}
-            _OutSensor : BOOL;
+            OutSensor : BOOL;
 
             {#ix-attr:[Container(Layout.Stack)]}
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
             {#ix-set:AttributeName = "<#Move in signal#>"}
-            _MoveInSignal : BOOL;
+            MoveInSignal : BOOL;
 
             {#ix-attr:[ComponentDetails("Signals")]}
             {#ix-attr:[ReadOnly()]}
             {#ix-set:AttributeName = "<#Move out signal#>"}
-            _MoveOutSignal : BOOL;
+            MoveOutSignal : BOOL;
 
+            {#ix-attr:[ComponentDetails("Tasks")]}            
+            {#ix-set:AttributeName = "<#Stop#>"}
+            _StopTask : AxoTask;           
             _Messenger : AXOpen.Messaging.Static.AxoMessenger;
         END_VAR
-
+        
+        VAR PRIVATE            
+            _InSensor : BOOL;            
+            _OutSensor : BOOL;            
+            _MoveInSignal : BOOL;            
+            _MoveOutSignal : BOOL;
+        END_VAR    
         VAR PRIVATE
             _MoveToOutIsSuspended : BOOL;
             _MoveToInIsSuspended : BOOL;
@@ -96,14 +101,14 @@ NAMESPACE AXOpen.Components.Pneumatics
             IF (inParent = NULL) THEN 
                 RETURN; 
             END_IF;
-
+            
             IF _context = NULL THEN
                 SUPER.Run(inParent);
                 _context := THIS.GetContext();
             END_IF;
 
             SUPER.Run(inParent);
-
+          
             _InSensor := inInSensor;
             _OutSensor := inOutSensor;
 
@@ -155,6 +160,11 @@ NAMESPACE AXOpen.Components.Pneumatics
 
             _MoveToInIsSuspended := FALSE;
             _MoveToOutIsSuspended := FALSE;
+
+            InSensor := inInSensor;
+            OutSensor := inOutSensor;
+            MoveInSignal := outMoveInSignal;
+            MoveOutSignal := outMoveOutSignal;
         END_METHOD
 
         METHOD PROTECTED OVERRIDE ManualControl

--- a/src/components.pneumatics/ctrl/test/CylinderTests.st
+++ b/src/components.pneumatics/ctrl/test/CylinderTests.st
@@ -113,10 +113,10 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
         END_METHOD
@@ -131,10 +131,10 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOutSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD  
@@ -155,10 +155,10 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD
@@ -179,10 +179,10 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
         END_METHOD  
@@ -200,8 +200,8 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
@@ -242,14 +242,17 @@ NAMESPACE Cylinder.Tests
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
-            context.Open();                                                              
+            context.Open();            
+            _homeSensor := FALSE;                                                  
+            _workSensor := FALSE;
             context.InitializeRootObject(cylinderParent);
-            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             cylinder.SuspendMoveToOutWhile(TRUE);
+            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);              
             context.Close();                          
-                
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            
+            AxUnit.Assert.Equal(FALSE, _moveWorkSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
@@ -312,13 +315,13 @@ NAMESPACE Cylinder.Tests
             // AxUnit.Assert.Equal(FALSE, cylinder._Messenger.IsActive);
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
             context.Open();                                                              
-            context.InitializeRootObject(cylinderParent);                                                        
-            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
-            cylinder.SuspendMoveToInWhile(TRUE);
+            context.InitializeRootObject(cylinderParent);   
+            cylinder.SuspendMoveToInWhile(TRUE);                                                     
+            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);              
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
@@ -412,8 +415,8 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(TRUE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(TRUE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(TRUE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(TRUE, cylinder.MoveOut().IsBusy());   
 
@@ -423,8 +426,8 @@ NAMESPACE Cylinder.Tests
             cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());  
             AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
@@ -453,13 +456,13 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
             context.Open();                                                              
-            context.InitializeRootObject(cylinderParent);                                                        
-            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
-            cylinder.AbortMoveToWorkWhen(TRUE);
+            context.InitializeRootObject(cylinderParent);     
+            cylinder.AbortMoveToWorkWhen(TRUE);                                                   
+            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);              
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveOutTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveOut().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);
@@ -523,13 +526,13 @@ NAMESPACE Cylinder.Tests
             AxUnit.Assert.Equal(FALSE, cylinder._Messenger.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired);
 
             context.Open();                                                              
-            context.InitializeRootObject(cylinderParent);                                                        
-            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);  
-            cylinder.AbortMoveToHomeWhen(TRUE);
+            context.InitializeRootObject(cylinderParent);  
+            cylinder.AbortMoveToHomeWhen(TRUE);                                                      
+            cylinder.Run(cylinderParent, _homeSensor, _workSensor, _moveHomeSignal, _moveWorkSignal);             
             context.Close();                          
                 
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveOutSignal);   
-            AxUnit.Assert.Equal(FALSE, cylinder._MoveInSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveOutSignal);   
+            AxUnit.Assert.Equal(FALSE, cylinder.MoveInSignal);   
             AxUnit.Assert.Equal(FALSE, cylinder._MoveInTask.IsBusy());   
             AxUnit.Assert.Equal(FALSE, cylinder.MoveIn().IsBusy());   
             // AxUnit.Assert.Equal(TRUE, cylinder._Messenger.IsActive);

--- a/src/components.pneumatics/docs/AXOCYLINDER.md
+++ b/src/components.pneumatics/docs/AXOCYLINDER.md
@@ -27,6 +27,8 @@ To accomplish this, call the `Run` method cyclically with the proper variables (
 
 [!INCLUDE [IntializeAndRun](../../../docfx/articles/notes/CYCLIC_UPDATE_NOTICE.md)]
 
+>[!IMPORTANT]
+>Movement suspension and movement abort methods (`SuspendMoveToInWhile`, `SuspendMoveToOutWhile`, `AbortMoveToHomeWhen`, `AbortMoveToWorkWhen`) must be called cyclically **before** calling the `Run` method to ensure proper operation and safety.
 
 #### Example use
 

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor
@@ -82,11 +82,11 @@
             <!-- Pneumatic Cylinder Assembly -->
             <div class="pneumatic-cylinder @(IsMoving && ShowAnimation ? "cylinder-moving" : "") flex-1">
                 <!-- Movement Direction Indicator -->
-                @if (ShowAnimation && Component._MoveInSignal.Cyclic)
+                @if (ShowAnimation && Component.MoveInSignal.Cyclic)
                 {
                     <div class="direction-indicator text-warning">◄</div>
                 }
-                @if (ShowAnimation && Component._MoveOutSignal.Cyclic)
+                @if (ShowAnimation && Component.MoveOutSignal.Cyclic)
                 {
                     <div class="direction-indicator text-warning">►</div>
                 }

--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.cs
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics.blazor/AxoCylinder/AxoCylinderView.razor.cs
@@ -18,9 +18,9 @@ namespace AXOpen.Components.Pneumatics
         private bool ShowAnimationPanel { get; set; } = false;
         private bool ShowServiceView { get; set; } = false;
 
-        protected bool IsInInnerPosition => Component._InSensor.Cyclic && !Component._OutSensor.Cyclic;
-        protected bool IsInOuterPosition => Component._OutSensor.Cyclic && !Component._InSensor.Cyclic;
-        protected bool IsMoving => Component._MoveInSignal.Cyclic || Component._MoveOutSignal.Cyclic;
+        protected bool IsInInnerPosition => Component.InSensor.Cyclic && !Component.OutSensor.Cyclic;
+        protected bool IsInOuterPosition => Component.OutSensor.Cyclic && !Component.InSensor.Cyclic;
+        protected bool IsMoving => Component.MoveInSignal.Cyclic || Component.MoveOutSignal.Cyclic;
 
         private bool ShowMessages { get; set; } = false;
         private AxoMessageProvider? _messageProvider { get; set; }
@@ -119,12 +119,12 @@ namespace AXOpen.Components.Pneumatics
         public override void ConfigurePolling()
         {
             // Poll sensor states
-            this.StartPolling(Component._InSensor);
-            this.StartPolling(Component._OutSensor);
+            this.StartPolling(Component.InSensor);
+            this.StartPolling(Component.OutSensor);
 
             // Poll signal states
-            this.StartPolling(Component._MoveInSignal);
-            this.StartPolling(Component._MoveOutSignal);
+            this.StartPolling(Component.MoveInSignal);
+            this.StartPolling(Component.MoveOutSignal);
 
             // Poll task statuses
             this.StartPolling(Component._MoveOutTask.Status);


### PR DESCRIPTION
## Pull Request Overview

This PR refactors the `AxoCylinder` component to improve encapsulation by converting internal state variables from public to private, while exposing them through public read-only properties. The change affects sensor states and movement signals across the component implementation, tests, and UI views.

**Key Changes:**
- Converted `_InSensor`, `_OutSensor`, `_MoveInSignal`, and `_MoveOutSignal` from public to private variables
- Added public read-only properties (`InSensor`, `OutSensor`, `MoveInSignal`, `MoveOutSignal`) to expose these states
- Updated all references across C# Blazor views and test files to use the new public properties

### Reviewed Changes

Copilot reviewed 5 out of 5 changed files in this pull request and generated no comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| AxoCylinder.st | Restructured variable declarations to use private backing fields with public read-only properties for sensor and signal states |
| AxoCylinderView.razor.cs | Updated polling configuration and state checks to use new public properties instead of private fields |
| AxoCylinderView.razor | Updated UI bindings to use new public property names for movement signal checks |
| CylinderTests.st | Updated test assertions to use new public properties and reorganized test setup to call suspension/abort methods before `Run()` |
| AXOCYLINDER.md | Added documentation note about calling suspension and abort methods before `Run()` |
</details>


closes #835