### PR TITLE
Show step status in sequencer debugger tables

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor
@@ -7,16 +7,18 @@
 		<div class="overflow-x-auto">
 			<table class="table table-striped table-hover w-full">
 				<colgroup>
-					<col style="width:1%;" />
-					<col style="width:1%;" />
-					<col style="width:1%;" />
-					<col />
-					<col style="width:1%;" />
+					<col style="width: 1%;" /> <!-- Breakpoint -->
+					<col style="width: 1%;" /> <!-- Actions -->
+					<col style="width: 1%;" /> <!-- Status -->
+					<col style="width: 1%;" /> <!-- Order -->
+					<col /> <!-- Description (flex) -->
+					<col style="width: 1%;" /> <!-- Remove -->
 				</colgroup>
 				<thead>
 					<tr>
 						<th class="whitespace-nowrap">@Localizer["SequencerBreakpoint"]</th>
 						<th class="whitespace-nowrap">@Localizer["Actions"]</th>
+						<th class="whitespace-nowrap">@Localizer["SequencerStatus"]</th>
 						<th class="whitespace-nowrap">@Localizer["SequencerOrder"]</th>
 						<th>@Localizer["SequencerDesc"]</th>
 						<th class="whitespace-nowrap">@Localizer["SequencerRemove"]</th>
