### PR TITLE
Refactor tab button styles for consistency across VisualComposer and DataExchange views

### DIFF
--- a/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor
+++ b/src/base/src/AXOpen.VisualComposer/Components/VisualComposerContainer.razor
@@ -12,18 +12,19 @@
 
 <AuthorizeView Roles="Administrator">
     <Authorized>
-        <div class="flex flex-wrap items-center">
-            <nav class="tab m-2 grow">
+        <div class="flex flex-wrap">
+            
+                <nav class="tab">
                 @foreach (var item in _serverStorageAllViews)
                 {
-                    <button class="btn tab-btn @(_currentViewName == item ? "active" : null) @GetBgColor(SaveLocationType.Server)" @onclick="() => LoadAsync(item)">@item</button>
+                    <button class="tab-btn @(_currentViewName == item ? "active" : null) @GetBgColor(SaveLocationType.Server)" @onclick="() => LoadAsync(item)">@item</button>
                 }
                 @foreach (var item in _localStorageData.Keys)
                 {
-                    <button class="btn tab-btn @(_currentViewName == item ? "active" : null) @GetBgColor(SaveLocationType.Local)" @onclick="() => LoadAsync(item)">@item</button>
+                    <button class="tab-btn @(_currentViewName == item ? "active" : null) @GetBgColor(SaveLocationType.Local)" @onclick="() => LoadAsync(item)">@item</button>
                 }
             </nav>
-
+            
             <div class="flex items-center ms-auto">
                 @if (_inDesignMode)
                 {

--- a/src/data/src/AXOpen.Data.Blazor/AxoDataExchange/DataExchangeView.razor
+++ b/src/data/src/AXOpen.Data.Blazor/AxoDataExchange/DataExchangeView.razor
@@ -434,9 +434,13 @@ else
 
     <Modal @ref="_modalView">
         <div class="modal-header">
-            <div class="flex flex-col">
-                <h3>@Vm.RefUIData.AttributeName</h3>            
-                <h4>@Vm.SelectedRecord?._EntityId</h4>
+            <div class="flex flex-row">
+                <div class="basis-1/3 mx-4">
+                    <h4>@Vm.RefUIData.AttributeName</h4>            
+                </div>
+                <div class="basis-2/3 my-1">
+                    <h5>@Vm.SelectedRecord?._EntityId</h5>
+                </div>
             </div>
             <button type="button" class="cursor-pointer ms-auto my-auto" @onclick="() => _modalView.CloseModal()">
                 <Operon.Icons.HeroIcon Icon="x-mark" Type="Operon.Icons.IconType.Outline" Class="size-6" />
@@ -489,7 +493,14 @@ else
 
     <Modal @ref="_modalChanges">
         <div class="modal-header">
-            <h4>@Vm.SelectedRecord?._EntityId</h4>
+            <div class="flex flex-row">
+                <div class="basis-1/3 mx-4">
+                    <h4>@Vm.RefUIData.AttributeName</h4>            
+                </div>
+                <div class="basis-2/3 my-1">
+                    <h5>@Vm.SelectedRecord?._EntityId</h5>
+                </div>
+            </div>
             <button type="button" class="cursor-pointer ms-auto my-auto" @onclick="() => _modalChanges.CloseModal()">
                 <Operon.Icons.HeroIcon Icon="x-mark" Type="Operon.Icons.IconType.Outline" Class="size-6" />
             </button>
@@ -540,7 +551,14 @@ else
 
     <Modal @ref="_modalEdit">
         <div class="modal-header">
-            <h4>@Vm.SelectedRecord?._EntityId</h4>
+             <div class="flex flex-row">
+                <div class="basis-1/3 mx-4">
+                    <h4>@Vm.RefUIData.AttributeName</h4>            
+                </div>
+                <div class="basis-2/3 my-1">
+                    <h5>@Vm.SelectedRecord?._EntityId</h5>
+                </div>
+            </div>
             <button class="cursor-pointer ms-auto my-auto" @onclick="() => { _modalEdit.CloseModal(); Vm.UnLocked(); }">
                 <Operon.Icons.HeroIcon Icon="x-mark" Type="Operon.Icons.IconType.Outline" Class="size-6" />
             </button>

--- a/src/data/src/AXOpen.Data.Blazor/AxoDataExchange/DataExchangeView.razor
+++ b/src/data/src/AXOpen.Data.Blazor/AxoDataExchange/DataExchangeView.razor
@@ -434,7 +434,10 @@ else
 
     <Modal @ref="_modalView">
         <div class="modal-header">
-            <h4>@Vm.SelectedRecord?._EntityId</h4>
+            <div class="flex flex-col">
+                <h3>@Vm.RefUIData.AttributeName</h3>            
+                <h4>@Vm.SelectedRecord?._EntityId</h4>
+            </div>
             <button type="button" class="cursor-pointer ms-auto my-auto" @onclick="() => _modalView.CloseModal()">
                 <Operon.Icons.HeroIcon Icon="x-mark" Type="Operon.Icons.IconType.Outline" Class="size-6" />
             </button>

--- a/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataView.razor
+++ b/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataView.razor
@@ -22,7 +22,7 @@ else
         <ul class="tab">
             @foreach (var exchange in DistributedVM.DisplayedExchanges)
             {
-                <button type="button" class="btn tab-btn @(DistributedVM?.SelectedManagerVm?.Model == exchange ? "active" : null)" @onclick="async () => { await DistributedVM.SelectManager(exchange); }">@exchange.PresentableInstanceName</button>
+                <button type="button" class="tab-btn @(DistributedVM?.SelectedManagerVm?.Model == exchange ? "active" : null)" @onclick="async () => { await DistributedVM.SelectManager(exchange); }">@exchange.PresentableInstanceName</button>
             }
         </ul>
     }

