### PR TITLE
added option to saved visualComposer files outside the application fo…

### DIFF
--- a/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor.cs
+++ b/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor.cs
@@ -45,7 +45,6 @@ namespace AXOpen.VisualComposer.Components
         public SerializableView CurrentView { get; set; } = new SerializableView();
         private SerializableConfiguration? _serverStorageConfiguration { get; set; }
         private List<string> _serverStorageAllViews { get; set; } = new List<string>();
-        public const string SERVER_STORAGE_MAIN_DIR = "VisualComposerSerialize";
 
         public Size ElementSize { get; set; } = new Size();
         private Size _windowSize { get; set; } = new Size();
@@ -257,8 +256,8 @@ namespace AXOpen.VisualComposer.Components
             {
                 _serverStorageAllViews.Remove(name);
 
-                if (File.Exists(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), name.CorrectFilePath() + ".json")))
-                    File.Delete(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), name.CorrectFilePath() + ".json"));
+                if (File.Exists(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), name.CorrectFilePath() + ".json")))
+                    File.Delete(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), name.CorrectFilePath() + ".json"));
             }
             else if (_localStorageData.ContainsKey(name))
             {
@@ -274,7 +273,7 @@ namespace AXOpen.VisualComposer.Components
                 if (_serverStorageConfiguration.DefaultView == name)
                     _serverStorageConfiguration.DefaultView = null;
 
-                await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
+                await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
             }
 
             if (_currentViewName == name)
@@ -299,10 +298,10 @@ namespace AXOpen.VisualComposer.Components
 
             if (_serverStorageAllViews.Contains(_currentViewName))
             {
-                if (!Directory.Exists(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath())))
-                    Directory.CreateDirectory(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath()));
+                if (!Directory.Exists(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath())))
+                    Directory.CreateDirectory(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath()));
 
-                await Serializing<SerializableView>.SerializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), _currentViewName.CorrectFilePath() + ".json"), CurrentView);
+                await Serializing<SerializableView>.SerializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), _currentViewName.CorrectFilePath() + ".json"), CurrentView);
             }
             else if(_localStorageData.ContainsKey(_currentViewName))
             {
@@ -312,7 +311,7 @@ namespace AXOpen.VisualComposer.Components
 
         private async Task LoadMainAsync()
         {
-            _serverStorageConfiguration = await Serializing<SerializableConfiguration>.DeserializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath() + ".json"));
+            _serverStorageConfiguration = await Serializing<SerializableConfiguration>.DeserializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath() + ".json"));
             if (_serverStorageConfiguration == null)
                 _serverStorageConfiguration = new SerializableConfiguration(new List<string>(), null);
 
@@ -333,12 +332,12 @@ namespace AXOpen.VisualComposer.Components
         {
             List<string> files = new();
 
-            if (!Directory.Exists(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath())))
+            if (!Directory.Exists(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath())))
                 return files;
 
             try
             {
-                Directory.GetFiles(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath()), "*.json").ToList().ForEach(p => files.Add(Path.GetFileNameWithoutExtension(p)));
+                Directory.GetFiles(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath()), "*.json").ToList().ForEach(p => files.Add(Path.GetFileNameWithoutExtension(p)));
             }
             catch (Exception ex)
             {
@@ -357,7 +356,7 @@ namespace AXOpen.VisualComposer.Components
 
             SerializableView? deserializedData = null;
             if (_serverStorageAllViews.Contains(view))
-                deserializedData = await Serializing<SerializableView>.DeserializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
+                deserializedData = await Serializing<SerializableView>.DeserializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
             else if (_localStorageData.ContainsKey(view))
                 deserializedData = _localStorageData[view];
 
@@ -394,13 +393,13 @@ namespace AXOpen.VisualComposer.Components
             if (oldType == SaveLocationType.Server && _serverStorageAllViews.Contains(view) && newSaveLocation == "Local")
             {
                 // Read
-                var deserializedData = await Serializing<SerializableView>.DeserializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
+                var deserializedData = await Serializing<SerializableView>.DeserializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
 
                 // Remove
                 _serverStorageAllViews.Remove(view);
 
-                if (File.Exists(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), view.CorrectFilePath() + ".json")))
-                    File.Delete(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
+                if (File.Exists(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), view.CorrectFilePath() + ".json")))
+                    File.Delete(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"));
 
                 if(deserializedData != null)
                 {
@@ -426,10 +425,10 @@ namespace AXOpen.VisualComposer.Components
                     _serverStorageAllViews.Add(view);
 
                     // Save
-                    if (!Directory.Exists(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath())))
-                        Directory.CreateDirectory(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath()));
+                    if (!Directory.Exists(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath())))
+                        Directory.CreateDirectory(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath()));
 