@@ -26,31 +28,43 @@
 					@if (!MonitoredSteps.Any())
 					{
 						<tr>
-							<td colspan="5" class="text-center text-text/70">@Localizer["SequencerNoMonitoredStepsSelected"]</td>
+							<td colspan="6" class="text-center text-text/70">@Localizer["SequencerNoMonitoredStepsSelected"]</td>
 						</tr>
 					}
 					else
 					{
 						@foreach (var monitored in MonitoredSteps)
 						{
-							<tr class=" @GetCurrentStepRowClass(monitored)">
-								<td class="breakpoint-col">
+							<tr class="opacity-90">
+								<td class="breakpoint-col whitespace-nowrap">
 									<input type="checkbox" class="breakpoint-dot @GetBeforeBreakpointDotClass(monitored) @GetCurrentStepDotClass(monitored, monitored.BreakpointBeforeExecution)" checked="@monitored.BreakpointBeforeExecution" disabled />
 								</td>
-								<td>
-									<div class="flex items-center gap-2 whitespace-nowrap">
-										@if (monitored.Order == CurrentStepOrder && ShowCurrentStepRunButtons)
-										{
-											<button class="btn btn-warning btn-sm"
-													@onclick="RunAsync">
-												@Localizer["SequencerContinue"]
-											</button>
-										}
-									</div>
+								<td class="whitespace-nowrap">
+									@if (monitored.Order == CurrentStepOrder && ShowCurrentStepRunButtons)
+									{
+										<button class="btn btn-warning btn-sm"
+												@onclick="RunAsync">
+											@Localizer["SequencerContinue"]
+										</button>
+									}
+									else
+									{
+										<span style="display:inline-block;width:100%;height:32px;"></span>
+									}
 								</td>
-								<td>@monitored.Order</td>
+								<td class="whitespace-nowrap">
+									@if (monitored.Order == CurrentStepOrder)
+									{
+										<div class="@GetStepStatusBadgeClass(monitored) w-auto justify-center">@GetStepStatusLabel(monitored)</div>
+									}
+									else
+									{
+										<span style="display:inline-block;width:100%;height:32px;"></span>
+									}
+								</td>
+								<td class="whitespace-nowrap">@monitored.Order</td>
 								<td>@monitored.Desc</td>
-								<td>
+								<td class="whitespace-nowrap">
 									<button class="btn btn-danger btn-sm"
 											@onclick="() => RemoveFromMonitor(monitored)">
 										@Localizer["SequencerRemove"]
@@ -68,7 +82,7 @@
 		<summary class="cursor-pointer select-none text-sm font-medium">@Localizer["ViewDetails"]</summary>
 		<div class="overflow-x-auto mt-2">
 			<div class="mb-2 flex justify-center mt-2">
-				
+
 				<button class="btn btn-warning btn-sm m-2"
 						@onclick="ApplyBreakpointConfigurationAsync"
 						disabled="@(Steps.Count == 0)">
@@ -82,27 +96,32 @@
 			</div>
 			<table class="table table-striped table-hover w-full">
 				<colgroup>
-					<col style="width:1%;" />
-					<col style="width:1%;" />
-					<col style="width:1%;" />
+					<col style="width: 1%;" />
+					<col style="width: 1%;" />
+					<col style="width: 1%;" />
+					<col style="width: 1%;" />
 					<col />
-					<col style="width:1%;" />
+					<col style="width: 1%;" />
 				</colgroup>
 				<thead>
 					<tr>
-						<th class="breakpoint-col">@Localizer["SequencerBreakpoint"]</th>
+						<th class="breakpoint-col whitespace-nowrap">@Localizer["SequencerBreakpoint"]</th>
 						<th class="whitespace-nowrap">@Localizer["Actions"]</th>
+						<th class="whitespace-nowrap">@Localizer["SequencerStatus"]</th>
 						<th class="whitespace-nowrap">@Localizer["SequencerOrder"]</th>
 						<th>@Localizer["SequencerDesc"]</th>
+
 						<th class="whitespace-nowrap">@Localizer["SequencerMonitor"]</th>
-			
+
+
+						@* <th>@Localizer["SequencerStepExecutionMode"]</th> *@
 					</tr>
 				</thead>
 				<tbody>
 					@if (Steps.Count == 0)
 					{
 						<tr>
-							<td colspan="5" class="text-center text-text/70">@Localizer["SequencerNoStepsFound"]</td>
+							<td colspan="6" class="text-center text-text/70">@Localizer["SequencerNoStepsFound"]</td>
 						</tr>
 					}
 					else
@@ -110,29 +129,40 @@
 						@foreach (var item in Steps)
 						{
 							<tr class="@GetCurrentStepRowClass(item)">
-								<td class="breakpoint-col">
-									<input type="checkbox" class="breakpoint-dot @GetBeforeBreakpointDotClass(item) @GetCurrentStepDotClass(item, item.BreakpointBeforeExecution)" @bind="item.BreakpointBeforeExecution" />
+								<td class="breakpoint-col whitespace-nowrap">
+									<input type="checkbox"
+										   class="breakpoint-dot @GetBeforeBreakpointDotClass(item) @GetCurrentStepDotClass(item, item.BreakpointBeforeExecution)"
+										   checked="@item.BreakpointBeforeExecution"
+										   @onchange="@(args => ToggleBreakpointAsync(item, args))" />
 								</td>
-								<td>
+								<td class="whitespace-nowrap">
 									@if (item.Order == CurrentStepOrder && ShowCurrentStepRunButtons)
 									{
-									
+
 										<button class="btn btn-warning btn-sm"
 												@onclick="RunAsync">
 											@Localizer["SequencerContinue"]
 										</button>
 									}
 								</td>
-								<td>@item.Order</td>
+								<td class="whitespace-nowrap">
+									@if (item.Order == CurrentStepOrder)
+									{
+										<div class="@GetStepStatusBadgeClass(item) w-auto justify-center">@GetStepStatusLabel(item)</div>
+									}
+								</td>
+								<td class="whitespace-nowrap">@item.Order</td>
 								<td>@item.Desc</td>
-								<td>
+
+								<td class="whitespace-nowrap">
 									<button class="btn btn-primary btn-sm"
 											@onclick="() => AddToMonitor(item)"
 											disabled="@IsMonitored(item)">
 										@Localizer["SequencerAddToMonitor"]
 									</button>
 								</td>
-	
+
+
 							</tr>
 						}
 					}

--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor.cs
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor.cs
@@ -10,53 +10,54 @@ namespace AXOpen.Core;
 
 public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<AxoSequencer>
 {
-	private readonly AxoSequencerStepsCollector _collector = new();
+    private readonly AxoSequencerStepsCollector _collector = new();
     private readonly HashSet<ulong> _monitoredStepOrders = new();
     private bool _isMonitoredStepsLoaded;
 
-	[Parameter]
-	public string? Class { get; set; }
+    [Parameter]
+    public string? Class { get; set; }
 
     [Inject]
     private IJSRuntime JSRuntime { get; set; } = default!;
 
 
 
-	protected IReadOnlyList<FlatAxoStepItem> Steps { get; private set; } = Array.Empty<FlatAxoStepItem>();
+    protected IReadOnlyList<FlatAxoStepItem> Steps { get; private set; } = Array.Empty<FlatAxoStepItem>();
 
     private string MonitoredStepsStorageKey => $"axo-sequencer-monitored-steps:{Component.Symbol}";
 
     private IEnumerable<FlatAxoStepItem> MonitoredSteps =>
         Steps.Where(step => _monitoredStepOrders.Contains(step.Order));
 
-	private bool ShowCurrentStepRunButtons =>
-		Component.CurrentStep is not null
-		&& Component.CurrentStep.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue;
+    private bool ShowCurrentStepRunButtons =>
+        Component.CurrentStep is not null
+        && Component.CurrentStep.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue
+            && Component.CurrentStep.Status.LastValue == (short)eAxoTaskState.Ready;
 
-	protected override async Task OnAfterRenderAsync(bool firstRender)
-	{
-        if (firstRender)
+    private bool ShowCurrentStepRunning =>
+        Component.CurrentStep is not null
+        && Component.CurrentStep.Status.LastValue == (short)eAxoTaskState.Busy;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
         {
-            Steps = await _collector.GetFlatSteps(
-                Component.GetConnector(),
-                Component,
-                static (sequence, step) => new FlatAxoStepItem(sequence, step),
-                static item => item.Order);
-            StateHasChanged();
+            return;
         }
+
+        Steps = await _collector.GetFlatSteps(
+            Component.GetConnector(),
+            Component,
+            static (sequence, step) => new FlatAxoStepItem(sequence, step),
+            static item => item.Order);
 
         if (!_isMonitoredStepsLoaded)
         {
-            var loaded = await TryLoadMonitoredStepsAsync();
-            if (loaded)
-            {
-                _isMonitoredStepsLoaded = true;
-                StateHasChanged();
-            }
+            _isMonitoredStepsLoaded = await TryLoadMonitoredStepsAsync();
         }
-	}
-    private eAxoSteppingMode _currentSteppingMode => (eAxoSteppingMode)this.Component.SteppingMode.LastValue;
-    private string _currentStepDescription => string.IsNullOrEmpty(this.Component.CurrentStep.Descr.GetCyclic(Thread.CurrentThread.CurrentUICulture)) ? "-" : this.Component.CurrentStep.Descr.GetCyclic(Thread.CurrentThread.CurrentUICulture);
+
+        StateHasChanged();
+    }
     public ulong CurrentStepOrder
     {
         get
@@ -76,44 +77,65 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         }
     }
 