--- a/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataView.razor
+++ b/src/data/src/AXOpen.Data.Blazor/Distributed/DistributedDataView.razor
@@ -22,7 +22,7 @@ else
         <ul class="tab">
             @foreach (var exchange in DistributedVM.DisplayedExchanges)
             {
-                <button type="button" class="tab-btn @(DistributedVM?.SelectedManagerVm?.Model == exchange ? "active" : null)" @onclick="async () => { await DistributedVM.SelectManager(exchange); }">@exchange.PresentableInstanceName</button>
+                <button type="button" class="tab-btn @(DistributedVM.SelectedManagerVm?.Model == exchange ? "active" : null)" @onclick="async () => { await DistributedVM.SelectManager(exchange); }">@exchange.PresentableInstanceName</button>
             }
         </ul>
     }


### PR DESCRIPTION
This pull request focuses on UI improvements and code cleanup in several Blazor components, primarily targeting the modal headers for better clarity and updating button styling for consistency. The most significant changes involve restructuring modal headers to display both the attribute name and entity ID, and simplifying button classes across tab navigation elements.

**UI/UX Enhancements:**

* Updated modal headers in `DataExchangeView.razor` to display both the attribute name (`AttributeName`) and the entity ID (`_EntityId`) in a structured two-column layout for better readability and context. [[1]](diffhunk://#diff-2f01f1905d1b861b3e53286ead38c24c0b287a7e7efb8cd5c9595423984804bfL437-R444) [[2]](diffhunk://#diff-2f01f1905d1b861b3e53286ead38c24c0b287a7e7efb8cd5c9595423984804bfL489-R503) [[3]](diffhunk://#diff-2f01f1905d1b861b3e53286ead38c24c0b287a7e7efb8cd5c9595423984804bfL540-R561)

**Styling and Code Cleanup:**

* Removed the redundant `btn` class from tab navigation buttons in `VisualComposerContainer.razor` and `DistributedDataView.razor` to streamline styling and ensure consistency across the UI. [[1]](diffhunk://#diff-d2966af140c1d0dff8f96782805bcf892d746cea4877244729823b3be8569674L15-R24) [[2]](diffhunk://#diff-44cfe7c33ca5e6a7f0305af828787a348a1f9f2a785f223baf3c9ee4b308ac8cL25-R25)