### PR TITLE
Update ax.catalog version to 0.0.40 and adjust dependencies across multiple components

### DIFF
--- a/src/ax.axopen.app/ctrl/apax.yml
+++ b/src/ax.axopen.app/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.hwlibrary/ctrl/apax.yml
+++ b/src/ax.axopen.hwlibrary/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.axopen.min/ctrl/apax.yml
+++ b/src/ax.axopen.min/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/ax.catalog/apax.yml
+++ b/src/ax.catalog/apax.yml
@@ -1,5 +1,5 @@
 name: "@inxton/ax.catalog"
-version: '0.0.39'
+version: '0.0.40'
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 type: catalog
@@ -20,13 +20,13 @@ catalogDependencies:
   "@ax/hw-s7-1500": 4.0.0	                                # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.0
   "@ax/hwc": 4.0.0	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.0
   "@ax/hwld": 3.2.0	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  3.2.0
-  "@ax/mod": 1.9.4	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.9.4
-  "@ax/mon": 1.9.4	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.9.4
+  "@ax/mod": 1.10.8	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.10.8
+  "@ax/mon": 1.10.8	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.10.8
   "@ax/plc-control": 1.4.3	                              # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.4.3
   "@ax/plc-info": 4.0.0	                                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.0
   "@ax/plc-web-app-manager": 1.1.0	                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.1.0
-  "@ax/sdb": 1.9.4	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.9.4
-  "@ax/sdk": 2510.0.0	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  2510.0.0
+  "@ax/sdb": 1.10.8	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  1.10.8
+  "@ax/sdk": 2510.1.0	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  2510.1.0
   "@ax/simatic-alarming": 5.0.1	                          # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  5.0.1
   "@ax/simatic-clocks": 11.0.14	                          # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.14
   "@ax/simatic-communication": 11.0.1	                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.1
@@ -54,10 +54,10 @@ catalogDependencies:
   "@ax/simatic-tasks": 11.0.2	                            # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.2
   "@ax/simatic-technology-objects": 4.0.8	                # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.8
   "@ax/sld": 3.5.5	                                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  3.5.5
-  "@ax/st-ls": 11.0.142	                                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.142
+  "@ax/st-ls": 11.1.55	                                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.1.55
   "@ax/st-opcua.stc-plugin": 2.0.0	                      # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  2.0.0
   "@ax/st-resources.stc-plugin": 4.0.3	                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.3
-  "@ax/stc": 11.0.142	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.142
+  "@ax/stc": 11.1.55	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.142
   "@ax/system": 10.2.7	                                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
   "@ax/system-bitaccess": 10.2.7	                        # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
   "@ax/system-conversion": 10.2.7	                        # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
@@ -71,7 +71,7 @@ catalogDependencies:
   "@ax/system-serde": 10.2.7	                            # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
   "@ax/system-strings": 10.2.7	                          # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
   "@ax/system-timer": 10.2.7	                            # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  10.2.7
-  "@ax/target-llvm": 11.0.142	                            # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.142
-  "@ax/target-mc7plus": 11.0.142	                        # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.0.142
+  "@ax/target-llvm": 11.1.55	                            # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.1.55
+  "@ax/target-mc7plus": 11.1.55	                        # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  11.1.55
   "@ax/tia2st": 4.0.10	                                  # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  4.0.10
-  "@ax/trace": 3.1.0	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  3.1.0
+  "@ax/trace": 3.2.0	                                    # @ax/simatic-ax@2510.0.0 contained at the time of creation this catalog (3.11.2025) version  3.1.0

--- a/src/ax.latest.packages/ctrl/apax.yml
+++ b/src/ax.latest.packages/ctrl/apax.yml
@@ -8,7 +8,7 @@ devDependencies:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 dependencies:
   "@ax/simatic-1500-clocks": 10.0.6
   "@ax/system-bitaccess": 10.2.7
@@ -17,7 +17,7 @@ dependencies:
   "@ax/hwc": 4.0.0
   "@ax/hw-s7-1500": 4.0.0
   "@ax/hwld": 3.2.0
-  "@ax/stc": 11.0.142
+  "@ax/stc": 11.1.55
   "@ax/sld": 3.5.5
 installStrategy: strict
 apaxVersion: 3.5.0

--- a/src/components.siem.communication/ctrl/apax.yml
+++ b/src/components.siem.communication/ctrl/apax.yml
@@ -9,7 +9,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:

--- a/src/sdk-ax/ctrl/apax.yml
+++ b/src/sdk-ax/ctrl/apax.yml
@@ -6,7 +6,7 @@ files:
 registries:
   "@inxton": "https://npm.pkg.github.com/"
 catalogs:
-  "@inxton/ax.catalog": 0.0.39
+  "@inxton/ax.catalog": 0.0.40
 dependencies:
   '@ax/apax-build': 2.1.79
   '@ax/axunitst': 8.4.20
@@ -16,19 +16,19 @@ dependencies:
   '@ax/hw-s7-1500': 4.0.0
   '@ax/hwc': 4.0.0
   '@ax/hwld': 3.2.0
-  '@ax/mod': 1.9.4
-  '@ax/mon': 1.9.4
+  '@ax/mod': 1.10.8
+  '@ax/mon': 1.10.8
   '@ax/performance-info': 1.1.2
   '@ax/plc-info': 4.0.0