-  
+
     public override void ConfigurePolling()
-	{
-		foreach (var step in Component.GetDescendants<AxoStep>())
-		{
-			StartPolling(step.Order, 500);
+    {
+        foreach (var step in Component.GetDescendants<AxoStep>())
+        {
+            StartPolling(step.Order, 500);
             StartPolling(step.StepExecutionMode, 500);
-		}
+        }
         StartPolling(this.Component.SteppingMode, 500);
+        StartPolling(this.Component.CurrentStep.Status, 500);
         StartPolling(this.Component.CurrentStep.Descr, 500);
-		
+
     }
 
     protected async Task ApplyBreakpointConfigurationAsync()
-	{
-		foreach (var item in Steps)
-		{
+    {
+        foreach (var item in Steps)
+        {
             if (item.BreakpointBeforeExecution)
-			{
-				await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.SwitchToStepModeBeforeEnteringStep);
-			}
-          
-			else
-			{
-				if (item.Step.StepExecutionMode.LastValue !=(short)eAxoStepExecutionMode.ExecuteAndContinue)
-                    await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.ExecuteAndContinue);
-			}
-		}
+            {
+                await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.SwitchToStepModeBeforeEnteringStep);
+            }
 
-		StateHasChanged();
-	}
+            else
+            {
+                if (item.Step.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue)
+                    await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.ExecuteAndContinue);
+            }
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task ToggleBreakpointAsync(FlatAxoStepItem item, ChangeEventArgs args)
+    {
+        var isChecked = args.Value switch
+        {
+            bool value => value,
+            string value => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase),
+            _ => false
+        };
+
+        item.BreakpointBeforeExecution = isChecked;
+
+        if (!isChecked)
+        {
+            if (item.Step.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue)
+                await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.ExecuteAndContinue);
+        }
+
+        StateHasChanged();
+    }
 
     protected async Task ClearAllBreakpointsAsync()
     {
         foreach (var item in Steps)
         {
             item.BreakpointBeforeExecution = false;
-          
+
         }
 
         await ApplyBreakpointConfigurationAsync();
@@ -122,10 +144,10 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         StateHasChanged();
     }
 
