### PR TITLE
Refactor AxoMessengerTextItem to support dynamic message and help text expressions

### DIFF
--- a/src/components.pneumatics/src/AXOpen.Components.Pneumatics/AxoCylinder/AxoCylinder.cs
+++ b/src/components.pneumatics/src/AXOpen.Components.Pneumatics/AxoCylinder/AxoCylinder.cs
@@ -23,15 +23,15 @@ namespace AXOpen.Components.Pneumatics
             List<KeyValuePair<ulong, AxoMessengerTextItem>> messengerTextList = new List<KeyValuePair<ulong, AxoMessengerTextItem>>
             {
                 new KeyValuePair<ulong, AxoMessengerTextItem>(0, new AxoMessengerTextItem("  ", "  ")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(1, new AxoMessengerTextItem($"Movement position `{this.OutLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(2, new AxoMessengerTextItem($"Movement  position `{this.InLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(1, new AxoMessengerTextItem(() => $"Movement position `{this.OutLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(2, new AxoMessengerTextItem(() => $"Movement  position `{this.InLabel}` did not succeed.", "Check that cylinder is free to move, check the air pressure, and extremity sensor.")),
                 new KeyValuePair<ulong, AxoMessengerTextItem>(3, new AxoMessengerTextItem("Both extremity sensors are active at the same time.", "Check the positions of the sensors.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(4, new AxoMessengerTextItem($"Movement to position `{this.OutLabel}` is temporarily suspended.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(5, new AxoMessengerTextItem($"Movement to position `{this.InLabel}` is temporarily suspended.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(6, new AxoMessengerTextItem($"Movement position `{this.OutLabel}` is aborted.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(7, new AxoMessengerTextItem($"Movement position `{this.InLabel}` is aborted.", "Check the blocking condition.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(8, new AxoMessengerTextItem($"Movement position `{this.InLabel}` overshot the extremity sensor.", "Check the sensor position.")),
-                new KeyValuePair<ulong, AxoMessengerTextItem>(9, new AxoMessengerTextItem($"Movement  position `{this.OutLabel}` overshot the extremity sensor.", "Check the sensor position.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(4, new AxoMessengerTextItem(() => $"Movement to position `{this.OutLabel}` is temporarily suspended.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(5, new AxoMessengerTextItem(() => $"Movement to position `{this.InLabel}` is temporarily suspended.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(6, new AxoMessengerTextItem(() => $"Movement position `{this.OutLabel}` is aborted.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(7, new AxoMessengerTextItem(() => $"Movement position `{this.InLabel}` is aborted.", "Check the blocking condition.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(8, new AxoMessengerTextItem(() => $"Movement position `{this.InLabel}` overshot the extremity sensor.", "Check the sensor position.")),
+                new KeyValuePair<ulong, AxoMessengerTextItem>(9, new AxoMessengerTextItem(() => $"Movement  position `{this.OutLabel}` overshot the extremity sensor.", "Check the sensor position.")),
             };
 
             _Messenger.DotNetMessengerTextList = messengerTextList;

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessenger.cs
@@ -136,8 +136,8 @@ public partial class AxoMessenger
     private List<KeyValuePair<ulong, AxoMessengerTextItem>> dotNetMessengerTextList;
     public List<KeyValuePair<ulong, AxoMessengerTextItem>> DotNetMessengerTextList
     {
-        get{return dotNetMessengerTextList != null ? dotNetMessengerTextList : new List<KeyValuePair<ulong, AxoMessengerTextItem>>();}
-        set{dotNetMessengerTextList = value != null ? value : new List<KeyValuePair<ulong, AxoMessengerTextItem>>(); }
+        get{ return dotNetMessengerTextList != null ? dotNetMessengerTextList : new List<KeyValuePair<ulong, AxoMessengerTextItem>>(); }
+        set{ dotNetMessengerTextList = value != null ? value : new List<KeyValuePair<ulong, AxoMessengerTextItem>>(); }
     }
 
 

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessengerTextItem.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessengerTextItem.cs
@@ -16,12 +16,9 @@ public class AxoMessengerTextItem
     public string MessageText 
     { 
         get { 
-                if(_messageText is null)
+                if(_messageText is null && MessageTextExpression is not null)
                 {
-                    if(MessageTextExpression is not null)
-                    {
-                        return MessageTextExpression.Invoke();
-                    }
+                    return MessageTextExpression.Invoke();
                 }
                 return _messageText; 
         } 

--- a/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessengerTextItem.cs
+++ b/src/core/src/AXOpen.Core/AxoMessenger/Static/AxoMessengerTextItem.cs
@@ -9,14 +9,50 @@ namespace AXOpen.Messaging.Static;
 
 public class AxoMessengerTextItem
 {
-    public string MessageText { get; }
-    public string HelpText { get; }
+    public Func<string> MessageTextExpression { get; set; }
+    public Func<string> HelpTextExpression { get; set; }
+
+    private string _messageText;
+    public string MessageText 
+    { 
+        get { 
+                if(_messageText is null)
+                {
+                    if(MessageTextExpression is not null)
+                    {
+                        return MessageTextExpression.Invoke();
+                    }
+                }
+                return _messageText; 
+        } 
+
+        private set 
+        { 
+            _messageText = value; 
+        } 
+    }
+
+    private string _helpText;
+    public string HelpText { get { return _helpText; } private set { _helpText = value; } }
 
     public AxoMessengerTextItem(string messageText, string helpText)
     {
         MessageText = messageText;
         HelpText = helpText;
     }
+
+    public AxoMessengerTextItem(Func<string> messageTextExpression, Func<string> helpTextExpression)
+    {
+        MessageTextExpression = messageTextExpression;
+        HelpTextExpression = helpTextExpression;
+    }
+
+    public AxoMessengerTextItem(Func<string> messageTextExpression, string helpText)
+    {
+        MessageTextExpression = messageTextExpression;
+        HelpText = helpText;
+    }
+
     public AxoMessengerTextItem(string messageText)
     {
         MessageText = messageText;


### PR DESCRIPTION
This pull request updates the way dynamic message texts are handled in the `AxoMessengerTextItem` class and its usage, allowing for more flexible and context-aware messages, especially when referencing instance-specific properties like `InLabel` and `OutLabel`. The main focus is on enabling message text to be generated at runtime using functions, rather than being fixed at construction.

**Enhancements to dynamic message text handling:**

* The `AxoMessengerTextItem` class now supports storing message and help texts as functions (`Func<string>`) that are evaluated at runtime, in addition to static strings. This allows messages to reflect the current state or properties of the object when accessed.
* New constructors were added to `AxoMessengerTextItem` to support initialization with function-based message and/or help texts, providing greater flexibility for dynamic content.

**Refactoring of messenger text initialization:**

* In `AxoCylinder.cs`, the initialization of the messenger text list was updated to use the new function-based constructors for messages that include instance properties (like `this.InLabel` and `this.OutLabel`). This ensures the displayed messages always reflect the current values of these properties.