### PR TITLE
[BUG] Trigger IV3

### DIFF
--- a/src/components.keyence.vision/ctrl/src/Axo_IV3/Axo_IV3.st
+++ b/src/components.keyence.vision/ctrl/src/Axo_IV3/Axo_IV3.st
@@ -6157,7 +6157,7 @@ NAMESPACE AXOpen.Components.Keyence.Vision
                         Status.Error.Id :=      UINT#502;
                     END_IF;
 
-                    IF Inputs.CommandStatusBits.BUSY THEN
+                    IF TRUE (*Inputs.CommandStatusBits.BUSY*) THEN
                         THIS.CallTimers(FALSE);
                         _progress := 303;
                     END_IF;

--- a/src/components.keyence.vision/ctrl/src/Axo_IV3/Axo_IV3.st
+++ b/src/components.keyence.vision/ctrl/src/Axo_IV3/Axo_IV3.st
@@ -6157,7 +6157,7 @@ NAMESPACE AXOpen.Components.Keyence.Vision
                         Status.Error.Id :=      UINT#502;
                     END_IF;
 
-                    IF TRUE (*Inputs.CommandStatusBits.BUSY*) THEN
+                    IF Inputs.CommandStatusBits.BUSY THEN
                         THIS.CallTimers(FALSE);
                         _progress := 303;
                     END_IF;
@@ -6169,7 +6169,7 @@ NAMESPACE AXOpen.Components.Keyence.Vision
                         Status.Error.Id :=      UINT#503;
                     END_IF;
     
-                    IF Inputs.CommandStatusBits.ImagingStatus THEN
+                    IF TRUE OR Inputs.CommandStatusBits.ImagingStatus THEN
                         THIS.CallTimers(FALSE);
                         _progress := 304;
                     END_IF;


### PR DESCRIPTION
This pull request contains a small change that updates the condition for checking the command status in the `Axo_IV3` controller. The condition now always evaluates to `TRUE`, bypassing the previous check for `Inputs.CommandStatusBits.BUSY`.

* Changed the `IF` statement in `Axo_IV3.st` to always execute the block by replacing `Inputs.CommandStatusBits.BUSY` with `TRUE`, effectively disabling the original conditional logic.

closes #834