-	protected async Task RunAsync()
-	{
+    protected async Task RunAsync()
+    {
         await RunCurrentStepAsync(removeBreakpointForCurrentStep: false);
-	}
+    }
 
 
 
@@ -138,21 +160,21 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         }
         FlatAxoStepItem item;
 
-       
+
 
         item = Steps.FirstOrDefault(step => step.Order == CurrentStepOrder);
         if (item is not null)
         {
             await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.ExecuteAndContinue);
         }
-       
+
 
         await this.Component.SetReqSteppingMode.SetAsync(true);
         await this.Component.ReqSteppingMode.SetAsync((short)eAxoSteppingMode.Continous);
 
         if (removeBreakpointForCurrentStep)
         {
-           
+
             if (item is not null)
             {
                 item.BreakpointBeforeExecution = false;
@@ -161,10 +183,10 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         }
         else
         {
-           
+
             if (item.BreakpointBeforeExecution)
                 await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.SwitchToStepModeBeforeEnteringStep);
-         
+
 
         }
         StateHasChanged();
@@ -177,7 +199,7 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
             : string.Empty;
     }
 
-   
+
 
     private string GetCurrentStepDotClass(FlatAxoStepItem item, bool isChecked)
     {
@@ -192,6 +214,7 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
             ? "current-step-row"
             : string.Empty;
     }
+
 
     private async Task AddToMonitor(FlatAxoStepItem item)
     {
@@ -249,5 +272,31 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         await JSRuntime.InvokeVoidAsync("localStorage.setItem", MonitoredStepsStorageKey, storedOrders);
     }
 
-  
+    private string GetStepStatusBadgeClass(FlatAxoStepItem item)
+    {
+        if (item.Order != CurrentStepOrder) return string.Empty;
+        var status = Component.CurrentStep.Status.LastValue;
+        if (status == (short)eAxoTaskState.Ready) return "badge badge-success";
+        if (status == (short)eAxoTaskState.Kicking) return "badge badge-info";
+        if (status == (short)eAxoTaskState.Busy) return "badge badge-primary";
+        if (status == (short)eAxoTaskState.Done) return "badge badge-success";
+        if (status == (short)eAxoTaskState.Aborted) return "badge badge-warning";
+        if (status == (short)eAxoTaskState.Error) return "badge badge-danger";
+        return string.Empty;
+    }
+
+    private string GetStepStatusLabel(FlatAxoStepItem item)
+    {
+        if (item.Order != CurrentStepOrder) return string.Empty;
+        var status = Component.CurrentStep.Status.LastValue;
+        if (status == (short)eAxoTaskState.Ready) return Localizer["SequencerTaskStateReady"];
+        if (status == (short)eAxoTaskState.Kicking) return Localizer["SequencerTaskStateKicking"];
+        if (status == (short)eAxoTaskState.Busy) return Localizer["SequencerTaskStateBusy"];
+        if (status == (short)eAxoTaskState.Done) return Localizer["SequencerTaskStateDone"];
+        if (status == (short)eAxoTaskState.Aborted) return Localizer["SequencerTaskStateAborted"];
+        if (status == (short)eAxoTaskState.Error) return Localizer["SequencerTaskStateError"];
+        return string.Empty;
+    }
+
+
 }

--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/FlatAxoStepItem.cs
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/FlatAxoStepItem.cs
@@ -30,11 +30,7 @@ public sealed record FlatAxoStepItem(
     }
 
     public eAxoStepExecutionMode StepExecutionMode => RawStepExecutionMode;
