### PR TITLE
Troubleshooting cicd

### DIFF
--- a/cake/ApaxCmd.cs
+++ b/cake/ApaxCmd.cs
@@ -27,6 +27,21 @@ using Path = System.IO.Path;
 
 public static class ApaxCmd
 {
+
+    public static void ApaxSelfUpdate(this BuildContext context, string version)
+    {
+        var apaxArguments = $"self-update {version}";
+
+        context.Log.Information($"apax self-update to version '{version}'");
+        context.ProcessRunner.Start(Helpers.GetApaxCommand(), new ProcessSettings()
+        {
+            Arguments = apaxArguments,            
+            RedirectStandardOutput = false,
+            RedirectStandardError = false,
+            Silent = false
+        }).WaitForExit();
+    }
+
     public static void ApaxInstall(this BuildContext context, IEnumerable<string> folders)
     {
         foreach (var folder in folders)

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -206,11 +206,13 @@ public sealed class BuildTask : FrostingTask<BuildContext>
             context.DotNetBuild(Path.Combine(context.RootDir, "AXOpen.proj"), context.DotNetBuildSettings);
         }
 
-        if (!context.BuildParameters.NoBuild && !context.BuildParameters.DoTest && !context.BuildParameters.DoPack)
-        {
-            context.ApaxBuild(new[] { traversalProjectFolder });
-        }
+        //if (!context.BuildParameters.NoBuild && !context.BuildParameters.DoTest && !context.BuildParameters.DoPack)
+        //{
+        //    context.Log.Information("Creating apax traversal.");
+        //    context.ApaxBuild(new[] { traversalProjectFolder });
+        //}
 
+        //throw new NotImplementedException("BuildTask is deprecated. Use CreateArtifactsTask instead.");
         // Clean up travversal files after build remove apax.yml and .apax folder
         context.DeleteFile(Path.Combine(traversalProjectFolder, "apax.yml"));
         System.IO.Directory.Delete(Path.Combine(traversalProjectFolder, ".apax"), true);

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -122,6 +122,10 @@ public sealed class ProvisionTask : FrostingTask<BuildContext>
         {
             context.CopyFiles(Path.Combine(context.RootDir, "traversals", "traversalBuilds", "**/*.*"), Path.Combine(context.RootDir, library.folder));
         }
+
+        // with this we will enforce use of specific apax version at least temporarily 
+        // due to issues with apax versions in some environments.
+        context.ApaxSelfUpdate("4.0.0");
     }
 
     private static void ProvisionTools(BuildContext context)

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -172,11 +172,13 @@ public sealed class BuildTask : FrostingTask<BuildContext>
 
         if (context.BuildParameters.DoPack)
         {
+            var apaxFiles = new List<string>();
+            context.Log.Information("Collecting .apax files.");
+            ApaxTraversal.CollectApaxFileInfoRecursively(context.RootDir, new List<string>() { ".apax", "traversals" }, apaxFiles);
+
             context.Libraries.ToList().ForEach(lib =>
             {
-                //foreach (var apaxfile in context.GetApaxFiles(lib))
-                var apaxFiles = new List<string>();
-                ApaxTraversal.CollectApaxFileInfoRecursively(context.RootDir, new List<string>() { ".apax", "traversals" }, apaxFiles);
+                //foreach (var apaxfile in context.GetApaxFiles(lib))               
                 foreach (var apaxfile in apaxFiles)
                 {
                     context.UpdateApaxVersion(apaxfile, GitVersionInformation.SemVer);
@@ -188,9 +190,10 @@ public sealed class BuildTask : FrostingTask<BuildContext>
        // context.DotnetIxr(context.Libraries.Where(p => p.pack && Directory.Exists(Path.Combine(context.RootDir, p.folder, "ctrl", "src"))).Select(p => Path.Combine(context.RootDir, p.folder, "ctrl")));
 
         var traversalProjectFolder = Path.Combine(context.RootDir, "traversals", "apax");
-        if (!context.BuildParameters.NoBuild)
+        if (!context.BuildParameters.NoBuild || context.BuildParameters.DoPack)
         {
             var traversalProject = Path.Combine(traversalProjectFolder, "apax.yml");
+            context.Log.Information("Creating apax traversal.");
             context.CreateApaxTraversal(context.RootDir, traversalProject);
             context.ApaxInstall(new[] { traversalProjectFolder });
             context.DotnetIxc(new[] { traversalProjectFolder });
@@ -208,6 +211,9 @@ public sealed class BuildTask : FrostingTask<BuildContext>
             context.ApaxBuild(new[] { traversalProjectFolder });
         }
 
+        // Clean up travversal files after build remove apax.yml and .apax folder
+        context.DeleteFile(Path.Combine(traversalProjectFolder, "apax.yml"));
+        System.IO.Directory.Delete(Path.Combine(traversalProjectFolder, ".apax"), true);
 
     }
 }
@@ -480,8 +486,7 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
                 context.ApaxInstall(context.GetLibraryAxFolders(lib));
                 context.ApaxBuild(context.GetLibraryAxFolders(lib));
                 context.ApaxPack(lib);
-                context.ApaxCopyArtifacts(lib);    
-                System.Threading.Thread.Sleep(10000);        
+                context.ApaxCopyArtifacts(lib);                   
             });
 
         }
