### PR TITLE
add validator for password in userManagement

### DIFF
--- a/src/Security/src/AXOpen.Security.Blazor/Pages/UserManagement.razor
+++ b/src/Security/src/AXOpen.Security.Blazor/Pages/UserManagement.razor
@@ -336,7 +336,7 @@
         }
     }
 
-    private sealed class InputModel
+    private sealed class InputModel : IValidatableObject
     {
         [Display(Name = "Group")]
         public string? Group { get; set; }
@@ -347,14 +347,13 @@
         [Display(Name = "Phone number")]
         public string? PhoneNumber { get; set; }
 
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 1)]
+        [StringLength(100, ErrorMessage = "The {0} must be max {1} characters long.")]
         [DataType(DataType.Password)]
         [Display(Name = "New password")]
         public string? NewPassword { get; set; }
 
         [DataType(DataType.Password)]
         [Display(Name = "Confirm new password")]
-        [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
         public string? ConfirmPassword { get; set; }
 
         [Display(Name = "Can User Change Password")]
@@ -368,6 +367,30 @@
 
         [Display(Name = "External Auth Id")]
         public string? ExternalAuthId { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Treat empty as null (in case you didn't do Fix 1)
+            var newPw = string.IsNullOrWhiteSpace(NewPassword) ? null : NewPassword;
+            var confirm = string.IsNullOrWhiteSpace(ConfirmPassword) ? null : ConfirmPassword;
+
+            // Only validate Compare when user is actually setting a new password
+            if (newPw is not null)
+            {
+                if (confirm is null)
+                {
+                    yield return new ValidationResult(
+                        "Please confirm the new password.",
+                        new[] { nameof(ConfirmPassword) });
+                }
+                else if (newPw != confirm)
+                {
+                    yield return new ValidationResult(
+                        "The new password and confirmation password do not match.",
+                        new[] { nameof(ConfirmPassword) });
+                }
+            }
+        }
     }
 
     protected override void OnInitialized()


### PR DESCRIPTION
This pull request updates the user management form validation logic in `UserManagement.razor` to improve password handling and input validation. The most notable changes are the introduction of custom validation for password fields and the removal of the minimum password length requirement.

**Validation improvements:**

* The `InputModel` class now implements `IValidatableObject`, allowing for custom validation logic.
* Custom validation ensures that the "Confirm new password" field is only required and compared when a new password is provided, giving more precise feedback to users.

**Password requirements adjustment:**

* The minimum length restriction for the "New password" field has been removed; only a maximum length of 100 characters is now enforced.
* The `[Compare]` attribute for confirming the new password has been removed in favor of the new custom validation logic.