-        //BreakpointBeforeExecution
-        //    ? eAxoStepExecutionMode.SwitchToStepModeBeforeEnteringStep
-        //    : BreakpointAfterExecution
-        //        ? eAxoStepExecutionMode.SwitchToStepModeAfterLeavingStep
-        //    : RawStepExecutionMode;
+
 
     private eAxoStepExecutionMode RawStepExecutionMode => (eAxoStepExecutionMode)Step.StepExecutionMode.LastValue;
 };

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.de-DE.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.de-DE.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -361,5 +361,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Alle Breakpoints loschen</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Bereit</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Startet</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Lauft</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Fertig</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Abgebrochen</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Fehler</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.de.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -302,5 +302,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Alle Breakpoints loschen</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Bereit</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Startet</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Lauft</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Fertig</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Abgebrochen</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Fehler</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.es-ES.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.es-ES.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -361,5 +361,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Borrar todos los puntos de interrupcion</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Listo</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Iniciando</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>En ejecucion</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Completado</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Abortado</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Error</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.es.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.es.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -186,7 +186,6 @@
   <data name="SequencerNoStepsFound" xml:space="preserve">
     <value>No se encontraron pasos.</value>
   </data>
-
   <data name="SeverityError" xml:space="preserve">
     <value>Error</value>
   </data>
@@ -303,5 +302,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Borrar todos los puntos de interrupcion</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Listo</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Iniciando</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>En ejecucion</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Completado</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Abortado</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Error</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.hu-HU.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.hu-HU.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -361,5 +361,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Osszes torespont torlese</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Kesz</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Inditas</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Folyamatban</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Befejezve</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Megszakitva</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Hiba</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.pl-PL.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.pl-PL.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -361,5 +361,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Wyczysc wszystkie punkty przerwania</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Gotowy</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Uruchamianie</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>W trakcie</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Zakonczono</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Przerwano</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Blad</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -156,10 +156,10 @@
   </data>
   <!-- State Labels -->
   <data name="ActiveAcknowledged" xml:space="preserve">
-    <value>Active � Acknowledged</value>
+    <value>Active · Acknowledged</value>
   </data>
   <data name="ActiveUnacknowledged" xml:space="preserve">
-    <value>Active � Unacknowledged</value>
+    <value>Active · Unacknowledged</value>
   </data>
   <data name="Cleared" xml:space="preserve">
     <value>Cleared</value>
@@ -225,7 +225,7 @@
     <value>Pending</value>
   </data>
   <data name="ActiveAck" xml:space="preserve">
-    <value>Active � Ack</value>
+    <value>Active · Ack</value>
   </data>
   <!-- Component Container -->
   <data name="Alarms" xml:space="preserve">
@@ -307,5 +307,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Clear all breakpoints</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Ready</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Kicking</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Busy</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Aborted</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Error</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.sk-SK.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.sk-SK.resx
@@ -1,64 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
-    Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-    
-    Example:
-    
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">2.0</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-        <value>[base64 mime encoded serialized .NET Framework object]</value>
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-        <comment>This is a comment</comment>
-    </data>
-                
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-    
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-            : and then encoded with base64 encoding.
-    
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-            : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-            : using a System.ComponentModel.TypeConverter
-            : and then encoded with base64 encoding.
-    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -117,41 +58,43 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <!-- Task/Sequencer Status -->
   <data name="Running" xml:space="preserve">
-    <value>Beh</value>
+    <value>Beží</value>
   </data>
   <data name="Idle" xml:space="preserve">
-    <value>Nečinnosť</value>
+    <value>Nečinný</value>
   </data>
   <data name="Error" xml:space="preserve">
     <value>Chyba</value>
   </data>
   <data name="Timeout" xml:space="preserve">
-    <value>Časový limit</value>
+    <value>Vypršal čas</value>
   </data>
   <data name="StepMode" xml:space="preserve">
-    <value>KROKOVÝ REŽIM</value>
+    <value>KROKOVÝ MÓD</value>
   </data>
   <data name="StepModeActiveControlledByMaster" xml:space="preserve">
-    <value>AKTÍVNY KROKOVÝ REŽIM - RIADENÝ HLAVNOU SEKVENCIOU</value>
+    <value>KROKOVÝ MÓD AKTÍVNY - RIADENÝ HLAVNOU SEKVENCIOU</value>
   </data>
   <data name="StepModeControlledByMaster" xml:space="preserve">
-    <value>KROKOVÝ REŽIM RIADENÝ HLAVNOU SEKVENCIOU</value>
+    <value>KROKOVÝ MÓD RIADENÝ HLAVNOU SEKVENCIOU</value>
   </data>
   <data name="EnterStepMode" xml:space="preserve">
