### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,4 +1,6 @@
 name: master
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,6 @@
 name: nightly
+permissions:
+  contents: read
 on: 
   workflow_dispatch :
     branches :  

--- a/.github/workflows/pr-dev.yml
+++ b/.github/workflows/pr-dev.yml
@@ -1,4 +1,6 @@
 name: pr-dev
+permissions:
+  contents: read
 
 on:  
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ name: publish
 on: 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: release
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/single_app_run.yml
+++ b/.github/workflows/single_app_run.yml
@@ -1,4 +1,6 @@
 name: single_app_run
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Inxton/AXOpen/security/code-scanning/6](https://github.com/Inxton/AXOpen/security/code-scanning/6)

**General Fix:**  
Add a `permissions:` block explicitly limiting the permissions for the `GITHUB_TOKEN` used by the workflow/job to the minimum required. By default, for build/test jobs that only check out code, `contents: read` is recommended unless more access is needed.

**Best Way to Fix:**  
Add `permissions: contents: read` at the top level of the workflow (just after the `name:` declaration, before `on:`), so that all jobs are covered and best security/hygiene practices are followed. No existing functionality will change, and should further write permissions be needed for specific jobs/steps, they can be expanded explicitly on those jobs only.

**What to Change:**  
- File: `.github/workflows/pr-dev.yml`
- Insert:
    ```yaml
    permissions:
      contents: read
    ```
  immediately after the `name: pr-dev` line (line 1).

- No extra imports or method changes are required, as this is a YAML workflow spec.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
