### PR TITLE
Enhance messaging functionality by adding TaskMessenger serve call an…

### DIFF
--- a/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
+++ b/src/components.mitsubishi.robotics/ctrl/src/AxoCr800_v_1_x_x.st
@@ -121,7 +121,8 @@ NAMESPACE AXOpen.Components.Mitsubishi.Robotics.v_1_x_x
             SUPER.Run(inParent);
 
             Messenger.Serve(THIS);
-
+            TaskMessenger.Serve(THIS);
+            
             IF NOT _initHwCheckDone THEN
                 IF inParent = NULL THEN
                     Messenger.Activate(UINT#700, eAxoMessageCategory#ProgrammingError);

--- a/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
+++ b/src/core/ctrl/src/AxoMessaging/Static/AxoMessenger.st
@@ -80,7 +80,7 @@ NAMESPACE AXOpen.Messaging.Static
             IF((THIS.MessengerState = eAxoMessengerState#ActiveAlreadyAcknowledged ||
                 THIS.MessengerState = eAxoMessengerState#ActiveAcknowledgeRequired ||
                 THIS.MessengerState = eAxoMessengerState#ActiveAcknowledgeNotRequired) 
-                && Category >= eAxoMessageCategory#Error) THEN
+                && Category >= eAxoMessageCategory#Warning) THEN
                 THIS.AggregateMessage(LINT#1);            
             END_IF;    
  


### PR DESCRIPTION
This pull request introduces a minor update to the robotics component and messaging logic. The changes mainly enhance the task messaging capability and adjust the message aggregation threshold.

**Messaging improvements:**

* The `TaskMessenger.Serve(THIS);` call was added to `AxoCr800_v_1_x_x.st`, enabling the task messenger to serve the component alongside the standard messenger.

**Message aggregation logic:**

* The threshold for message aggregation in `AxoMessenger.st` was lowered from `Error` to `Warning`, so messages with a warning level or higher will now be aggregated.