-    <value>Vstup do krokového režimu</value>
+    <value>Zapnúť krokový mód</value>
   </data>
   <data name="ExitStepMode" xml:space="preserve">
-    <value>Ukončenie krokového režimu</value>
+    <value>Vypnúť krokový mód</value>
   </data>
+  <!-- Messenger/Alarm Labels -->
   <data name="Equipment" xml:space="preserve">
     <value>Zariadenie</value>
   </data>
   <data name="Raised" xml:space="preserve">
-    <value>Zvýšené</value>
+    <value>Vyvolaný</value>
   </data>
   <data name="Acknowledged" xml:space="preserve">
-    <value>Potvrdené</value>
+    <value>Potvrdený</value>
   </data>
   <data name="Duration" xml:space="preserve">
     <value>Trvanie</value>
@@ -160,7 +103,7 @@
     <value>Symbol</value>
   </data>
   <data name="HumanReadable" xml:space="preserve">
-    <value>Čitateľný pre ľudí</value>
+    <value>Čitateľný názov</value>
   </data>
   <data name="AlarmId" xml:space="preserve">
     <value>ID alarmu</value>
@@ -172,53 +115,50 @@
     <value>OBNOVIŤ</value>
   </data>
   <data name="RestoreButton" xml:space="preserve">
-    <value>Obnovenie</value>
+    <value>Obnoviť</value>
   </data>
   <data name="Acknowledge" xml:space="preserve">
     <value>Potvrdiť</value>
   </data>
   <data name="HideDetails" xml:space="preserve">
-    <value>SKRYŤ PODROBNOSTI</value>
+    <value>SKRYŤ DETAILY</value>
   </data>
   <data name="ShowDetails" xml:space="preserve">
-    <value>ZOBRAZIŤ PODROBNOSTI</value>
+    <value>ZOBRAZIŤ DETAILY</value>
   </data>
   <data name="ViewDetails" xml:space="preserve">
-    <value>Zobraziť podrobnosti</value>
+    <value>Zobraziť detaily</value>
   </data>
   <data name="ResetTask" xml:space="preserve">
-    <value>Obnovenie úlohy</value>
+    <value>Resetovať úlohu</value>
   </data>
+  <!-- Severity Names -->
   <data name="Info" xml:space="preserve">
-    <value>Informácie</value>
+    <value>Info</value>
   </data>
   <data name="Warning" xml:space="preserve">
-    <value>Upozornenie</value>
+    <value>Varovanie</value>
   </data>
   <data name="Error_" xml:space="preserve">
     <value>Chyba</value>
   </data>
   <data name="SeverityMajorFault" xml:space="preserve">
-    <value>Hlavná porucha</value>
-  </data>
-  <data name="SeverityError" xml:space="preserve">
-    <value>Chyba</value>
-  </data>
-  <data name="System" xml:space="preserve">
-    <value>Chyba systému</value>
+    <value>Väčšia chyba</value>
   </data>
   <data name="Critical" xml:space="preserve">
-    <value>Kritické</value>
+    <value>Kritický</value>
   </data>
+  <!-- State Labels -->
   <data name="ActiveAcknowledged" xml:space="preserve">
-    <value>Aktívne - potvrdené</value>
+    <value>Aktívny · Potvrdený</value>
   </data>
   <data name="ActiveUnacknowledged" xml:space="preserve">
-    <value>Aktívne - nepotvrdené</value>
+    <value>Aktívny · Nepotvrdený</value>
   </data>
   <data name="Cleared" xml:space="preserve">
-    <value>Vymazané</value>
+    <value>Vymazaný</value>
   </data>
+  <!-- Component View -->
   <data name="ActiveAlarms" xml:space="preserve">
     <value>Aktívny alarm</value>
   </data>
@@ -230,89 +170,6 @@
   </data>
   <data name="Active" xml:space="preserve">
     <value>aktívny</value>
