### PR TITLE
ci: run docs build+deploy inside dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,12 @@
 name: dev
 permissions:
   contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 on:
 #  push:
@@ -53,3 +59,67 @@ jobs:
         dotnet run --project cake/Build.csproj --do-publish-only --do-publish --do-publish-release
         "PACK_EXIT_CODE=$LASTEXITCODE" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
       shell: pwsh
+
+  docs:
+    needs: build
+    runs-on: [self-hosted, Windows, X64, L2, AX]
+    steps:
+    - name: Generate ctrl API metadata (ixd)
+      shell: pwsh
+      run: |
+        dotnet ixd `
+          -x .\src\abstractions\ctrl `
+             .\src\core\ctrl `
+             .\src\data\ctrl `
+             .\src\inspectors\ctrl `
+             .\src\io\ctrl `
+             .\src\probers\ctrl `
+             .\src\simatic1500\ctrl `
+             .\src\timers\ctrl `
+             .\src\utils\ctrl `
+             .\src\components.abstractions\ctrl `
+             .\src\components.abb.robotics\ctrl `
+             .\src\components.balluff.identification\ctrl `
+             .\src\components.cognex.vision\ctrl `
+             .\src\components.desoutter.tightening\ctrl `
+             .\src\components.drives\ctrl `
+             .\src\components.dukane.welders\ctrl `
+             .\src\components.elements\ctrl `
+             .\src\components.festo.drives\ctrl `
+             .\src\components.keyence.vision\ctrl `
+             .\src\components.kuka.robotics\ctrl `
+             .\src\components.mitsubishi.robotics\ctrl `
+             .\src\components.pneumatics\ctrl `
+             .\src\components.rexroth.drives\ctrl `
+             .\src\components.rexroth.press\ctrl `
+             .\src\components.rexroth.tightening\ctrl `
+             .\src\components.robotics\ctrl `
+             .\src\components.siem.communication\ctrl `
+             .\src\components.siem.identification\ctrl `
+             .\src\components.ur.robotics\ctrl `
+             .\src\components.zebra.vision\ctrl `
+          -o .\docfx\apictrl\
+
+    - name: Docfx metadata
+      shell: pwsh
+      run: dotnet docfx metadata .\docfx\docfx.json
+
+    - name: Docfx build
+      shell: pwsh
+      run: dotnet docfx build .\docfx\docfx.json --output .\docs\
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: docs
+
+  deploy:
+    needs: docs
+    runs-on: [self-hosted, Windows, X64, L2, AX]
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,39 +66,7 @@ jobs:
     steps:
     - name: Generate ctrl API metadata (ixd)
       shell: pwsh
-      run: |
-        dotnet ixd `
-          -x .\src\abstractions\ctrl `
-             .\src\core\ctrl `
-             .\src\data\ctrl `
-             .\src\inspectors\ctrl `
-             .\src\io\ctrl `
-             .\src\probers\ctrl `
-             .\src\simatic1500\ctrl `
-             .\src\timers\ctrl `
-             .\src\utils\ctrl `
-             .\src\components.abstractions\ctrl `
-             .\src\components.abb.robotics\ctrl `
-             .\src\components.balluff.identification\ctrl `
-             .\src\components.cognex.vision\ctrl `
-             .\src\components.desoutter.tightening\ctrl `
-             .\src\components.drives\ctrl `
-             .\src\components.dukane.welders\ctrl `
-             .\src\components.elements\ctrl `
-             .\src\components.festo.drives\ctrl `
-             .\src\components.keyence.vision\ctrl `
-             .\src\components.kuka.robotics\ctrl `
-             .\src\components.mitsubishi.robotics\ctrl `
-             .\src\components.pneumatics\ctrl `
-             .\src\components.rexroth.drives\ctrl `
-             .\src\components.rexroth.press\ctrl `
-             .\src\components.rexroth.tightening\ctrl `
-             .\src\components.robotics\ctrl `
-             .\src\components.siem.communication\ctrl `
-             .\src\components.siem.identification\ctrl `
-             .\src\components.ur.robotics\ctrl `
-             .\src\components.zebra.vision\ctrl `
-          -o .\docfx\apictrl\
+      run: .\scripts\_invoke_ixd.ps1
 
     - name: Docfx metadata
       shell: pwsh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,10 @@
 name: docs
 
 on:
-  push:
-    branches: [ "dev" ]
-    paths:
-      - 'src/**'
-      - 'docfx/**'
-      - 'scripts/_build_documentation.ps1'
-      - '.github/workflows/docs.yml'
+  workflow_run:
+    workflows: ["dev"]
+    types: [completed]
+    branches: [dev]
   workflow_dispatch:
 
 permissions:
@@ -21,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, Windows, X64, L2, AX]
     steps:
       - name: Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,39 +23,7 @@ jobs:
 
       - name: Generate ctrl API metadata (ixd)
         shell: pwsh
-        run: |
-          dotnet ixd `
-            -x .\src\abstractions\ctrl `
-               .\src\core\ctrl `
-               .\src\data\ctrl `
-               .\src\inspectors\ctrl `
-               .\src\io\ctrl `
-               .\src\probers\ctrl `
-               .\src\simatic1500\ctrl `
-               .\src\timers\ctrl `
-               .\src\utils\ctrl `
-               .\src\components.abstractions\ctrl `
-               .\src\components.abb.robotics\ctrl `
-               .\src\components.balluff.identification\ctrl `
-               .\src\components.cognex.vision\ctrl `
-               .\src\components.desoutter.tightening\ctrl `
-               .\src\components.drives\ctrl `
-               .\src\components.dukane.welders\ctrl `
-               .\src\components.elements\ctrl `
-               .\src\components.festo.drives\ctrl `
-               .\src\components.keyence.vision\ctrl `
-               .\src\components.kuka.robotics\ctrl `
-               .\src\components.mitsubishi.robotics\ctrl `
-               .\src\components.pneumatics\ctrl `
-               .\src\components.rexroth.drives\ctrl `
-               .\src\components.rexroth.press\ctrl `
-               .\src\components.rexroth.tightening\ctrl `
-               .\src\components.robotics\ctrl `
-               .\src\components.siem.communication\ctrl `
-               .\src\components.siem.identification\ctrl `
-               .\src\components.ur.robotics\ctrl `
-               .\src\components.zebra.vision\ctrl `
-            -o .\docfx\apictrl\
+        run: .\scripts\_invoke_ixd.ps1
 
       - name: Docfx metadata
         shell: pwsh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,6 @@
 name: docs
 
 on:
-  workflow_run:
-    workflows: ["dev"]
-    types: [completed]
-    branches: [dev]
   workflow_dispatch:
 
 permissions:
@@ -18,7 +14,6 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: [self-hosted, Windows, X64, L2, AX]
     steps:
       - name: Checkout

--- a/scripts/_build_documentation.ps1
+++ b/scripts/_build_documentation.ps1
@@ -1,35 +1,4 @@
-dotnet ixd `
--x .\src\abstractions\ctrl `
-.\src\core\ctrl `
-.\src\data\ctrl `
-.\src\inspectors\ctrl `
-.\src\io\ctrl `
-.\src\probers\ctrl `
-.\src\simatic1500\ctrl `
-.\src\timers\ctrl `
-.\src\utils\ctrl `
-.\src\components.abstractions\ctrl `
-.\src\components.abb.robotics\ctrl `
-.\src\components.balluff.identification\ctrl `
-.\src\components.cognex.vision\ctrl `
-.\src\components.desoutter.tightening\ctrl `
-.\src\components.drives\ctrl `
-.\src\components.dukane.welders\ctrl `
-.\src\components.elements\ctrl `
-.\src\components.festo.drives\ctrl `
-.\src\components.keyence.vision\ctrl `
-.\src\components.kuka.robotics\ctrl `
-.\src\components.mitsubishi.robotics\ctrl `
-.\src\components.pneumatics\ctrl `
-.\src\components.rexroth.drives\ctrl `
-.\src\components.rexroth.press\ctrl `
-.\src\components.rexroth.tightening\ctrl `
-.\src\components.robotics\ctrl `
-.\src\components.siem.communication\ctrl `
-.\src\components.siem.identification\ctrl `
-.\src\components.ur.robotics\ctrl `
-.\src\components.zebra.vision\ctrl `
--o .\docfx\apictrl\
+& "$PSScriptRoot\_invoke_ixd.ps1"
 
 # Generate metadata (.NET API documentation) from C# projects
 dotnet docfx metadata .\docfx\docfx.json

