### PR TITLE
Update AXSharp tool versions to 0.47.0-alpha.405

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "AXSharp.ixc": {
-      "version": "0.47.0-alpha.394",
+      "version": "0.47.0-alpha.405",
       "commands": [
         "ixc"
       ],
@@ -17,14 +17,14 @@
       "rollForward": false
     },
     "AXSharp.ixd": {
-      "version": "0.47.0-alpha.394",
+      "version": "0.47.0-alpha.405",
       "commands": [
         "ixd"
       ],
       "rollForward": false
     },
     "AXSharp.ixr": {
-      "version": "0.47.0-alpha.394",
+      "version": "0.47.0-alpha.405",
       "commands": [
         "ixr"
       ],
@@ -53,6 +53,7 @@
     }
   }
 }
+
 
 
 


### PR DESCRIPTION
This pull request updates the versions of several AXSharp .NET tools in the `.config/dotnet-tools.json` file to ensure the project uses the latest alpha release.

Tool version updates:

* Upgraded `AXSharp.ixc`, `AXSharp.ixd`, and `AXSharp.ixr` tool versions from `0.47.0-alpha.394` to `0.47.0-alpha.405` in `.config/dotnet-tools.json`. [[1]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L6-R6) [[2]](diffhunk://#diff-7afd3bcf0d0c06d6f87c451ef06b321beef770ece4299b3230bb280470ada2f6L20-R27)