-  </data>
-  <!-- Table Headers -->
-  <data name="Severity" xml:space="preserve">
-    <value>Závažnosť</value>
-  </data>
-  <data name="Title" xml:space="preserve">
-    <value>Názov</value>
-  </data>
-  <data name="State" xml:space="preserve">
-    <value>Stav</value>
-  </data>
-  <data name="Actions" xml:space="preserve">
-    <value>Akcie</value>
-  </data>
-  <!-- UI Elements -->
-  <data name="SearchAlarms" xml:space="preserve">
-    <value>Hľadať alarmy</value>
-  </data>
-  <data name="SearchTitleOrEquipment" xml:space="preserve">
-    <value>Hľadať názov alebo zariadenie</value>
-  </data>
-  <data name="Refresh" xml:space="preserve">
-    <value>Obnoviť</value>
-  </data>
-  <data name="RefreshMessages" xml:space="preserve">
-    <value>Obnoviť správy</value>
-  </data>
-  <data name="NoAlarmsToDisplay" xml:space="preserve">
-    <value>Žiadne alarmy na zobrazenie.</value>
-  </data>
-  <data name="HideDetails_Duplicate[1]" xml:space="preserve">
-    <value>Skryť podrobnosti</value>
-  </data>
-  <data name="ShowDetails_Duplicate[1]" xml:space="preserve">
-    <value>Zobraziť podrobnosti</value>
-  </data>
-  <data name="AcknowledgeAlarm" xml:space="preserve">
-    <value>Potvrdiť alarm</value>
-  </data>
-  <data name="ACKN" xml:space="preserve">
-    <value>POTV</value>
-  </data>
-  <data name="Ack" xml:space="preserve">
-    <value>Potv</value>
-  </data>
-  <data name="Pending" xml:space="preserve">
-    <value>Čakajúci</value>
-  </data>
-  <data name="ActiveAck" xml:space="preserve">
-    <value>Aktívny · Potv</value>
-  </data>
-  <!-- Component Container -->
-  <data name="Alarms" xml:space="preserve">
-    <value>alarmy</value>
-  </data>
-  <data name="Alarm" xml:space="preserve">
-    <value>alarm</value>
-  </data>
-  <data name="ToggleServiceView" xml:space="preserve">
-    <value>Prepnúť servisné zobrazenie</value>
-  </data>
-  <data name="Normal" xml:space="preserve">
-    <value>Normálny</value>
-  </data>
-  <data name="Service" xml:space="preserve">
-    <value>Servis</value>
-  </data>
-  <data name="CONFIGURATION" xml:space="preserve">
-    <value>KONFIGURÁCIA</value>
-  </data>
-  <data name="STATE" xml:space="preserve">
-    <value>STAV</value>
-  </data>
-  <!-- Array Views -->
-  <data name="Data" xml:space="preserve">
-    <value>Údaje</value>
-  </data>
-  <!-- Aria Labels -->
-  <data name="SeverityLabel" xml:space="preserve">
-    <value>Závažnosť</value>
-  </data>
-  <data name="AlarmCode" xml:space="preserve">
-    <value>Kód alarmu</value>
   </data>
   <data name="SequencerSendSuspendConfiguration" xml:space="preserve">
     <value>Odoslat konfiguraciu pozastavenia</value>
@@ -328,6 +185,90 @@
   </data>
   <data name="SequencerNoStepsFound" xml:space="preserve">
     <value>Nenasli sa ziadne kroky.</value>
