### PR TITLE
Update AXSharp dependencies to version 0.46.0-dev-new.368

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.46.0-alpha.366",
+      "version": "0.46.0-dev-new.368",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.46.0-alpha.366",
+      "version": "0.46.0-dev-new.368",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.46.0-alpha.366",
+      "version": "0.46.0-dev-new.368",
       "commands": [
         "ixr"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,11 +11,11 @@
   <!-- Framework-Agnostic Packages -->
   <ItemGroup>
     <!-- AX# Libraries -->
-    <PackageVersion Include="AXSharp.Abstractions" Version="0.46.0-alpha.366" />
-    <PackageVersion Include="AXSharp.Connector" Version="0.46.0-alpha.366" />
-    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.46.0-alpha.366" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.46.0-alpha.366" />
-    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.46.0-alpha.366" />
+    <PackageVersion Include="AXSharp.Abstractions" Version="0.46.0-dev-new.368" />
+    <PackageVersion Include="AXSharp.Connector" Version="0.46.0-dev-new.368" />
+    <PackageVersion Include="AXSharp.Connector.S71500.WebAPI" Version="0.46.0-dev-new.368" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor" Version="0.46.0-dev-new.368" />
+    <PackageVersion Include="AXSharp.Presentation.Blazor.Controls" Version="0.46.0-dev-new.368" />
     <PackageVersion Include="Inxton.Operon" Version="0.3.0-alpha.100" />
     <!-- Data & Serialization -->
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
@@ -88,6 +88,7 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
   </ItemGroup>
 </Project>
+
 
 
 


### PR DESCRIPTION
This pull request updates the AX# tool and library dependencies to a newer development version across the project. This ensures consistency between the tools and libraries used, and prepares the project for features or fixes available in the new version.

Dependency version updates:

* Updated the versions of `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` tools in `.config/dotnet-tools.json` from `0.46.0-alpha.366` to `0.46.0-dev-new.368` to use the latest development builds. [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)
* Updated the versions of `AXSharp.Abstractions`, `AXSharp.Connector`, `AXSharp.Connector.S71500.WebAPI`, `AXSharp.Presentation.Blazor`, and `AXSharp.Presentation.Blazor.Controls` in `Directory.Packages.props` to `0.46.0-dev-new.368` for compatibility with the new tool versions.