### PR TITLE
Addresses a problem when visual composer does not save changes on W/H change

### DIFF
--- a/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor
+++ b/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor
@@ -501,8 +501,8 @@
                         </AccordionItem>
                     </Accordion>
                     <div class="mt-2">
-                        <BaseInput @bind-Value="CurrentView.BackgroundWidth" Label="Width" />
-                        <BaseInput @bind-Value="CurrentView.BackgroundHeight" Label="Height" />
+                        <BaseInput @bind-Value="CurrentView.BackgroundWidth" OnFocusOut="SaveAsync" Label="Width" />
+                        <BaseInput @bind-Value="CurrentView.BackgroundHeight" OnFocusOut="SaveAsync" Label="Height" />
                     </div>
                 </div>
                 <div class="modal-footer flex justify-end gap-1">


### PR DESCRIPTION
This pull request introduces a minor improvement to the user experience in the visual composer container. The change ensures that updates to the background width and height are saved automatically when the input fields lose focus.

User experience enhancement:

* Added the `OnFocusOut="SaveAsync"` event handler to the `BaseInput` components for `CurrentView.BackgroundWidth` and `CurrentView.BackgroundHeight` in `VisualComposerContainer.razor`, so changes are saved immediately when the user leaves the input fields.