### PR TITLE
removed net9.0 target

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
  <PropertyGroup>    
   <AxSharpRoot>$(MSBuildThisFileDirectory)..\..\axsharp\src\</AxSharpRoot>
-   <TargetFrameworks>net10.0;net9.0</TargetFrameworks>  
+   <TargetFrameworks>net10.0</TargetFrameworks>  
     <!-- Define output directories based on project names 
     <OutputPath>$(MSBuildThisFileDirectory)\.builds\bin\$(MSBuildProjectName)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>$(MSBuildThisFileDirectory)\.builds\obj\$(MSBuildProjectName)\$(Configuration)\</IntermediateOutputPath>  -->

--- a/src/tools/src/PlcSimAdvancedStarter/PlcSimAdvancedStarterTool/PlcSimAdvancedStarterTool.csproj
+++ b/src/tools/src/PlcSimAdvancedStarter/PlcSimAdvancedStarterTool/PlcSimAdvancedStarterTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target framework for the project to .NET 10.0, removing support for .NET 9.0. This ensures the codebase is aligned with the latest .NET version and simplifies maintenance.

**Target framework update:**

* Changed the `TargetFrameworks` property in `Directory.Build.props` to only include `net10.0`, removing `net9.0` support.
* Updated the `TargetFramework` in `PlcSimAdvancedStarterTool.csproj` from `net9.0` to `net10.0`.