--- a/scripts/_invoke_ixd.ps1
+++ b/scripts/_invoke_ixd.ps1
@@ -1,0 +1,36 @@
+param(
+    [string]$Output = ".\docfx\apictrl\"
+)
+
+dotnet ixd `
+    -x .\src\abstractions\ctrl `
+       .\src\core\ctrl `
+       .\src\data\ctrl `
+       .\src\inspectors\ctrl `
+       .\src\io\ctrl `
+       .\src\probers\ctrl `
+       .\src\simatic1500\ctrl `
+       .\src\timers\ctrl `
+       .\src\utils\ctrl `
+       .\src\components.abstractions\ctrl `
+       .\src\components.abb.robotics\ctrl `
+       .\src\components.balluff.identification\ctrl `
+       .\src\components.cognex.vision\ctrl `
+       .\src\components.desoutter.tightening\ctrl `
+       .\src\components.drives\ctrl `
+       .\src\components.dukane.welders\ctrl `
+       .\src\components.elements\ctrl `
+       .\src\components.festo.drives\ctrl `
+       .\src\components.keyence.vision\ctrl `
+       .\src\components.kuka.robotics\ctrl `
+       .\src\components.mitsubishi.robotics\ctrl `
+       .\src\components.pneumatics\ctrl `
+       .\src\components.rexroth.drives\ctrl `
+       .\src\components.rexroth.press\ctrl `
+       .\src\components.rexroth.tightening\ctrl `
+       .\src\components.robotics\ctrl `
+       .\src\components.siem.communication\ctrl `
+       .\src\components.siem.identification\ctrl `
+       .\src\components.ur.robotics\ctrl `
+       .\src\components.zebra.vision\ctrl `
+    -o $Output

--- a/scripts/build_test_docu.ps1
+++ b/scripts/build_test_docu.ps1
@@ -1,35 +1,4 @@
-dotnet ixd `
--x .\src\abstractions\ctrl `
-.\src\core\ctrl `
-.\src\data\ctrl `
-.\src\inspectors\ctrl `
-.\src\io\ctrl `
-.\src\probers\ctrl `
-.\src\simatic1500\ctrl `
-.\src\timers\ctrl `
-.\src\utils\ctrl `
-.\src\components.abstractions\ctrl `
-.\src\components.abb.robotics\ctrl `
-.\src\components.balluff.identification\ctrl `
-.\src\components.cognex.vision\ctrl `
-.\src\components.desoutter.tightening\ctrl `
-.\src\components.drives\ctrl `
-.\src\components.dukane.welders\ctrl `
-.\src\components.elements\ctrl `
-.\src\components.festo.drives\ctrl `
-.\src\components.keyence.vision\ctrl `
-.\src\components.kuka.robotics\ctrl `
-.\src\components.mitsubishi.robotics\ctrl `
-.\src\components.pneumatics\ctrl `
-.\src\components.rexroth.drives\ctrl `
-.\src\components.rexroth.press\ctrl `
-.\src\components.rexroth.tightening\ctrl `
-.\src\components.robotics\ctrl `
-.\src\components.siem.communication\ctrl `
-.\src\components.siem.identification\ctrl `
-.\src\components.ur.robotics\ctrl `
-.\src\components.zebra.vision\ctrl `
--o .\docfx\apictrl\
+& "$PSScriptRoot\_invoke_ixd.ps1"
 
 if ((Test-Path .\docs-test\)) {
     del .\docs-test\


### PR DESCRIPTION
## Summary
- Move docs build + Pages deploy into dev.yml as jobs chained via needs: build → needs: docs.
- docs.yml kept as manual-only (workflow_dispatch) fallback; auto trigger removed.
- No actions/checkout in the new docs job — reuses the self-hosted runner workspace produced by build, so restored NuGet packages and compiled outputs are available to docfx metadata.

## Why
Previous standalone docs run failed (run 24445347613) with CS0246 across AXSharp / Serilog / Microsoft.Extensions / Blazorise types — docfx metadata ran without prior restore/build. Keeping docs in the same workflow guarantees artifacts exist on the runner when docfx runs.

## Caveats
- Assumes the [self-hosted, Windows, X64, L2, AX] label resolves to a single runner (or that needs: consistently lands on the same agent). If the pool grows, switch to artifact upload/download or pin a runner label.
- Added pages: write and id-token: write permissions at workflow level for deploy.

## Test plan
- [ ] workflow_dispatch on dev runs build → docs → deploy successfully
- [ ] Pages site updates after a successful dev run
- [ ] Manual docs workflow still dispatchable