### PR TITLE
allow files up to 25 MB

### DIFF
--- a/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor.cs
+++ b/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor.cs
@@ -575,7 +575,7 @@ namespace AXOpen.VisualComposer.Components
                     Directory.CreateDirectory(Settings.VisualComposerImagesSerializeFolderPath + "/" + Id.CorrectFilePath());
 
                 await using FileStream fs = new(Settings.VisualComposerImagesSerializeFolderPath + "/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath(), FileMode.Create);
-                await e.File.OpenReadStream().CopyToAsync(fs);
+                await e.File.OpenReadStream(25 * 1024 * 1024).CopyToAsync(fs);
 
                 CurrentView.ImgSrc = Settings.VisualComposerImagesSerializeName + "/" + Id.CorrectFilePath() + "/" + newName.CorrectFilePath();
 
@@ -588,6 +588,7 @@ namespace AXOpen.VisualComposer.Components
             catch (Exception ex)
             {
                 CurrentView.ImgSrc = null;
+                Console.WriteLine($"VisualComposer Error: {ex.Message}");
             }
 
             _isFileImporting = false;


### PR DESCRIPTION
This pull request introduces improvements to the file upload process in the `VisualComposerContainer` component, focusing on better handling of large files and enhanced error reporting.

File upload enhancements:

* Increased the maximum allowed stream size for file uploads to 25 MB by specifying a size limit in `OpenReadStream`, which helps prevent issues with large image files.

Error handling improvements:

* Added error logging to the catch block to output exceptions to the console, making it easier to debug upload failures.