### PR TITLE
removes missing parmaters of axotaskview in other components

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerView.razor
@@ -63,22 +63,22 @@
     <div class="flex flex-wrap m-2 @(_currentSteppingMode == eAxoSteppingMode.StepByStep ? "justify-between" : "justify-center") items-center p-2 gap-2">
         @if(_currentSteppingMode == eAxoSteppingMode.StepByStep)
         {
-            <AxoTaskCommandView ShowText="false" HideRestoreButton="true" ShowAbortButton="false" Component="this.Component.StepBackwardCommand" Class="btn-lg" />
+            <AxoTaskCommandView HideRestoreButton="true" Component="this.Component.StepBackwardCommand" Class="btn-lg" />
         }
         @if (Component.CurrentStep != null)
         {
             @if(_currentSteppingMode == eAxoSteppingMode.StepByStep)
             {
-                <AxoTaskCommandView Text="@_runStepButtonText" ShowText="true" HideRestoreButton="false" ShowAbortButton="false" Component="this.Component.StepIn" Class="btn-lg w-125" />
+                <AxoTaskCommandView Text="@_runStepButtonText" HideRestoreButton="false" Component="this.Component.StepIn" Class="btn-lg w-125" />
             }
             else
             {
-                <AxoTaskStatusView Text="@_runStepButtonText" ShowText="true" HideRestoreButton="false" ShowAbortButton="false" Component="this.Component.StepIn" Class="btn-lg w-125" />
+                <AxoTaskStatusView Text="@_runStepButtonText" HideRestoreButton="false" Component="this.Component.StepIn" Class="btn-lg w-125" />
             }
         }
         @if(_currentSteppingMode == eAxoSteppingMode.StepByStep)
         {
-            <AxoTaskCommandView ShowText="false" HideRestoreButton="true" ShowAbortButton="false" Component="this.Component.StepForwardCommand" Class="btn-lg" />
+            <AxoTaskCommandView HideRestoreButton="true" Component="this.Component.StepForwardCommand" Class="btn-lg" />
         }
     </div>
       


### PR DESCRIPTION
This pull request makes minor adjustments to the `AxoSequencerView.razor` component by removing the `ShowText` and `ShowAbortButton` parameters from several `AxoTaskCommandView` and `AxoTaskStatusView` component usages. This simplifies the component calls, likely relying on default values for these parameters.

- Simplified component usage in `AxoSequencerView.razor` by removing explicit `ShowText` and `ShowAbortButton` parameters from `AxoTaskCommandView` and `AxoTaskStatusView` instances.