-                    await Serializing<SerializableView>.SerializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"), data);
+                    await Serializing<SerializableView>.SerializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath(), view.CorrectFilePath() + ".json"), data);
                 }
             }
 
@@ -459,7 +458,7 @@ namespace AXOpen.VisualComposer.Components
             else
                 _serverStorageConfiguration.Views.Add(view);
 
-            await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
+            await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
         }
 
         private async Task ChangeDefaultViewAsync(string view)
@@ -469,7 +468,7 @@ namespace AXOpen.VisualComposer.Components
             if (!_serverStorageConfiguration.Views.Contains(view))
                 _serverStorageConfiguration.Views.Add(view);
 
-            await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(SERVER_STORAGE_MAIN_DIR, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
+            await Serializing<SerializableConfiguration>.SerializeAsync(Path.Combine(Settings.VisualComposerSerializeFolderPath, Id.CorrectFilePath() + ".json"), _serverStorageConfiguration);
         }
 
         private string? _searchValue { get; set; } = null;
@@ -549,18 +548,18 @@ namespace AXOpen.VisualComposer.Components
 
             try
             {
-                if (!Directory.Exists("wwwroot/Images/"))
-                    Directory.CreateDirectory("wwwroot/Images/");
+                if (!Directory.Exists(Settings.VisualComposerImagesSerializeFolderPath))
+                    Directory.CreateDirectory(Settings.VisualComposerImagesSerializeFolderPath);
 
                 string newName = _currentViewName + Path.GetExtension(e.File.Name);
 
-                if (!Directory.Exists("wwwroot/Images/VisualComposerSerialize/" + Id.CorrectFilePath()))
-                    Directory.CreateDirectory("wwwroot/Images/VisualComposerSerialize/" + Id.CorrectFilePath());
+                if (!Directory.Exists(Settings.VisualComposerImagesSerializeFolderPath + "/" + Id.CorrectFilePath()))
+                    Directory.CreateDirectory(Settings.VisualComposerImagesSerializeFolderPath + "/" + Id.CorrectFilePath());
 
-                await using FileStream fs = new("wwwroot/Images/VisualComposerSerialize/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath(), FileMode.Create);
+                await using FileStream fs = new(Settings.VisualComposerImagesSerializeFolderPath + "/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath(), FileMode.Create);
                 await e.File.OpenReadStream().CopyToAsync(fs);
 
-                CurrentView.ImgSrc = "Images/VisualComposerSerialize/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath();
+                CurrentView.ImgSrc = Settings.VisualComposerImagesSerializeName + "/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath();
 
                 var dimensions = await GetImageDimensions(CurrentView.ImgSrc);
                 CurrentView.BackgroundWidth = dimensions.Width;

--- a/src/base/src/AXOpen.VisualComposer/Settings.cs
+++ b/src/base/src/AXOpen.VisualComposer/Settings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AXOpen.VisualComposer
+{
+    public static class Settings
+    {
+        public static string VisualComposerSerializeFolderPath { get; set; } = "VisualComposerSerialize";
+        public static string VisualComposerImagesSerializeFolderPath { get; set; } = "wwwroot/Images/VisualComposerSerialize";
+        public static string VisualComposerImagesSerializeName { get; set; } = "/Images/VisualComposerSerialize";
+    }
+}


### PR DESCRIPTION
This pull request refactors the file and image storage paths in the `VisualComposerContainer` component to use centralized settings, improving maintainability and configurability. Instead of hardcoding directory names throughout the code, all paths are now referenced from the new static `Settings` class.

**Centralization of storage paths:**

* Introduced a new static `Settings` class in `Settings.cs` to define and manage storage folder paths for serialized views and images (`VisualComposerSerializeFolderPath`, `VisualComposerImagesSerializeFolderPath`, and `VisualComposerImagesSerializeName`).

**Refactoring of path usage throughout `VisualComposerContainer.razor.cs`:**

* Replaced all hardcoded references to `"VisualComposerSerialize"` and image directories with the corresponding properties from the `Settings` class in methods for saving, loading, deleting, and moving serialized view and configuration files. [[1]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL48) [[2]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL260-R260) [[3]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL277-R276) [[4]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL302-R304) [[5]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL315-R314) [[6]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL336-R340) [[7]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL360-R359) [[8]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL397-R402) [[9]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL429-R431) [[10]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL462-R461) [[11]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL472-R471) [[12]](diffhunk://#diff-78673f33877057198e515d1a938d9b725460bf5d5b39ff7a6b609d2013c3787dL552-R562)

These changes make it easier to update storage locations in the future and improve code readability by removing duplicated string literals.

closes #842 