-  '@ax/sdb': 1.9.4
+  '@ax/sdb': 1.10.8
   '@ax/simatic-package-tool': 2.0.17
   '@ax/sld': 3.5.5
-  '@ax/st-ls': 11.0.142
+  '@ax/st-ls': 11.1.55
   '@ax/st-resources.stc-plugin': 4.0.3
-  '@ax/stc': 11.0.142
-  '@ax/target-llvm': 11.0.142
-  '@ax/target-mc7plus': 11.0.142
-  '@ax/trace': 3.1.0
+  '@ax/stc': 11.1.55
+  '@ax/target-llvm': 11.1.55
+  '@ax/target-mc7plus': 11.1.55
+  '@ax/trace': 3.2.0
 installStrategy: strict
 apaxVersion: 3.5.0
 scripts:

--- a/src/traversals/apax/apax.yml
+++ b/src/traversals/apax/apax.yml
@@ -13,7 +13,7 @@ dependencies:
   "@inxton/ax.axopen.app": "0.0.0-dev.0"
   "@inxton/ax.axopen.hwlibrary": "0.0.0-dev.0"
   "@inxton/ax.axopen.min": "0.0.0-dev.0"
-  "@inxton/ax.catalog": "0.0.39"
+  "@inxton/ax.catalog": "0.0.40"
   "@inxton/ax.latest.packages": "0.0.0-dev.0"
   "app_axopen.components.abb.robotics": "0.0.0-dev.0"
   "@inxton/axopen.components.abb.robotics": "0.0.0-dev.0"


### PR DESCRIPTION
This pull request updates the `@inxton/ax.catalog` package to version 0.0.40 across the repository and synchronizes all dependent packages to use this new catalog version. In addition to the catalog version bump, several dependencies within the catalog and related projects are updated to newer versions, ensuring compatibility and access to the latest features and fixes.

**Catalog and Dependency Updates:**

* Updated the version of `@inxton/ax.catalog` to `0.0.40` in the catalog itself and in all dependent projects, including `ax.axopen.app`, `ax.axopen.hwlibrary`, `ax.axopen.min`, `ax.latest.packages`, `components.siem.communication`, `sdk-ax`, and `traversals/apax`. [[1]](diffhunk://#diff-aab8ed0e505758ebbdca39bff5896a89983cb8b459f68a86d44cfca94eed4da4L2-R2) [[2]](diffhunk://#diff-5b95e3fc6089719f9f93af8ade09855489c751ae1ed8428143aa7118d7fc38adL9-R9) [[3]](diffhunk://#diff-8e9251619262f638b80a695996e639e8e3ee5835b15fa8dacff2f581771d355dL9-R9) [[4]](diffhunk://#diff-89e01002b9b9a648ebf8805d0bb03d193c0b56d7cdb9d797e1d253b244d6fc37L9-R9) [[5]](diffhunk://#diff-b7adc7d14d8f3cd2fa69625674b9dd8c3233b6bdc5651e126858427018481be9L11-R11) [[6]](diffhunk://#diff-6b85a434bdf6dab010169d10951886ac54898b57c438ff9169765c1a47f172e9L12-R12) [[7]](diffhunk://#diff-5ecf0591f7d0e0980987da286bf20767696876ddb0bc000b2f392fbd4483645dL9-R9) [[8]](diffhunk://#diff-2e5d40bf396002296e5476528bac9bc0a2152dcee6c0a09d83cd716686ab6b60L16-R16)

**Catalog Dependency Synchronization:**

* Bumped multiple dependencies in `src/ax.catalog/apax.yml` to newer versions:
  - `@ax/mod`, `@ax/mon`, `@ax/sdb` to `1.10.8`
  - `@ax/sdk` to `2510.1.0`
  - `@ax/st-ls`, `@ax/stc`, `@ax/target-llvm`, `@ax/target-mc7plus` to `11.1.55`
  - `@ax/trace` to `3.2.0`
  [[1]](diffhunk://#diff-aab8ed0e505758ebbdca39bff5896a89983cb8b459f68a86d44cfca94eed4da4L23-R29) [[2]](diffhunk://#diff-aab8ed0e505758ebbdca39bff5896a89983cb8b459f68a86d44cfca94eed4da4L57-R60) [[3]](diffhunk://#diff-aab8ed0e505758ebbdca39bff5896a89983cb8b459f68a86d44cfca94eed4da4L74-R77)

**Downstream Dependency Alignment:**

* Updated downstream project dependencies to match the new catalog versions, including `@ax/stc`, `@ax/st-ls`, `@ax/mod`, `@ax/mon`, `@ax/sdb`, `@ax/target-llvm`, `@ax/target-mc7plus`, and `@ax/trace` in `sdk-ax` and `ax.latest.packages`. [[1]](diffhunk://#diff-5ecf0591f7d0e0980987da286bf20767696876ddb0bc000b2f392fbd4483645dL19-R31) [[2]](diffhunk://#diff-b7adc7d14d8f3cd2fa69625674b9dd8c3233b6bdc5651e126858427018481be9L20-R20)

These changes ensure all projects are using the latest compatible versions from the catalog, reducing the risk of version mismatches and taking advantage of recent improvements and fixes in dependencies.