+  </data>
+  <data name="SeverityError" xml:space="preserve">
+    <value>Chyba</value>
+  </data>
+  <data name="System" xml:space="preserve">
+    <value>Chyba systému</value>
+  </data>
+  <data name="Severity" xml:space="preserve">
+    <value>Závažnosť</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Názov</value>
+  </data>
+  <data name="State" xml:space="preserve">
+    <value>Štát</value>
+  </data>
+  <data name="Actions" xml:space="preserve">
+    <value>Činnosti</value>
+  </data>
+  <data name="SearchAlarms" xml:space="preserve">
+    <value>Vyhľadávanie alarmov</value>
+  </data>
+  <data name="SearchTitleOrEquipment" xml:space="preserve">
+    <value>Vyhľadávanie názvu alebo zariadenia</value>
+  </data>
+  <data name="Refresh" xml:space="preserve">
+    <value>Obnoviť</value>
+  </data>
+  <data name="RefreshMessages" xml:space="preserve">
+    <value>Obnovenie správ</value>
+  </data>
+  <data name="NoAlarmsToDisplay" xml:space="preserve">
+    <value>Nezobrazujú sa žiadne alarmy.</value>
+  </data>
+  <data name="HideDetails_Duplicate[1]" xml:space="preserve">
+    <value>Skryť podrobnosti</value>
+  </data>
+  <data name="ShowDetails_Duplicate[1]" xml:space="preserve">
+    <value>Zobraziť podrobnosti</value>
+  </data>
+  <data name="AcknowledgeAlarm" xml:space="preserve">
+    <value>Potvrdenie alarmu</value>
+  </data>
+  <data name="ACKN" xml:space="preserve">
+    <value>ACKN</value>
+  </data>
+  <data name="Ack" xml:space="preserve">
+    <value>Ack</value>
+  </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Čaká sa na</value>
+  </data>
+  <data name="ActiveAck" xml:space="preserve">
+    <value>Aktívne - Ack</value>
+  </data>
+  <data name="Alarms" xml:space="preserve">
+    <value>alarmy</value>
+  </data>
+  <data name="Alarm" xml:space="preserve">
+    <value>alarm</value>
+  </data>
+  <data name="ToggleServiceView" xml:space="preserve">
+    <value>Prepnutie zobrazenia služby</value>
+  </data>
+  <data name="Normal" xml:space="preserve">
+    <value>Normálne</value>
+  </data>
+  <data name="Service" xml:space="preserve">
+    <value>Služba</value>
+  </data>
+  <data name="CONFIGURATION" xml:space="preserve">
+    <value>KONFIGURÁCIA</value>
+  </data>
+  <data name="STATE" xml:space="preserve">
+    <value>ŠTÁT</value>
+  </data>
+  <data name="Data" xml:space="preserve">
+    <value>Údaje</value>
+  </data>
+  <data name="SeverityLabel" xml:space="preserve">
+    <value>Závažnosť</value>
+  </data>
+  <data name="AlarmCode" xml:space="preserve">
+    <value>Kód alarmu</value>
   </data>
   <data name="SequencerMonitoredSteps" xml:space="preserve">
     <value>Monitorované kroky</value>
@@ -361,5 +302,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Vymazať všetky body prerušenia</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Pripravený</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Spúšťanie</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Beží</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Dokončené</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Prerušené</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Chyba</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.sk.resx
+++ b/src/core/src/AXOpen.Core.Blazor/Properties/AxOpenCoreResources.sk.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
@@ -302,5 +302,23 @@
   </data>
   <data name="SequencerClearAllBreakpoints" xml:space="preserve">
     <value>Vymazať všetky body prerušenia</value>
+  </data>
+  <data name="SequencerTaskStateReady" xml:space="preserve">
+    <value>Pripravený</value>
+  </data>
+  <data name="SequencerTaskStateKicking" xml:space="preserve">
+    <value>Spúšťanie</value>
+  </data>
+  <data name="SequencerTaskStateBusy" xml:space="preserve">
+    <value>Beží</value>
+  </data>
+  <data name="SequencerTaskStateDone" xml:space="preserve">
+    <value>Dokončené</value>
+  </data>
+  <data name="SequencerTaskStateAborted" xml:space="preserve">
+    <value>Prerušené</value>
+  </data>
+  <data name="SequencerTaskStateError" xml:space="preserve">
+    <value>Chyba</value>
   </data>
 </root>

--- a/src/core/src/AXOpen.Core/AxoCoordination/AxoSequencerStepsCollector.cs
+++ b/src/core/src/AXOpen.Core/AxoCoordination/AxoSequencerStepsCollector.cs
@@ -7,8 +7,6 @@ namespace AXOpen.Core;
 
 public sealed class AxoSequencerStepsCollector
 {
-    public IReadOnlyList<FlatAxoStepItem> GetStepsBySequence(ITwinObject root, string sequenceSymbol)
-        => GetStepsBySequence(root, sequenceSymbol, static (sequence, step) => new FlatAxoStepItem(sequence, step), static item => item.Order);
 
     public IReadOnlyList<TItem> GetStepsBySequence<TItem>(
         ITwinObject root,


### PR DESCRIPTION
Added "SequencerStatus" column to steps and monitored steps tables, displaying badges and localized labels for current step state. Improved logic for "Continue" button and status badge display. Changed breakpoint checkbox to controlled input with explicit handler. Polling now includes current step status. Added helper methods for badge and label mapping. Updated resource files with localized step status strings and improved translations. Refactored steps collector for clarity.