@@ -496,8 +501,7 @@ public sealed class CreateArtifactsTask : FrostingTask<BuildContext>
                 context.ApaxInstall(context.GetLibraryAxFolders(lib));
                 context.ApaxBuild(context.GetLibraryAxFolders(lib));
                 context.ApaxPack(lib);
-                context.ApaxCopyArtifacts(lib);  
-                System.Threading.Thread.Sleep(10000);        
+                context.ApaxCopyArtifacts(lib);                  
             });
         }
     }

--- a/cake/Program.cs
+++ b/cake/Program.cs
@@ -206,16 +206,17 @@ public sealed class BuildTask : FrostingTask<BuildContext>
             context.DotNetBuild(Path.Combine(context.RootDir, "AXOpen.proj"), context.DotNetBuildSettings);
         }
 
-        //if (!context.BuildParameters.NoBuild && !context.BuildParameters.DoTest && !context.BuildParameters.DoPack)
-        //{
-        //    context.Log.Information("Creating apax traversal.");
-        //    context.ApaxBuild(new[] { traversalProjectFolder });
-        //}
+        if (!context.BuildParameters.NoBuild && !context.BuildParameters.DoTest && !context.BuildParameters.DoPack)
+        {
+            context.Log.Information("Creating apax traversal.");
+            context.ApaxBuild(new[] { traversalProjectFolder });
+        }
 
-        //throw new NotImplementedException("BuildTask is deprecated. Use CreateArtifactsTask instead.");
+
         // Clean up travversal files after build remove apax.yml and .apax folder
         context.DeleteFile(Path.Combine(traversalProjectFolder, "apax.yml"));
-        System.IO.Directory.Delete(Path.Combine(traversalProjectFolder, ".apax"), true);
+
+        //System.IO.Directory.Delete(Path.Combine(traversalProjectFolder, ".apax"), true);
 
     }
 }

--- a/src/core/ctrl/apax.yml
+++ b/src/core/ctrl/apax.yml
@@ -10,6 +10,8 @@ files:
 #   APAX_BUILD_ARGS: [ -d ]
 registries:
   "@inxton": "https://npm.pkg.github.com/"
+catalogs:
+  "@inxton/ax.catalog": 0.0.40  
 devDependencies:
   "@inxton/ax-sdk": '0.0.0-dev.0'
 dependencies:


### PR DESCRIPTION
This pull request introduces improvements and cleanup to the build and packaging process in the `cake/Program.cs` script, as well as an update to the `apax.yml` configuration. The main changes focus on optimizing the handling of `.apax` files, refining the traversal project build logic, and updating dependencies.

Build and Packaging Process Improvements:

* Refactored `.apax` file collection to occur once before iterating through libraries, preventing redundant file system traversal and improving efficiency.
* Adjusted traversal project build logic: now, the traversal is created and built if either building or packing is requested, and informative logging statements have been added to clarify build steps. [[1]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L191-R196) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826R211-R220)
* Added cleanup step to remove the traversal `apax.yml` file after the build, helping to keep the build directory clean.
* Removed unnecessary `Thread.Sleep` calls after packaging operations, which should speed up the packaging process. [[1]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L484) [[2]](diffhunk://#diff-449b61961e241832ceccf07a842638af6e32ccf1ccd439c1bf9541146024f826L500)

Dependency and Configuration Updates:

* Updated the `apax.yml` configuration to include a new catalog dependency: `@inxton/ax.catalog` version `0.0.40`.