### PR TITLE
ci(docs): deploy Pages from ubuntu to avoid bash on Windows runner

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -76,18 +76,31 @@ jobs:
       shell: pwsh
       run: dotnet docfx build .\docfx\docfx.json --output .\docs\
 
-    - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+    - name: Upload docs artifact
+      uses: actions/upload-artifact@v4
       with:
+        name: docs-site
         path: docs
+        retention-days: 1
 
   deploy:
     needs: docs
-    runs-on: [self-hosted, Windows, X64, L2, AX]
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+    - name: Download docs artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: docs-site
+        path: site
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: site
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,18 +33,31 @@ jobs:
         shell: pwsh
         run: dotnet docfx build .\docfx\docfx.json --output .\docs\
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: docs-site
           path: docs
+          retention-days: 1
 
   deploy:
     needs: build
-    runs-on: [self-hosted, Windows, X64, L2, AX]
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-site
+          path: site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Docs build stays on self-hosted Windows (needs restored workspace from `build` job).
- Replace `actions/upload-pages-artifact@v3` in the Windows `docs` job with plain `actions/upload-artifact@v4` (name: docs-site).
- New `deploy` job on `ubuntu-latest`: download-artifact → upload-pages-artifact → deploy-pages.
- Same split applied to the manual `docs.yml` fallback.

## Why
Run 24449486432 failed at `Upload Pages artifact` with `bash: command not found` — `upload-pages-artifact@v3` invokes bash, which is not on PATH on the self-hosted Windows runner. Keeping the Pages-specific steps on Linux sidesteps the dependency entirely.

## Test plan
- [ ] workflow_dispatch on dev: build → docs (windows) → deploy (ubuntu) succeeds
- [ ] Pages site updates
- [ ] Manual docs workflow still works