### PR TITLE
930 bug dataselectorview

### DIFF
--- a/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataSelectorView.razor.cs
+++ b/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataSelectorView.razor.cs
@@ -81,7 +81,13 @@ namespace AXOpen.Data
                     if (DistributedVM.AllExchangesHasTheSameId())
                     {
                         var id = (DistributedVM.MainExchange.DataExchangeTwinObject as IAxoDataEntity)._EntityId.Cyclic;
-                        this.SelectedEntity = DistributedVM.MainExchange.GetRecords(id, 1, 0, eSearchMode.Exact, "", false).First();
+
+                        var recs = DistributedVM.MainExchange.GetRecords(id, 1, 0, eSearchMode.Exact, "", false);
+
+                        if (recs != null && recs.Any())
+                        {
+                            this.SelectedEntity = recs.First();
+                        }
                     }
 
                     ConfigSuffix = string.IsNullOrEmpty(ConfigSuffix) ? string.Empty : ConfigSuffix;

--- a/src/data/src/AXOpen.Data/DataPersistentExchange/AxoDataPersistentExchange.cs
+++ b/src/data/src/AXOpen.Data/DataPersistentExchange/AxoDataPersistentExchange.cs
@@ -92,6 +92,8 @@ namespace AXOpen.Data
         /// <returns>Returns true if the write operation is successful; otherwise, false.</returns>
         public async Task<bool> WritePersistentGroupFromRepository(string group)
         {
+            if (!tagsInGroups.ContainsKey(group)) return false; // group not exist 
+
             var recordFromRepo = _Repository.Read(group);
 
             List<ITwinPrimitive> tagsToWrite = new List<ITwinPrimitive>();
@@ -153,10 +155,11 @@ namespace AXOpen.Data
 
         private bool UpdateReadedTagsToRepository(string persistentGroupName)
         {
+            if (!tagsInGroups.ContainsKey(persistentGroupName)) return false; // group not exist 
+
             var primitivesTagsInGroup = tagsInGroups[persistentGroupName];
 
-            if (primitivesTagsInGroup == null)
-                return false;
+            if (primitivesTagsInGroup == null) return false;
 
             List<TagObject> NewTagValues = new List<TagObject>();
 


### PR DESCRIPTION
This pull request introduces several important stability improvements to the handling of data groups and entity selection in the distributed data management components. The main focus is on adding defensive checks to prevent errors when groups or records are missing, ensuring the application behaves reliably in edge cases.

**Data group existence checks:**

* Added a check in `AxoDataPersistentExchange.WritePersistentGroupFromRepository` to return `false` immediately if the specified group does not exist in `tagsInGroups`, preventing attempts to write non-existent groups.
* Added a similar check in `AxoDataPersistentExchange.UpdateReadedTagsToRepository` to return `false` if the persistent group is not present in `tagsInGroups`, which avoids null reference exceptions and improves method robustness.

**Entity selection safety:**

* Updated `DistributedDataSelectorView.OnInitializedAsync` to verify that the record list returned by `GetRecords` is not null or empty before attempting to select the first entity, preventing potential runtime errors when no records are found.