### PR TITLE
width in axobytearrayview is computed automaticaly

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoArrays/AxoByteArrayView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoArrays/AxoByteArrayView.razor
@@ -51,7 +51,7 @@
                         {
                             <div class="input-group">
                                 <label>@item.Index</label>
-                                <input type="text" @bind="item.Data" maxlength="@MaxLen" class="w-20!" />
+                                <input type="text" @bind="item.Data" maxlength="@MaxLen" style="width: calc(var(--spacing) * 9 + var(--spacing) * 2 * @MaxLen) !important;" />
                             </div>
                         }
                     }


### PR DESCRIPTION
This pull request updates the styling for input fields in the `AxoByteArrayView.razor` component to improve layout flexibility. The most important change is:

Styling improvements:

* Updated the inline `style` attribute of the input field to use a dynamic width calculation based on the `MaxLen` parameter, replacing the fixed width class. This allows the input field to automatically adjust its width according to the maximum length, improving usability and appearance. (`AxoByteArrayView.razor`)

closes #862 