### PR TITLE
Update step run button logic and breakpoint handling

### DIFF
--- a/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor.cs
+++ b/src/core/src/AXOpen.Core.Blazor/AxoCoordination/AxoSequencer/AxoSequencerDebuggerView.razor.cs
@@ -31,7 +31,7 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
 
     private bool ShowCurrentStepRunButtons =>
         Component.CurrentStep is not null
-        && Component.CurrentStep.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue
+        //&& Component.CurrentStep.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue
             && Component.CurrentStep.Status.LastValue == (short)eAxoTaskState.Ready;
 
     private bool ShowCurrentStepRunning =>
@@ -124,7 +124,12 @@ public partial class AxoSequencerDebuggerView : RenderableComplexComponentBase<A
         if (!isChecked)
         {
             if (item.Step.StepExecutionMode.LastValue != (short)eAxoStepExecutionMode.ExecuteAndContinue)
+            { 
                 await item.Step.StepExecutionMode.SetAsync((short)eAxoStepExecutionMode.ExecuteAndContinue);
+
+                //await this.Component.SetReqSteppingMode.SetAsync(true);
+                //await this.Component.ReqSteppingMode.SetAsync((short)eAxoSteppingMode.Continous);
+            }
         }
 
         StateHasChanged();


### PR DESCRIPTION
Modified ShowCurrentStepRunButtons to relax execution mode check, allowing buttons to display for ExecuteAndContinue mode. Added logic to set step execution mode to ExecuteAndContinue when a breakpoint is unchecked, with additional commented-out stepping mode options for future use.
