### PR TITLE
[IDEA] Having extensive logging, is it really necessary compulsory message ackn for errors?

### DIFF
--- a/src/core/core.code-workspace
+++ b/src/core/core.code-workspace
@@ -1,9 +1,11 @@
 {
 	"folders": [
 		{
+			"name": "ctrl",
 			"path": "ctrl"
 		},
 		{
+			"name": "app",
 			"path": "app"
 		}
 	],

--- a/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
+++ b/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
@@ -111,7 +111,7 @@ NAMESPACE AXOpen.Messaging.Static
                 _context.GetLogger().Log('Risen', THIS.ToLogLevel(_category), THIS);
                 MessageCode := _messageCode;
                 Category := _category;
-                AcknowledgementRequired := Category >= eAxoMessageCategory#Error;
+                //  AcknowledgementRequired := Category >= eAxoMessageCategory#Error;
             END_IF;
 
             // "Reactivation" in case of acknowledgable alarm rised, falled and rised again without acknowledgement
@@ -290,6 +290,9 @@ NAMESPACE AXOpen.Messaging.Static
         ///</summary>
         METHOD PUBLIC RequireAcknowledgement : AXOpen.Messaging.Static.IAxoMessageProperties
             AcknowledgementRequired := TRUE;
+            IF THIS.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired THEN
+                THIS.MessengerState := eAxoMessengerState#ActiveAcknowledgeRequired;
+            END_IF;            
             RequireAcknowledgement := THIS;
         END_METHOD
 
@@ -298,6 +301,9 @@ NAMESPACE AXOpen.Messaging.Static
         ///</summary>
         METHOD PUBLIC DoNotRequireAcknowledgement : AXOpen.Messaging.Static.IAxoMessageProperties
             AcknowledgementRequired := FALSE;
+            IF THIS.MessengerState = eAxoMessengerState#ActiveAcknowledgeRequired THEN
+                THIS.MessengerState := eAxoMessengerState#ActiveAcknowledgeNotRequired;
+            END_IF;            
             DoNotRequireAcknowledgement := THIS;
         END_METHOD
 

--- a/src/core/ctrl/src/AxoMessaging/eAxoMessageCategory.st
+++ b/src/core/ctrl/src/AxoMessaging/eAxoMessageCategory.st
@@ -21,7 +21,7 @@ NAMESPACE AXOpen.Messaging
 
             ///<summary>
             /// Error message.
-            /// Use this categoty when there is a failure that cannot be immediately recovered and an intervention is needed. This is typically a situation when a device fails
+            /// Use this category when there is a failure that cannot be immediately recovered and an intervention is needed. This is typically a situation when a device fails
             /// to deliver expected result. 
             /// Do not use this category to report information about failed process like measurement or detection.
             ///</summary>

--- a/src/core/ctrl/src/AxoTask/AxoTask.st
+++ b/src/core/ctrl/src/AxoTask/AxoTask.st
@@ -126,7 +126,7 @@ NAMESPACE AXOpen.Core
             _cyclicExecuteIsNotCalled := FALSE;
             Invoke := SUPER.Invoke();
             _messenger.Serve(THIS);            
-            _messenger.ActivateOnCondition(ULINT#1,_cyclicExecuteIsNotCalled,eAxoMessageCategory#ProgrammingError);
+            _messenger.ActivateOnCondition(ULINT#1,_cyclicExecuteIsNotCalled,eAxoMessageCategory#ProgrammingError).RequireAcknowledgement();
             Invoke := THIS;
         END_METHOD    
 
@@ -184,7 +184,7 @@ NAMESPACE AXOpen.Core
             _multipleExecuteIsCalled := FALSE;
             Execute := SUPER.Execute(inParent);
 
-            _messenger.ActivateOnCondition(ULINT#2,_multipleExecuteIsCalled,eAxoMessageCategory#ProgrammingError);       
+            _messenger.ActivateOnCondition(ULINT#2,_multipleExecuteIsCalled,eAxoMessageCategory#ProgrammingError).RequireAcknowledgement();
         END_METHOD    
         
        

--- a/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
+++ b/src/core/ctrl/test/AxoMessaging/Static/AxoMessaging_UnitTests.st
@@ -984,7 +984,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         END_METHOD
 
         {Test}
-        METHOD PUBLIC message_of_error_category_shouldrequire_acknowledgement_by_default
+        METHOD PUBLIC message_of_error_category_should_not_require_acknowledgement_by_default
             VAR
                 expMessage : TestMessage;
             END_VAR
@@ -1006,7 +1006,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
 
             //--Assert
             Assert.Equal(FALSE, _suti._object._messenger.IsActive());
-            Assert.Equal(TRUE, _suti._object._messenger.AcknowledgementRequired);
+            Assert.Equal(FALSE, _suti._object._messenger.AcknowledgementRequired);
 
         END_METHOD
 
@@ -1038,7 +1038,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         END_METHOD
 
         {Test}
-        METHOD PUBLIC message_of_programming_error_category_shouldrequire_acknowledgement_by_default
+        METHOD PUBLIC message_of_programming_error_category_should_not_require_acknowledgement_by_default
             VAR
                 expMessage : TestMessage;
             END_VAR
@@ -1060,7 +1060,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
 
             //--Assert
             Assert.Equal(FALSE, _suti._object._messenger.IsActive());
-            Assert.Equal(TRUE, _suti._object._messenger.AcknowledgementRequired);
+            Assert.Equal(FALSE, _suti._object._messenger.AcknowledgementRequired);
 
         END_METHOD
 
@@ -1092,7 +1092,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
         END_METHOD
 
         {Test}
-        METHOD PUBLIC message_of_critical_category_shouldrequire_acknowledgement_by_default
+        METHOD PUBLIC message_of_critical_category_should_not_require_acknowledgement_by_default
             VAR
                 expMessage : TestMessage;
             END_VAR
@@ -1114,7 +1114,7 @@ NAMESPACE AXOpen.AxoMessagingStatic_UnitTests
 
             //--Assert
             Assert.Equal(FALSE, _suti._object._messenger.IsActive());
-            Assert.Equal(TRUE, _suti._object._messenger.AcknowledgementRequired);
+            Assert.Equal(FALSE, _suti._object._messenger.AcknowledgementRequired);
 
         END_METHOD
 


### PR DESCRIPTION
This pull request updates the default behavior for message acknowledgement in the messaging system, making messages of error, programming error, and critical categories not require acknowledgement by default. It also introduces explicit methods to control acknowledgement requirements and updates related unit tests to reflect the new behavior.

**Messaging system behavior changes:**

* Removed the automatic requirement for acknowledgement for messages of error and higher categories by default in `AxoMessenger`, making acknowledgement opt-in instead.
* Added logic to explicitly set the messenger state when acknowledgement requirements are changed through `RequireAcknowledgement` and `DoNotRequireAcknowledgement` methods. [[1]](diffhunk://#diff-086808f56504ce7e73285a8ecf42ddedc2174069098d896e7af96d6690a2f3e1R293-R295) [[2]](diffhunk://#diff-086808f56504ce7e73285a8ecf42ddedc2174069098d896e7af96d6690a2f3e1R304-R306)

**Task handling updates:**

* Updated `AxoTask` to explicitly require acknowledgement for programming error messages by chaining `.RequireAcknowledgement()` after activation, instead of relying on category-based defaults. [[1]](diffhunk://#diff-1ea197470d66aeced33dd84453738343c393d2509080960290a70d749865515fL129-R129) [[2]](diffhunk://#diff-1ea197470d66aeced33dd84453738343c393d2509080960290a70d749865515fL187-R187)

**Unit test adjustments:**

* Renamed and updated unit tests to assert that error, programming error, and critical category messages do not require acknowledgement by default, aligning with the new logic. [[1]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L987-R987) [[2]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L1009-R1009) [[3]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L1041-R1041) [[4]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L1063-R1063) [[5]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L1095-R1095) [[6]](diffhunk://#diff-e9b9e4f7f2cf33552db8fdaea0d522073ffac0e83873b04880c90b890b6c00c9L1117-R1117)

**Documentation fix:**

* Corrected a typo in the documentation for the error message category in `eAxoMessageCategory.st`.

closes #843